### PR TITLE
chore: fix Github pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,5 @@ The Mobility Feed API service a list of open mobility data sources from across t
 Mobility Feed API is not released yet; any code or service hosted is considered as **Work in Progress**. For more information regarding the current Mobility Database Catalog, go to [The Mobility Database Catalogs](https://github.com/MobilityData/mobility-database-catalogs).
 
 # Viewing the API with Swagger. 
-<!--- Had to use the absolute adress. If not the source code of index.html would be displayed instead of the rendered page. --->
 
-Follow this [link](https://mobilitydata.github.io/mobility-feed-api/docs/SwaggerUI/index.html).
+Follow this [link](https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html).


### PR DESCRIPTION
## Description

The Github pages link was pointing to the docs folder instead of the root. This change aligns Github settings with README.md