### PR TITLE
Fix failing test `test_merge_gtfs_feed` 

### DIFF
--- a/api/tests/test_database.py
+++ b/api/tests/test_database.py
@@ -73,8 +73,9 @@ def test_bounding_box_disjoint(latitudes, longitudes, method, expected_found, te
 def test_merge_gtfs_feed(test_database):
     results = {
         feed.id: feed
-        for feed in FeedsApiImpl().get_gtfs_feeds(None, None, None, None, None, None, 
-                                                  None, None, None, None, None, None)
+        for feed in FeedsApiImpl().get_gtfs_feeds(
+            None, None, None, None, None, None, None, None, None, None, None, None
+        )
         if feed.id in TEST_GTFS_FEED_STABLE_IDS
     }
     assert len(results) == len(TEST_GTFS_FEED_STABLE_IDS)

--- a/api/tests/test_database.py
+++ b/api/tests/test_database.py
@@ -73,7 +73,8 @@ def test_bounding_box_disjoint(latitudes, longitudes, method, expected_found, te
 def test_merge_gtfs_feed(test_database):
     results = {
         feed.id: feed
-        for feed in FeedsApiImpl().get_gtfs_feeds(None, None, None, None, None, None, None, None, None, None, None, None)
+        for feed in FeedsApiImpl().get_gtfs_feeds(None, None, None, None, None, None, 
+                                                  None, None, None, None, None, None)
         if feed.id in TEST_GTFS_FEED_STABLE_IDS
     }
     assert len(results) == len(TEST_GTFS_FEED_STABLE_IDS)

--- a/api/tests/test_database.py
+++ b/api/tests/test_database.py
@@ -73,7 +73,7 @@ def test_bounding_box_disjoint(latitudes, longitudes, method, expected_found, te
 def test_merge_gtfs_feed(test_database):
     results = {
         feed.id: feed
-        for feed in FeedsApiImpl().get_gtfs_feeds(None, None, None, None, None, None, None, None, None, None, None)
+        for feed in FeedsApiImpl().get_gtfs_feeds(None, None, None, None, None, None, None, None, None, None, None, None)
         if feed.id in TEST_GTFS_FEED_STABLE_IDS
     }
     assert len(results) == len(TEST_GTFS_FEED_STABLE_IDS)


### PR DESCRIPTION
**Summary:**

`test_merge_gtfs_feed` fails because `get_gtfs_feeds` requires a new param.  This was missed in the original PR.

**Expected behavior:** 

`test_merge_gtfs_feed` should call `get_gtfs_feeds` successfully. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
