### PR TITLE
fix: Renaming API endpoints to resolve conflicting subpaths

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,6 +55,6 @@ jobs:
           scripts/api-gen.sh
 
 #      Uncomment the unit tests when tests are ready
-      - name: Run unit tests
-        run: |
-          scripts/api-test.sh
+#      - name: Run unit tests
+#        run: |
+#          scripts/api-test.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,6 +55,6 @@ jobs:
           scripts/api-gen.sh
 
 #      Uncomment the unit tests when tests are ready
-#      - name: Run unit tests
-#        run: |
-#          scripts/api-test.sh
+      - name: Run unit tests
+        run: |
+          scripts/api-test.sh

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -125,7 +125,6 @@ class FeedsApiImpl(BaseFeedsApi):
             bounding_filter_method: str,
     ) -> List[GtfsFeed]:
         """Get some (or all) GTFS feeds from the Mobility Database."""
-        print("In get_gtfs_feeds endpoint")
         return [self.get_gtfs_feed("foo")]
 
     def get_gtfs_rt_feed(

--- a/api/tests/test_datasets_api.py
+++ b/api/tests/test_datasets_api.py
@@ -2,25 +2,6 @@
 
 from fastapi.testclient import TestClient
 
-def test_datasets_gtfs_get(client: TestClient):
-    """Test case for datasets_gtfs_get
-
-    
-    """
-    params = [("limit", 10),     ("offset", 0),     ("filter", 'status=active'),     ("sort", '+provider'),     ("bounding_latitudes", '41.46,42.67'),     ("bounding_longitudes", '-78.58,-87-29'),     ("bounding_filter_method", 'completely_enclosed')]
-    headers = {
-        "ApiKeyAuth": "special-key",
-    }
-    response = client.request(
-        "GET",
-        "/v1/datasets/gtfs",
-        headers=headers,
-        params=params,
-    )
-
-    # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
 
 def test_datasets_gtfs_id_get(client: TestClient):
     """Test case for datasets_gtfs_id_get
@@ -37,7 +18,6 @@ def test_datasets_gtfs_id_get(client: TestClient):
         headers=headers,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 
 
@@ -52,11 +32,10 @@ def test_feeds_gtfs_id_datasets_get(client: TestClient):
     }
     response = client.request(
         "GET",
-        "/v1/feeds/gtfs/{id}/datasets".format(id='feed_0'),
+        "/v1/gtfs_feeds/{id}/datasets".format(id='feed_0'),
         headers=headers,
         params=params,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -69,7 +69,7 @@ def test_feeds_id_get(client: TestClient):
     }
     response = client.request(
         "GET",
-        "/v1/feeds/{id}".format(id='mdb-478'),
+        "/v1/feeds/{id}".format(id='mdb-1'),
         headers=headers,
     )
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -18,7 +18,6 @@ def test_feeds_get(client: TestClient):
         params=params,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 
 
@@ -33,12 +32,11 @@ def test_feeds_gtfs_get(client: TestClient):
     }
     response = client.request(
         "GET",
-        "/v1/feeds/gtfs",
+        "/v1/gtfs_feeds",
         headers=headers,
         params=params,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 
 
@@ -53,11 +51,10 @@ def test_feeds_gtfs_id_get(client: TestClient):
     }
     response = client.request(
         "GET",
-        "/v1/feeds/gtfs/{id}".format(id='feed_0'),
+        "/v1/gtfs_feeds/{id}".format(id='feed_0'),
         headers=headers,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 
 
@@ -72,10 +69,9 @@ def test_feeds_id_get(client: TestClient):
     }
     response = client.request(
         "GET",
-        "/v1/feeds/{id}".format(id='feed_0'),
+        "/v1/feeds/{id}".format(id='mdb-478'),
         headers=headers,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 

--- a/api/tests/test_metadata_api.py
+++ b/api/tests/test_metadata_api.py
@@ -18,6 +18,5 @@ def test_metadata_get(client: TestClient):
         headers=headers,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -69,7 +69,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BasicFeed"
 
-  /v1/feeds/gtfs:
+  /v1/gtfs_feeds:
     get:
       description: Get some (or all) GTFS feeds from the Mobility Database.
       tags:
@@ -94,7 +94,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/GtfsFeeds"
 
-  /v1/feeds/gtfs_rt:
+  /v1/gtfs_rt_feeds:
     get:
       description: Get some (or all) GTFS Realtime feeds from the Mobility Database.
       tags:
@@ -115,7 +115,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/GtfsRTFeeds"
 
-  /v1/feeds/gtfs/{id}:
+  /v1/gtfs_feeds/{id}:
     parameters:
       - $ref: "#/components/parameters/feedIdPathParam"
     get:
@@ -134,7 +134,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/GtfsFeed"
 
-  /v1/feeds/gtfs_rt/{id}:
+  /v1/gtfs_rt_feeds/{id}:
     parameters:
       - $ref: "#/components/parameters/feedIdPathParam"
     get:
@@ -154,7 +154,7 @@ paths:
                 $ref: "#/components/schemas/GtfsRTFeed"
 
 
-  /v1/feeds/gtfs/{id}/datasets:
+  /v1/gtfs_feeds/{id}/datasets:
     parameters:
       - $ref: "#/components/parameters/feedIdOfDatasetsPathParam"
     get:


### PR DESCRIPTION
**Summary:**

Issue: https://github.com/MobilityData/mobility-feed-api/issues/84

**Expected behavior:** 

All endpoints are accessible now.

Also all unit tests pass now. I removed a test for an endpoint that no longer exists.

I did not enable unit tests in CI because they depend on existing data in docker database. We can enable it when we have implemented complete unit tests (@goorui is working on it)

