### PR TITLE
fix: remove FeedLog getter endpoint from implementation function

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -15,8 +15,6 @@ from feeds.impl.datasets_api_impl import DatasetsApiImpl
 from feeds_gen.apis.feeds_api_base import BaseFeedsApi
 from feeds_gen.models.basic_feed import BasicFeed
 from feeds_gen.models.external_id import ExternalId
-from feeds_gen.models.extra_models import TokenModel
-from feeds_gen.models.feed_log import FeedLog
 from feeds_gen.models.gtfs_dataset import GtfsDataset
 from feeds_gen.models.gtfs_feed import GtfsFeed
 from feeds_gen.models.gtfs_rt_feed import GtfsRTFeed
@@ -159,17 +157,6 @@ class FeedsApiImpl(BaseFeedsApi):
             return ret[0]
         else:
             raise HTTPException(status_code=404, detail=f"Feed {id} not found")
-
-    def get_feed_logs(
-            id: str,
-            limit: int,
-            offset: int,
-            filter: str,
-            sort: str,
-            token_ApiKeyAuth: TokenModel,
-    ) -> List[FeedLog]:
-        """Get a list of logs related to a feed."""
-        return []
 
     def get_feeds(
             self,


### PR DESCRIPTION
**Summary:**

This PR removes the FeedLog model's reference from the API endpoint implementation file. This fixes the QA deployment, an example of a failing build [here](https://github.com/MobilityData/mobility-feed-api/actions/runs/6264420571/job/17011185401). 

Completes  #83 

**Expected behavior:** 

FeedLog is removed and Qa deployment is successful. 


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
