### PR TITLE
fix: 500 when limit is -1

### DIFF
--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -758,6 +758,7 @@ components:
       required: False
       schema:
         type: integer
+        minimum: 0
         example: 10
     offset:
       name: offset

--- a/docs/DatabaseCatalogAPI_IAP.yaml
+++ b/docs/DatabaseCatalogAPI_IAP.yaml
@@ -758,6 +758,7 @@ components:
       required: False
       schema:
         type: integer
+        minimum: 0
         example: 10
     offset:
       name: offset


### PR DESCRIPTION
**Summary:**

Fixes the 500 response from the API when limit parameter passed is negative. https://github.com/MobilityData/mobility-feed-api/issues/190

**Expected behavior:** 

Returns 422 with the below JSON body like offset parameter.

<img width="1026" alt="Screenshot 2023-12-26 at 2 02 26 PM" src="https://github.com/MobilityData/mobility-feed-api/assets/11898526/fc6cfde8-a4f0-4c5a-b2ea-91e67718f358">

