### PR TITLE
feat: Reset (forgot) password auth workflow

### DIFF
--- a/web-app/cypress/e2e/resetpassword.cy.ts
+++ b/web-app/cypress/e2e/resetpassword.cy.ts
@@ -1,4 +1,3 @@
-
 describe('Reset Password Screen', () => {
   beforeEach(() => {
     cy.visit('/forgot-password');
@@ -11,21 +10,15 @@ describe('Reset Password Screen', () => {
   it('should show error when email no email is provided', () => {
     cy.get('input[id="email"]').type('not an email', { force: true });
 
-    cy.get('[data-testid=emailError]')
-      .should('exist')
+    cy.get('[data-testid=emailError]').should('exist');
   });
 
-  it('should show error when email is invalid', () => {
+  it('should show the captcha error when is not accepted', () => {
+    cy.get('iframe[title="reCAPTCHA"]').should('exist');
     cy.get('input[id="email"]').type('notvalid@e.c', { force: true });
     cy.get('[type="submit"]').click();
-    cy.get('[data-testid=firebaseError]')
+    cy.get('[data-testid=reCaptchaError]')
       .should('exist')
-  });
-
-  it('should show error when user doesn\'t exist', () => {
-    cy.get('input[id="email"]').type('userdontexist@email.ca', { force: true });
-    cy.get('[type="submit"]').click();
-    cy.get('[data-testid=firebaseError]')
-      .should('exist')
+      .contains('You must verify you are not a robot.');
   });
 });

--- a/web-app/cypress/e2e/resetpassword.cy.ts
+++ b/web-app/cypress/e2e/resetpassword.cy.ts
@@ -1,0 +1,31 @@
+
+describe('Reset Password Screen', () => {
+  beforeEach(() => {
+    cy.visit('/forgot-password');
+  });
+
+  it('should render components', () => {
+    cy.get('input[id="email"]').should('exist');
+  });
+
+  it('should show error when email no email is provided', () => {
+    cy.get('input[id="email"]').type('not an email', { force: true });
+
+    cy.get('[data-testid=emailError]')
+      .should('exist')
+  });
+
+  it('should show error when email is invalid', () => {
+    cy.get('input[id="email"]').type('notvalid@e.c', { force: true });
+    cy.get('[type="submit"]').click();
+    cy.get('[data-testid=firebaseError]')
+      .should('exist')
+  });
+
+  it('should show error when user doesn\'t exist', () => {
+    cy.get('input[id="email"]').type('userdontexist@email.ca', { force: true });
+    cy.get('[type="submit"]').click();
+    cy.get('[data-testid=firebaseError]')
+      .should('exist')
+  });
+});

--- a/web-app/src/app/router/Router.tsx
+++ b/web-app/src/app/router/Router.tsx
@@ -6,6 +6,7 @@ import Account from '../screens/Account';
 import ContactInformation from '../screens/ContactInformation';
 import { ProtectedRoute } from './ProtectedRoute';
 import CompleteRegistration from '../screens/CompleteRegistration';
+import ForgotPassword from '../screens/ForgotPassword';
 
 export const AppRouter: React.FC = () => {
   return (
@@ -23,6 +24,7 @@ export const AppRouter: React.FC = () => {
         <Route path='account' element={<Account />} />
       </Route>
       <Route path='contact-info' element={<ContactInformation />} />
+      <Route path='forgot-password' element={<ForgotPassword />} />
     </Routes>
   );
 };

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -16,7 +16,7 @@ import { Alert } from '@mui/material';
 import {
   selectResetPasswordError,
   selectUserProfileStatus,
-  selectisRecoveryEmailSent,
+  selectIsRecoveryEmailSent,
 } from '../store/selectors';
 import {
   ACCOUNT_TARGET,
@@ -28,7 +28,7 @@ export default function ForgotPassword(): React.ReactElement {
   const navigateTo = useNavigate();
   const userProfileStatus = useSelector(selectUserProfileStatus);
   const resetPasswordError = useSelector(selectResetPasswordError);
-  const resetPasswordSuccess = useSelector(selectisRecoveryEmailSent);
+  const resetPasswordSuccess = useSelector(selectIsRecoveryEmailSent);
 
   const SignInSchema = Yup.object().shape({
     email: Yup.string().email().required('Email is required'),

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -121,6 +121,11 @@ export default function ForgotPassword(): React.ReactElement {
             data-testid='reCaptcha'
             style={{ alignSelf: 'center', margin: 'normal' }}
           />
+          {formik.errors.reCaptcha != null ? (
+            <Alert severity='error' data-testid='reCaptchaError' sx={{ mt: 1 }}>
+              {formik.errors.reCaptcha}
+            </Alert>
+          ) : null}
           <Button
             type='submit'
             variant='contained'

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -6,7 +6,7 @@ import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAppDispatch } from '../hooks';
 import { resetPassword } from '../store/profile-reducer';
 import { useSelector } from 'react-redux';
@@ -15,14 +15,18 @@ import * as Yup from 'yup';
 import { Alert } from '@mui/material';
 import {
   selectResetPasswordError,
-  //   selectUserProfileStatus, TODO uncomment once complete reg is merged
+  selectUserProfileStatus,
   selectisRecoveryEmailSent,
 } from '../store/selectors';
+import {
+  ACCOUNT_TARGET,
+  COMPLETE_REGISTRATION_TARGET,
+} from '../constants/Navigation';
 
 export default function ForgotPassword(): React.ReactElement {
   const dispatch = useAppDispatch();
-  //   const navigateTo = useNavigate();
-  //   const userProfileStatus = useSelector(selectUserProfileStatus);
+  const navigateTo = useNavigate();
+  const userProfileStatus = useSelector(selectUserProfileStatus);
   const resetPasswordError = useSelector(selectResetPasswordError);
   const resetPasswordSuccess = useSelector(selectisRecoveryEmailSent);
 
@@ -40,14 +44,14 @@ export default function ForgotPassword(): React.ReactElement {
     },
   });
 
-  //   React.useEffect(() => {
-  //     if (userProfileStatus === 'registered') {
-  //       navigateTo(ACCOUNT_TARGET);
-  //     }
-  //     if (userProfileStatus === 'authenticated') {
-  //       navigateTo(COMPLETE_REGISTRATION_TARGET);
-  //     }
-  //   }, [userProfileStatus]);
+  React.useEffect(() => {
+    if (userProfileStatus === 'registered') {
+      navigateTo(ACCOUNT_TARGET);
+    }
+    if (userProfileStatus === 'authenticated') {
+      navigateTo(COMPLETE_REGISTRATION_TARGET);
+    }
+  }, [userProfileStatus]);
 
   return (
     <Container component='main' maxWidth='xs'>

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -22,6 +22,8 @@ import {
   ACCOUNT_TARGET,
   COMPLETE_REGISTRATION_TARGET,
 } from '../constants/Navigation';
+import { getEnvConfig } from '../utils/config';
+import ReCAPTCHA from 'react-google-recaptcha';
 
 export default function ForgotPassword(): React.ReactElement {
   const dispatch = useAppDispatch();
@@ -30,15 +32,17 @@ export default function ForgotPassword(): React.ReactElement {
   const resetPasswordError = useSelector(selectResetPasswordError);
   const resetPasswordSuccess = useSelector(selectIsRecoveryEmailSent);
 
-  const SignInSchema = Yup.object().shape({
+  const ForgotPasswordScheme = Yup.object().shape({
     email: Yup.string().email().required('Email is required'),
+    reCaptcha: Yup.string().required('You must verify you are not a robot.'),
   });
 
   const formik = useFormik({
     initialValues: {
       email: '',
+      reCaptcha: null,
     },
-    validationSchema: SignInSchema,
+    validationSchema: ForgotPasswordScheme,
     onSubmit: (values) => {
       dispatch(resetPassword(values.email));
     },
@@ -52,6 +56,10 @@ export default function ForgotPassword(): React.ReactElement {
       navigateTo(COMPLETE_REGISTRATION_TARGET);
     }
   }, [userProfileStatus]);
+
+  const onChangeReCaptcha = (value: string | null): void => {
+    void formik.setFieldValue('reCaptcha', value);
+  };
 
   return (
     <Container component='main' maxWidth='xs'>
@@ -107,7 +115,12 @@ export default function ForgotPassword(): React.ReactElement {
               {formik.errors.email}
             </Alert>
           ) : null}
-
+          <ReCAPTCHA
+            sitekey={getEnvConfig('REACT_APP_RECAPTCHA_SITE_KEY')}
+            onChange={onChangeReCaptcha}
+            data-testid='reCaptcha'
+            style={{ alignSelf: 'center', margin: 'normal' }}
+          />
           <Button
             type='submit'
             variant='contained'

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import CssBaseline from '@mui/material/CssBaseline';
+import TextField from '@mui/material/TextField';
+import Link from '@mui/material/Link';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+// import { useNavigate } from 'react-router-dom';
+import { useAppDispatch } from '../hooks';
+import { resetPassword } from '../store/profile-reducer';
+import { useSelector } from 'react-redux';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import { Alert } from '@mui/material';
+import {
+  selectResetPasswordError,
+  //   selectUserProfileStatus, TODO uncomment once complete reg is merged
+  selectisRecoveryEmailSent,
+} from '../store/selectors';
+
+export default function ForgotPassword(): React.ReactElement {
+  const dispatch = useAppDispatch();
+  //   const navigateTo = useNavigate();
+  //   const userProfileStatus = useSelector(selectUserProfileStatus);
+  const resetPasswordError = useSelector(selectResetPasswordError);
+  const resetPasswordSuccess = useSelector(selectisRecoveryEmailSent);
+
+  const SignInSchema = Yup.object().shape({
+    email: Yup.string().email().required('Email is required'),
+  });
+
+  const formik = useFormik({
+    initialValues: {
+      email: '',
+    },
+    validationSchema: SignInSchema,
+    onSubmit: (values) => {
+      dispatch(resetPassword(values.email));
+    },
+  });
+
+  //   React.useEffect(() => {
+  //     if (userProfileStatus === 'registered') {
+  //       navigateTo(ACCOUNT_TARGET);
+  //     }
+  //     if (userProfileStatus === 'authenticated') {
+  //       navigateTo(COMPLETE_REGISTRATION_TARGET);
+  //     }
+  //   }, [userProfileStatus]);
+
+  return (
+    <Container component='main' maxWidth='xs'>
+      <CssBaseline />
+      <Box
+        sx={{
+          mt: 12,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography
+          component='h1'
+          variant='h5'
+          color='primary'
+          fontWeight='bold'
+        >
+          Reset Password
+        </Typography>
+        <Typography component='h5'>
+          Don&apos;t have an account?{' '}
+          <Link href='/sign-up' color={'inherit'} fontWeight='bold'>
+            Register Here
+          </Link>
+          .
+        </Typography>
+        <Box
+          component='form'
+          onSubmit={formik.handleSubmit}
+          noValidate
+          sx={{
+            mt: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <TextField
+            margin='normal'
+            required
+            fullWidth
+            id='email'
+            label='Email Address'
+            name='email'
+            autoComplete='email'
+            autoFocus
+            onChange={formik.handleChange}
+            value={formik.values.email}
+            error={formik.errors.email != null}
+          />
+          {formik.errors.email != null ? (
+            <Alert severity='error' data-testid='emailError'>
+              {formik.errors.email}
+            </Alert>
+          ) : null}
+
+          <Button
+            type='submit'
+            variant='contained'
+            sx={{ mt: 3, mb: 2 }}
+            onClick={() => formik.handleChange}
+            data-testid='signin'
+          >
+            Send Recovery Email
+          </Button>
+          {resetPasswordError != null ? (
+            <Alert severity='error' data-testid='firebaseError'>
+              {resetPasswordError.message}
+            </Alert>
+          ) : null}
+          {resetPasswordSuccess ? (
+            <Alert severity='success'>A recovery email was sent.</Alert>
+          ) : null}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -170,15 +170,18 @@ export const userProfileSlice = createSlice({
       if (state.status === 'unauthenticated') {
         state.isRecoveryEmailSent = false;
         state.errors = { ...initialState.errors };
+        state.isAppRefreshing = true;
       }
     },
     resetPasswordFail: (state, action: PayloadAction<AppError>) => {
       state.isRecoveryEmailSent = false;
       state.errors.ResetPassword = action.payload;
+      state.isAppRefreshing = false;
     },
     resetPasswordSuccess: (state) => {
       state.isRecoveryEmailSent = true;
       state.errors.ResetPassword = null;
+      state.isAppRefreshing = false;
     },
   },
 });

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -21,6 +21,7 @@ interface UserProfileState {
     | 'registering';
   isRefreshingAccessToken: boolean;
   isAppRefreshing: boolean;
+  isRecoveryEmailSent: boolean;
   errors: AppErrors;
   user: User | undefined;
 }
@@ -34,9 +35,11 @@ const initialState: UserProfileState = {
     Logout: null,
     RefreshingAccessToken: null,
     Registration: null,
+    ResetPassword: null,
   },
   isRefreshingAccessToken: false,
   isAppRefreshing: false,
+  isRecoveryEmailSent: false,
 };
 
 export const userProfileSlice = createSlice({
@@ -163,6 +166,20 @@ export const userProfileSlice = createSlice({
     refreshAppSuccess: (state) => {
       state.isAppRefreshing = false;
     },
+    resetPassword: (state, action: PayloadAction<string>) => {
+      if (state.status === 'unauthenticated') {
+        state.isRecoveryEmailSent = false;
+        state.errors = { ...initialState.errors };
+      }
+    },
+    resetPasswordFail: (state, action: PayloadAction<AppError>) => {
+      state.isRecoveryEmailSent = false;
+      state.errors.ResetPassword = action.payload;
+    },
+    resetPasswordSuccess: (state) => {
+      state.isRecoveryEmailSent = true;
+      state.errors.ResetPassword = null;
+    },
   },
 });
 
@@ -186,6 +203,9 @@ export const {
   refreshUserInformationSuccess,
   refreshApp,
   refreshAppSuccess,
+  resetPassword,
+  resetPasswordFail,
+  resetPasswordSuccess,
 } = userProfileSlice.actions;
 
 export default userProfileSlice.reducer;

--- a/web-app/src/app/store/profile-selectors.ts
+++ b/web-app/src/app/store/profile-selectors.ts
@@ -22,7 +22,7 @@ export const selectEmailLoginError = (state: RootState): AppError | null =>
 export const selectResetPasswordError = (state: RootState): AppError | null =>
   selectErrorBySource(state, ErrorSource.ResetPassword);
 
-export const selectisRecoveryEmailSent = (state: RootState): boolean =>
+export const selectIsRecoveryEmailSent = (state: RootState): boolean =>
   state.userProfile.isRecoveryEmailSent;
 
 export const selectSignUpError = (state: RootState): AppError | null =>

--- a/web-app/src/app/store/profile-selectors.ts
+++ b/web-app/src/app/store/profile-selectors.ts
@@ -19,6 +19,12 @@ export const selectErrorBySource = (
 export const selectEmailLoginError = (state: RootState): AppError | null =>
   selectErrorBySource(state, ErrorSource.Login);
 
+export const selectResetPasswordError = (state: RootState): AppError | null =>
+  selectErrorBySource(state, ErrorSource.ResetPassword);
+
+export const selectisRecoveryEmailSent = (state: RootState): boolean =>
+  state.userProfile.isRecoveryEmailSent;
+
 export const selectSignUpError = (state: RootState): AppError | null =>
   selectErrorBySource(state, ErrorSource.SignUp);
 

--- a/web-app/src/app/store/saga/auth-saga.ts
+++ b/web-app/src/app/store/saga/auth-saga.ts
@@ -9,6 +9,7 @@ import {
   USER_PROFILE_SIGNUP_SUCCESS,
   type OauthProvider,
   USER_PROFILE_LOGIN_WITH_PROVIDER,
+  USER_PROFILE_RESET_PASSWORD,
   type UserData,
 } from '../../types';
 import 'firebase/compat/auth';
@@ -18,6 +19,8 @@ import {
   logoutSuccess,
   signUpFail,
   signUpSuccess,
+  resetPasswordFail,
+  resetPasswordSuccess,
 } from '../profile-reducer';
 import { type NavigateFunction } from 'react-router-dom';
 import {
@@ -30,6 +33,8 @@ import {
   type AdditionalUserInfo,
   type UserCredential,
   getAdditionalUserInfo,
+  getAuth,
+  sendPasswordResetEmail,
 } from 'firebase/auth';
 import { getAppError } from '../../utils/error';
 
@@ -117,10 +122,23 @@ function* loginWithProviderSaga({
       userData,
       additionalUserInfo,
     );
-    console.log(userEnhanced);
     yield put(loginSuccess(userEnhanced));
   } catch (error) {
     yield put(loginFail(getAppError(error)));
+  }
+}
+
+function* resetPasswordSaga({
+  payload: email,
+}: PayloadAction<string>): Generator {
+  try {
+    const auth = getAuth();
+    yield call(async () => {
+      await sendPasswordResetEmail(auth, email);
+    });
+    yield put(resetPasswordSuccess());
+  } catch (error) {
+    yield put(resetPasswordFail(getAppError(error)));
   }
 }
 
@@ -130,4 +148,5 @@ export function* watchAuth(): Generator {
   yield takeLatest(USER_PROFILE_SIGNUP, signUpSaga);
   yield takeLatest(USER_PROFILE_SIGNUP_SUCCESS, sendEmailVerificationSaga);
   yield takeLatest(USER_PROFILE_LOGIN_WITH_PROVIDER, loginWithProviderSaga);
+  yield takeLatest(USER_PROFILE_RESET_PASSWORD, resetPasswordSaga);
 }

--- a/web-app/src/app/types.ts
+++ b/web-app/src/app/types.ts
@@ -42,6 +42,7 @@ export const USER_REQUEST_REFRESH_ACCESS_TOKEN = `${USER_PROFILE}/requestRefresh
 export const USER_PROFILE_LOAD_ORGANIZATION_FAIL = `${USER_PROFILE}/loadOrganizationFail`;
 export const USER_PROFILE_LOGIN_WITH_PROVIDER = `${USER_PROFILE}/loginWithProvider`;
 export const USER_PROFILE_REFRESH_INFORMATION = `${USER_PROFILE}/refreshUserInformation`;
+export const USER_PROFILE_RESET_PASSWORD = `${USER_PROFILE}/resetPassword`;
 
 export enum ErrorSource {
   SignUp = 'SignUp',
@@ -49,6 +50,7 @@ export enum ErrorSource {
   Logout = 'Logout',
   RefreshingAccessToken = 'RefreshingAccessToken',
   Registration = 'Registration',
+  ResetPassword = 'ResetPassword',
 }
 
 export interface AppError {


### PR DESCRIPTION
**Summary:**
Reset (forgot) password auth workflow
Closes #141 
Related to #188 

![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/84de2ae9-e909-431e-a60f-d2093c33f594)

**Testing tips:**
- Log out if logged in
- From the Login screen click on `Forgot your password? Reset Here.`. You should then be redirected to the password resetting screen
- Type your registered email and submit
- Reset your email by following the instructions on the email you received
- Log in with your new password

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
