### PR TITLE
feat: show a snackbar when refresh access token API call failed

### DIFF
--- a/web-app/src/app/screens/Account.tsx
+++ b/web-app/src/app/screens/Account.tsx
@@ -40,7 +40,6 @@ import {
 interface APIAccountState {
   showRefreshToken: boolean;
   showAccessToken: boolean;
-  accessTokenGenerated: boolean;
   codeBlockTooltip: string;
   tokenExpired: boolean;
 }
@@ -73,7 +72,6 @@ export default function APIAccount(): React.ReactElement {
   const [accountState, setAccountState] = React.useState<APIAccountState>({
     showRefreshToken: false,
     showAccessToken: false,
-    accessTokenGenerated: false,
     codeBlockTooltip: texts.copyToClipboard,
     tokenExpired: false,
   });
@@ -91,6 +89,10 @@ export default function APIAccount(): React.ReactElement {
     React.useState(false);
   const [refreshTokenCopyResult, setRefreshTokenCopyResult] =
     React.useState<string>('');
+
+  const showGenerateAccessTokenButton = React.useMemo(() => {
+    return user?.accessToken == null;
+  }, [user?.accessToken]);
 
   React.useEffect(() => {
     let interval: NodeJS.Timeout | null = null;
@@ -171,7 +173,6 @@ export default function APIAccount(): React.ReactElement {
   const handleGenerateAccessToken = (): void => {
     setAccountState({
       ...accountState,
-      accessTokenGenerated: true,
       tokenExpired: false,
     });
     dispatch(requestRefreshAccessToken());
@@ -402,7 +403,7 @@ export default function APIAccount(): React.ReactElement {
               <br />
               The access token updates regularly.
             </Typography>
-            {!accountState.accessTokenGenerated && (
+            {showGenerateAccessTokenButton && (
               <Box sx={{ mb: 2 }}>
                 <Button onClick={handleGenerateAccessToken} variant='contained'>
                   Generate Access Token
@@ -410,7 +411,7 @@ export default function APIAccount(): React.ReactElement {
               </Box>
             )}
 
-            {accountState.accessTokenGenerated && (
+            {!showGenerateAccessTokenButton && (
               <Box sx={{ width: 'fit-content', p: 1, mb: 5 }}>
                 <Box className='token-display-element'>
                   <Typography width={500} variant='body1'>
@@ -570,9 +571,7 @@ export default function APIAccount(): React.ReactElement {
               <br />
               <span style={{ color: '#f1fa8c' }}>--header</span>
               &apos;Authorization: Bearer{' '}
-              {accountState.accessTokenGenerated
-                ? user?.accessToken
-                : '[Your Access Token]'}
+              {user?.accessToken ?? '[Your Access Token]'}
               &apos;
             </Typography>
           </Paper>

--- a/web-app/src/app/screens/Account.tsx
+++ b/web-app/src/app/screens/Account.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Alert,
   CircularProgress,
+  Snackbar,
 } from '@mui/material';
 import {
   AccountCircleOutlined,
@@ -82,6 +83,8 @@ export default function APIAccount(): React.ReactElement {
   const [openDialog, setOpenDialog] = React.useState<boolean>(false);
   const [showAccessTokenCopiedTooltip, setShowAccessTokenCopiedTooltip] =
     React.useState(false);
+  const [showAccessTokenSnackbar, setShowAccessTokenSnackbar] =
+    React.useState(false);
   const [accessTokenCopyResult, setAccessTokenCopyResult] =
     React.useState<string>('');
   const [showRefreshTokenCopiedTooltip, setShowRefreshTokenCopiedTooltip] =
@@ -116,6 +119,10 @@ export default function APIAccount(): React.ReactElement {
       }
     };
   }, [user?.accessTokenExpirationTime]);
+
+  React.useEffect(() => {
+    setShowAccessTokenSnackbar(refreshingAccessTokenError !== null);
+  }, [refreshingAccessTokenError]);
 
   const handleClickShowToken = React.useCallback(
     (tokenType: TokenTypes): void => {
@@ -215,9 +222,23 @@ export default function APIAccount(): React.ReactElement {
         alignItems: 'center',
       }}
     >
-      {refreshingAccessTokenError != null ? (
-        <Alert severity='error'>{refreshingAccessTokenError.message}</Alert>
-      ) : null}
+      <Snackbar
+        open={showAccessTokenSnackbar}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        autoHideDuration={6000}
+        onClose={() => {
+          setShowAccessTokenSnackbar(false);
+        }}
+      >
+        <Alert
+          severity='error'
+          onClose={() => {
+            setShowAccessTokenSnackbar(false);
+          }}
+        >
+          {refreshingAccessTokenError?.message ?? ''}
+        </Alert>
+      </Snackbar>
       <CssBaseline />
       <Typography
         component='h1'

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -106,6 +106,10 @@ export const userProfileSlice = createSlice({
       }
       state.isRefreshingAccessToken = false;
     },
+    refreshAccessTokenFail: (state, action: PayloadAction<AppError>) => {
+      state.isRefreshingAccessToken = false;
+      state.errors.RefreshingAccessToken = action.payload;
+    },
     loginWithProvider: (
       state,
       action: PayloadAction<{
@@ -150,6 +154,7 @@ export const {
   signUpFail,
   resetProfileErrors,
   refreshAccessToken,
+  refreshAccessTokenFail,
   requestRefreshAccessToken,
   loginWithProvider,
   refreshUserInformation,

--- a/web-app/src/app/store/saga/profile-saga.ts
+++ b/web-app/src/app/store/saga/profile-saga.ts
@@ -13,6 +13,7 @@ import {
 import { generateUserAccessToken, updateUserInformation } from '../../services';
 import {
   refreshAccessToken,
+  refreshAccessTokenFail,
   refreshUserInformationFail,
   refreshUserInformationSuccess,
 } from '../profile-reducer';
@@ -26,7 +27,7 @@ function* refreshAccessTokenSaga(): Generator<StrictEffect, void, User> {
       yield put(refreshAccessToken(user));
     }
   } catch (error) {
-    // ignore
+    yield put(refreshAccessTokenFail(getAppError(error)));
   }
 }
 


### PR DESCRIPTION
**Summary:**

Closes #136 

**Expected behavior:** 
1. turn off Wifi
2. Click Refresh Access Token button
3. A snack bar with error message shown on the top center of your browser

New Testing steps:
Login
Click generate access token
Turn off Wifi
Click refresh access token icon button
A snackbar showing error message should displayed

![image](https://github.com/MobilityData/mobility-feed-api/assets/5789435/54ee4826-dc9f-47ec-8a05-f4b8b41a0992)


**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
