### PR TITLE
chore: add missing API permission

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -48,7 +48,8 @@ locals {
     "iap.googleapis.com",
     "identitytoolkit.googleapis.com",
     "secretmanager.googleapis.com",
-    "iamcredentials.googleapis.com"
+    "iamcredentials.googleapis.com",
+    "cloudbuild.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
**Summary:**

Add missing cloud build API permission required to deploy cloud functions.

**Expected behavior:** 

Cloud build API is enabled by terraform.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
