### PR TITLE
feat: Add feed_contact_email

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -61,6 +61,7 @@ class FeedsApiImpl(BaseFeedsApi):
             "feed_name": database_feed.feed_name,
             "note": database_feed.note,
             "provider": database_feed.provider,
+            "feed_contact_email": database_feed.feed_contact_email,
             "source_info": SourceInfo(
                 producer_url=database_feed.producer_url,
                 authentication_type=database_feed.authentication_type,

--- a/api/src/scripts/populate_db.py
+++ b/api/src/scripts/populate_db.py
@@ -137,6 +137,7 @@ class DatabasePopulateHelper:
                 data_type=row["data_type"],
                 feed_name=row["name"],
                 note=row["note"],
+                feed_contact_email=row["feed_contact_email"],
                 producer_url=row["urls.direct_download"],
                 authentication_type=str(int(row.get("urls.authentication_type", "0") or "0")),
                 authentication_info_url=row["urls.authentication_info"],

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -294,6 +294,9 @@ components:
         note:
          description: A note to clarify complex use cases for consumers.
          type: string
+        feed_contact_email:
+          description: Use to contact the feed producer.
+          type: string
         source_info:
           $ref: "#/components/schemas/SourceInfo"
         redirects:

--- a/docs/DatabaseCatalogAPI_IAP.yaml
+++ b/docs/DatabaseCatalogAPI_IAP.yaml
@@ -294,6 +294,9 @@ components:
         note:
          description: A note to clarify complex use cases for consumers.
          type: string
+        feed_contact_email:
+          description: Use to contact the feed producer.
+          type: string
         source_info:
           $ref: "#/components/schemas/SourceInfo"
         redirects:


### PR DESCRIPTION
**Summary:**
closes #194 
Added feat_contact_email in openAPI config and in the populate-db python script.
This PR goes with this mobility_database_catalog PR: https://github.com/MobilityData/mobility-database-catalogs/pull/316

**Expected behavior:** 

`feed_contact_email` added to all the feeds endpoints response
`feed_contact_email` added to the swagger

**Testing tips:**
- Generate the DB locally (see steps in https://github.com/MobilityData/mobility-feed-api/blob/main/README.md)
- Check that there is a `feed_contact_email` column added to the `feeds` table. You can use psql or pgAdmin4 for that)
- Use the sources.csv file generated by the mobility-database-catalog github action. 
- Fill the DB with populate-db.py script.
- Call the feeds endpoints from the API.
- Check that there is a `feed_contact_email` field in the response. Its value can be null.
- Add a line to the sources.csv file with the `feed_contact_email` set to something.
- Fill the DB with populate-db.py script.
- Check that the email is returned by the feeds enpoint.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
