### PR TITLE
fix: 155 currentuser is always null on the first call of appauth

### DIFF
--- a/web-app/src/app/router/ProtectedRoute.tsx
+++ b/web-app/src/app/router/ProtectedRoute.tsx
@@ -3,16 +3,15 @@ import { useSelector } from 'react-redux';
 import { selectIsAuthenticated } from '../store/selectors';
 import { useEffect } from 'react';
 import { app } from '../../firebase';
+import { onAuthStateChanged } from 'firebase/auth';
+import { User } from 'firebase/auth';
 
 /**
  * This component is used to protect routes that require authentication.
  */
 export const ProtectedRoute = (): JSX.Element => {
   const isAuthenticated = useSelector(selectIsAuthenticated);
-  // Minimum fix for #155
-  useEffect(() => {
-    app.auth();
-  });
+
   if (!isAuthenticated) {
     return <Navigate to='/' />;
   }

--- a/web-app/src/app/router/ProtectedRoute.tsx
+++ b/web-app/src/app/router/ProtectedRoute.tsx
@@ -3,17 +3,32 @@ import { useSelector } from 'react-redux';
 import { selectIsAuthenticated } from '../store/selectors';
 import { useEffect } from 'react';
 import { app } from '../../firebase';
-import { onAuthStateChanged } from 'firebase/auth';
-import { User } from 'firebase/auth';
+import { useAppDispatch } from '../hooks';
+import { refreshApp, refreshAppSuccess } from '../store/profile-reducer';
 
 /**
  * This component is used to protect routes that require authentication.
  */
 export const ProtectedRoute = (): JSX.Element => {
   const isAuthenticated = useSelector(selectIsAuthenticated);
+  useEffect(() => {
+    app.auth();
+  });
+  const dispatch = useAppDispatch();
 
   if (!isAuthenticated) {
     return <Navigate to='/' />;
   }
+
+  app.auth().onAuthStateChanged((user) => {
+    if (user != null) {
+      dispatch(refreshAppSuccess());
+    }
+  });
+
+  if (app.auth().currentUser == null) {
+    dispatch(refreshApp());
+  }
+
   return <Outlet />;
 };

--- a/web-app/src/app/services/profile-service.ts
+++ b/web-app/src/app/services/profile-service.ts
@@ -1,8 +1,4 @@
-import {
-  updateProfile,
-  type AdditionalUserInfo,
-  updateCurrentUser,
-} from 'firebase/auth';
+import { updateProfile, type AdditionalUserInfo } from 'firebase/auth';
 import { app } from '../../firebase';
 import { type OauthProvider, type User } from '../types';
 

--- a/web-app/src/app/services/profile-service.ts
+++ b/web-app/src/app/services/profile-service.ts
@@ -1,6 +1,11 @@
-import { updateProfile, type AdditionalUserInfo } from 'firebase/auth';
+import {
+  updateProfile,
+  type AdditionalUserInfo,
+  updateCurrentUser,
+} from 'firebase/auth';
 import { app } from '../../firebase';
 import { type OauthProvider, type User } from '../types';
+import { onAuthStateChanged } from 'firebase/auth';
 
 /**
  * Send an email verification to the current user.
@@ -59,8 +64,7 @@ export const generateUserAccessToken = async (): Promise<User | null> => {
   } */
   // I suggest to use the check above to test if the user is logged in, and update userProfileSlice accordingly.
   // When the user is no longer logged in, we should redirect to the login page.
-
-  const currentUser = app.auth().currentUser;
+  let currentUser = app.auth().currentUser;
   if (currentUser === null) {
     return null;
   }
@@ -69,6 +73,17 @@ export const generateUserAccessToken = async (): Promise<User | null> => {
   const idTokenResult = await currentUser.getIdTokenResult(true);
   const accessToken = idTokenResult.token;
   const accessTokenExpirationTime = idTokenResult.expirationTime;
+
+  app.auth().onAuthStateChanged((user) => {
+    if (user != null) {
+      // User is signed in
+      currentUser = user;
+    } else {
+      // User is signed out
+      console.log('User is signed out');
+      // return <Navigate to='/' />;
+    }
+  });
 
   return {
     fullname: currentUser?.displayName ?? undefined,

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -20,6 +20,7 @@ interface UserProfileState {
     | 'registered'
     | 'registering';
   isRefreshingAccessToken: boolean;
+  isAppRefreshing: boolean;
   errors: AppErrors;
   user: User | undefined;
 }
@@ -35,6 +36,7 @@ const initialState: UserProfileState = {
     Registration: null,
   },
   isRefreshingAccessToken: false,
+  isAppRefreshing: false,
 };
 
 export const userProfileSlice = createSlice({
@@ -139,6 +141,12 @@ export const userProfileSlice = createSlice({
       state.errors.Registration = null;
       state.status = 'registered';
     },
+    refreshApp: (state) => {
+      state.isAppRefreshing = true;
+    },
+    refreshAppSuccess: (state) => {
+      state.isAppRefreshing = false;
+    },
   },
 });
 
@@ -160,6 +168,8 @@ export const {
   refreshUserInformation,
   refreshUserInformationFail,
   refreshUserInformationSuccess,
+  refreshApp,
+  refreshAppSuccess,
 } = userProfileSlice.actions;
 
 export default userProfileSlice.reducer;

--- a/web-app/src/app/store/selectors.ts
+++ b/web-app/src/app/store/selectors.ts
@@ -1,4 +1,3 @@
-import { is } from 'cypress/types/bluebird';
 import { type RootState } from './store';
 
 export * from './profile-selectors';

--- a/web-app/src/app/store/selectors.ts
+++ b/web-app/src/app/store/selectors.ts
@@ -1,3 +1,4 @@
+import { is } from 'cypress/types/bluebird';
 import { type RootState } from './store';
 
 export * from './profile-selectors';
@@ -7,6 +8,7 @@ export const selectLoadingApp = (state: RootState): boolean => {
     state.userProfile.status === 'login_in' ||
     state.userProfile.status === 'registering' ||
     state.userProfile.status === 'login_out' ||
-    state.userProfile.status === 'sign_up'
+    state.userProfile.status === 'sign_up' ||
+    state.userProfile.isAppRefreshing
   );
 };


### PR DESCRIPTION
**Summary:**

Closes #155
**Expected behavior:** 

1. Login
2. Open developer console, choose slow 3G as network setting
3. Click Refresh button of browser
4. You'll see a spinner 
5. Click Generate Access Token
6. You'll see the token generated

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
