### PR TITLE
Fix for deprecated of `set-output` in GH actions

### DIFF
--- a/.github/workflows/db-update.yml
+++ b/.github/workflows/db-update.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Get full path of sources.csv
       id: getpath
-      run: echo "::set-output name=PATH::$(realpath sources.csv)"
+      run: echo "PATH=$(realpath sources.csv)" >> $GITHUB_OUTPUT
 
     - name: Populate Database
       if: inputs.RUN_POPULATE_SCRIPT


### PR DESCRIPTION
GitHub has deprecated set-output and will eventually make it unusable, so this is a preventative fix. See more info here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/