### PR TITLE
Create PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Submit a bug report
+labels: ['bug','status: Needs triage']
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting a bug, please make sure there isn't already an [existing issue open](https://github.com/MobilityData/mobility-feed-api/issues?q=is%3Aopen+is%3Aissue+label%3Abug).
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: >
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Steps/Code to Reproduce
+    description: |
+      Please add the steps that can reproduce the problem. More precise bug report tends to be solved more quickly because it avoids back-and-forth discussion between the maintainers and the reporter.
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Expected Results
+    description: >
+      Please describe the expected results.
+    placeholder: >
+      Example: The file shows the list of validation problems.
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Actual Results
+    description: |
+      Please paste or describe the results you observe instead of the expected results. 
+    placeholder: >
+      Example: The file is blank.
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: |
+      Visual examples can help us better understand the issue. You can drag-and-drop the image in this box to upload it.
+  validations:
+    required: false
+    
+- type: textarea
+  attributes:
+    label: Files used
+    description: |
+      Please provide any relevant file. You can drag-and-drop the file in this box to upload it.
+  validations:
+    required: false
+    
+- type: input
+  attributes:
+    label: Operating system
+    description: |
+      Which Operating System are you using?
+    placeholder: >
+      Example: MacOS, Apple M1
+  validations:
+    required: true
+    
+- type: input
+  attributes:
+    label: Java version
+    description: |
+      Which version of Java are you using? Type the following command in the terminal to know what your Java version is.
+      ```
+      java -version
+      ```
+  validations:
+    required: false
+    
+- type: textarea
+  attributes:
+    label: Additional notes
+    description: >
+      Anything else to add?
+  validations:
+    required: false
+
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,27 +59,6 @@ body:
   validations:
     required: false
     
-- type: input
-  attributes:
-    label: Operating system
-    description: |
-      Which Operating System are you using?
-    placeholder: >
-      Example: MacOS, Apple M1
-  validations:
-    required: true
-    
-- type: input
-  attributes:
-    label: Java version
-    description: |
-      Which version of Java are you using? Type the following command in the terminal to know what your Java version is.
-      ```
-      java -version
-      ```
-  validations:
-    required: false
-    
 - type: textarea
   attributes:
     label: Additional notes

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,0 +1,24 @@
+name: Documentation improvement
+description: Signal a problem or an improvement idea with our documentation
+labels: ['documentation','status: Needs triage']
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting this issue, please make sure there isn't already an [existing issue open](https://github.com/MobilityData/mobility-feed-api/issues?q=is%3Aopen+is%3Aissue+label%3Adocumentation).
+- type: textarea
+  attributes:
+    label: Describe the problem
+    description: >
+      What is the confusion or the problem with the documentation?
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Suggest a fix or an alternative
+    description: |
+      How can we improve our documentation in this regard?
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: ['enhancement', 'status: Needs triage']
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting a new feature idea, please make sure there isn't already an [existing issue open](https://github.com/MobilityData/mobility-feed-api/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement+).
+- type: textarea
+  attributes:
+    label: Describe the problem
+    description: >
+      Describe what you are trying to achieve, and how this tool makes it more difficult. Describe the other means you currently use to get the job done or to have the information you need.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Proposed solution
+    description: >
+      A clear and concise description of what you want to happen.
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: Alternatives you've considered
+    description: >
+      If relevant, describe any alternatives you've considered.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Additional context
+    description: >
+      Additional context that can help us better understand your need.
+  validations:
+    required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+**Summary:**
+
+Summarize the changes in the pull request including how it relates to any issues (include the #number, or link them).
+
+**Expected behavior:** 
+
+Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).
+
+
+Please make sure these boxes are checked before submitting your pull request - thanks!
+
+- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
+- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
+- [ ] Linked all relevant issues
+- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Explain and/or show screenshots for how you expect the pull request to work in y
 
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
-- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
+- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
 - [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
 - [ ] Linked all relevant issues
 - [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,34 @@
+# Configuration for welcome - https://github.com/behaviorbot/welcome
+
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+  Thanks for opening your first issue in this project! If you haven't already, you can [join our slack](https://share.mobilitydata.org/slack) and join the #gtfs-validators channel to meet our awesome community. Come say hi :wave:!
+  <br><br> Welcome to the community and thank you for your engagement in open source! :tada:
+  <br><br> ![](https://media.giphy.com/media/l2JHZ0dIcyFo5UQGQ/giphy.gif)
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: >
+  Thanks for opening this pull request! You're awesome.
+  We use [semantic commit messages](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix.
+  Examples of titles with semantic prefixes:
+    - `fix: Bug with ssl network connections + Java module permissions.`
+    - `feat: Initial support for multiple @PrimaryKey annotations`.
+    - `docs: update RELEASE.md with new process`
+  To get this PR to the finish line, please do the following:
+    - Read our [Contribution Guidelines](https://github.com/MobilityData/gtfs-validator/blob/master/docs/CONTRIBUTING.md)
+    - Follow [Google Java style](https://google.github.io/styleguide/javaguide.html) coding standards
+    - Include tests when adding/changing behavior
+    - Include screenshots
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+  :partying_face: Congrats on getting your first pull request merged!
+  <br><br> ![](https://media.giphy.com/media/l4KhQo2MESJkc6QbS/giphy.gif)
+
+# It is recommend to include as many gifs and emojis as possible

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,7 +4,7 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  Thanks for opening your first issue in this project! If you haven't already, you can [join our slack](https://share.mobilitydata.org/slack) and join the #gtfs-validators channel to meet our awesome community. Come say hi :wave:!
+  Thanks for opening your first issue in this project! If you haven't already, you can [join our slack](https://share.mobilitydata.org/slack) and join the #mobility-database channel to meet our awesome community. Come say hi :wave:!
   <br><br> Welcome to the community and thank you for your engagement in open source! :tada:
   <br><br> ![](https://media.giphy.com/media/l2JHZ0dIcyFo5UQGQ/giphy.gif)
 
@@ -19,8 +19,6 @@ newPRWelcomeComment: >
     - `feat: Initial support for multiple @PrimaryKey annotations`.
     - `docs: update RELEASE.md with new process`
   To get this PR to the finish line, please do the following:
-    - Read our [Contribution Guidelines](https://github.com/MobilityData/gtfs-validator/blob/master/docs/CONTRIBUTING.md)
-    - Follow [Google Java style](https://google.github.io/styleguide/javaguide.html) coding standards
     - Include tests when adding/changing behavior
     - Include screenshots
 


### PR DESCRIPTION
Added issue and PR templates.
Mostly copied from gtfs-validator, with some adjustments.
Closes https://github.com/MobilityData/mobility-feed-api/issues/27