### PR TITLE
fix: mobile navigation matches desktop navigation

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^5.14.9",
     "@mui/material": "^5.14.9",
+    "@mui/x-tree-view": "^6.17.0",
     "@reduxjs/toolkit": "^1.9.6",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -23,37 +23,49 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import HelpIcon from '@mui/icons-material/Help';
 import {
-  type NavigationHandler,
   navigationItems,
   navigationAccountItem,
   navigationHelpItem,
   SIGN_IN_TARGET,
+  ACCOUNT_TARGET,
 } from '../constants/Navigation';
 import type NavigationItem from '../interface/Navigation';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { selectIsAuthenticated } from '../store/selectors';
 import LogoutConfirmModal from './LogoutConfirmModal';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { TreeView } from '@mui/x-tree-view/TreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { OpenInNew } from '@mui/icons-material';
 import '../styles/Header.css';
 
 const drawerWidth = 240;
 const websiteTile = 'Mobility Database';
-
 const DrawerContent: React.FC<{
-  onClick: React.MouseEventHandler;
-  onNavigationClick: NavigationHandler;
-}> = ({ onClick, onNavigationClick }) => {
+  onLogoutClick: React.MouseEventHandler;
+  onNavigationClick: (target: NavigationItem | string) => void;
+}> = ({ onLogoutClick, onNavigationClick }) => {
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const navigateTo = useNavigate();
   return (
-    <Box onClick={onClick} sx={{ textAlign: 'center' }}>
-      <Typography
-        variant='h6'
-        sx={{ my: 2 }}
-        data-testid='websiteTile'
-        className='website-title'
+    <Box>
+      <Box
+        sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+        onClick={() => {
+          navigateTo('/');
+        }}
       >
-        {websiteTile}
-      </Typography>
+        <Avatar src='/assets/MOBILTYDATA_logo_purple_M.png'></Avatar>
+        <Typography
+          variant='h6'
+          sx={{ my: 2, cursor: 'pointer' }}
+          data-testid='websiteTile'
+        >
+          {websiteTile}
+        </Typography>
+      </Box>
       <Divider />
       <List>
         {navigationItems.map((item) => (
@@ -64,18 +76,76 @@ const DrawerContent: React.FC<{
               onNavigationClick(item);
             }}
           >
-            <ListItemButton sx={{ textAlign: 'center' }}>
+            <ListItemButton
+              sx={{
+                textAlign: 'left',
+                p: 0,
+                pl: '16px',
+              }}
+            >
               <ListItemText>{item.title}</ListItemText>
             </ListItemButton>
           </ListItem>
         ))}
+        <Divider sx={{ mt: 2, mb: 2 }} />
+        {isAuthenticated ? (
+          <TreeView
+            defaultCollapseIcon={<ExpandMoreIcon />}
+            defaultExpandIcon={<ChevronRightIcon />}
+            sx={{ textAlign: 'left' }}
+          >
+            <TreeItem nodeId='1' label='Account' sx={{ color: '#3959fa' }}>
+              <TreeItem
+                nodeId='2'
+                label='Account Details'
+                sx={{ color: '#7c7c7c', cursor: 'pointer' }}
+                onClick={() => {
+                  onNavigationClick(ACCOUNT_TARGET);
+                }}
+                icon={<AccountCircleIcon fontSize='small' />}
+              />
+              <TreeItem
+                nodeId='3'
+                label='Help'
+                sx={{ color: '#7c7c7c' }}
+                icon={<HelpIcon fontSize='small' />}
+              />
+              <TreeItem
+                nodeId='4'
+                label='Sign Out'
+                sx={{ color: '#7c7c7c' }}
+                onClick={onLogoutClick}
+                icon={<LogoutIcon fontSize='small' />}
+              />
+            </TreeItem>
+          </TreeView>
+        ) : (
+          <ListItem
+            sx={{ color: '#3959fa' }}
+            onClick={() => {
+              onNavigationClick(SIGN_IN_TARGET);
+            }}
+            key={'Login'}
+            disablePadding
+          >
+            <ListItemButton
+              sx={{
+                textAlign: 'left',
+                p: 0,
+                pl: '16px',
+              }}
+            >
+              <ListItemText>Login</ListItemText>
+            </ListItemButton>
+          </ListItem>
+        )}
       </List>
     </Box>
   );
 };
 
 export default function DrawerAppBar(): React.ReactElement {
-  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [mobileOpen, setMobileOpen] = React.useState(true);
   const [openDialog, setOpenDialog] = React.useState(false);
 
   const navigateTo = useNavigate();
@@ -85,10 +155,14 @@ export default function DrawerAppBar(): React.ReactElement {
     setMobileOpen((prevState) => !prevState);
   };
 
-  const handleNavigation = (navigationItem: NavigationItem): void => {
-    if (navigationItem.external === true)
-      window.open(navigationItem.target, '_blank', 'noopener noreferrer');
-    else navigateTo(navigationItem.target);
+  const handleNavigation = (navigationItem: NavigationItem | string): void => {
+    if (typeof navigationItem === 'string') navigateTo(navigationItem);
+    else {
+      if (navigationItem.external === true)
+        window.open(navigationItem.target, '_blank', 'noopener noreferrer');
+      else navigateTo(navigationItem.target);
+    }
+    setMobileOpen(false);
   };
 
   const handleLogoutClick = (): void => {
@@ -123,15 +197,7 @@ export default function DrawerAppBar(): React.ReactElement {
         sx={{ background: 'white' }}
       >
         <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <a
-            href={'/'}
-            style={{
-              textDecoration: 'none',
-              display: 'flex',
-              alignItems: 'center',
-            }}
-            className='btn-link'
-          >
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <IconButton
               color='inherit'
               aria-label='open drawer'
@@ -141,20 +207,27 @@ export default function DrawerAppBar(): React.ReactElement {
             >
               <MenuIcon />
             </IconButton>
-
-            <Avatar src='/assets/MOBILTYDATA_logo_purple_M.png'></Avatar>
-            <Typography
-              variant='h5'
-              component='div'
-              className='website-title'
-              sx={{
-                flexGrow: 1,
-                display: { xs: 'none', md: 'block' },
+            <a
+              href={'/'}
+              style={{
+                textDecoration: 'none',
               }}
+              className='btn-link'
             >
-              {websiteTile}
-            </Typography>
-          </a>
+              <Avatar src='/assets/MOBILTYDATA_logo_purple_M.png'></Avatar>
+              <Typography
+                variant='h5'
+                component='div'
+                className='website-title'
+                sx={{
+                  flexGrow: 1,
+                  display: { xs: 'none', md: 'block' },
+                }}
+              >
+                {websiteTile}
+              </Typography>
+            </a>
+          </Box>
 
           <Box sx={{ display: { xs: 'none', md: 'block' } }}>
             {navigationItems.map((item) => (
@@ -236,7 +309,7 @@ export default function DrawerAppBar(): React.ReactElement {
           }}
         >
           <DrawerContent
-            onClick={handleDrawerToggle}
+            onLogoutClick={handleLogoutClick}
             onNavigationClick={handleNavigation}
           />
         </Drawer>

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -21,11 +21,9 @@ import MenuIcon from '@mui/icons-material/Menu';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import LogoutIcon from '@mui/icons-material/Logout';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
-import HelpIcon from '@mui/icons-material/Help';
 import {
   navigationItems,
   navigationAccountItem,
-  navigationHelpItem,
   SIGN_IN_TARGET,
   ACCOUNT_TARGET,
 } from '../constants/Navigation';
@@ -108,12 +106,6 @@ const DrawerContent: React.FC<{
                   onNavigationClick(ACCOUNT_TARGET);
                 }}
                 icon={<AccountCircleIcon fontSize='small' />}
-              />
-              <TreeItem
-                nodeId='3'
-                label='Help'
-                sx={{ color: '#7c7c7c' }}
-                icon={<HelpIcon fontSize='small' />}
               />
               <TreeItem
                 nodeId='4'
@@ -273,16 +265,6 @@ export default function DrawerAppBar(): React.ReactElement {
                       <AccountCircleIcon fontSize='small' />
                     </ListItemIcon>
                     Account Details
-                  </MenuItem>
-                  <MenuItem
-                    onClick={() => {
-                      handleMenuItemClick(navigationHelpItem);
-                    }}
-                  >
-                    <ListItemIcon>
-                      <HelpIcon fontSize='small' />
-                    </ListItemIcon>
-                    Help
                   </MenuItem>
                   <MenuItem onClick={handleLogoutClick}>
                     <ListItemIcon>

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -83,7 +83,12 @@ const DrawerContent: React.FC<{
                 pl: '16px',
               }}
             >
-              <ListItemText>{item.title}</ListItemText>
+              <ListItemText>
+                {item.title}{' '}
+                {item.external === true ? (
+                  <OpenInNew sx={{ verticalAlign: 'middle' }} />
+                ) : null}
+              </ListItemText>
             </ListItemButton>
           </ListItem>
         ))}
@@ -145,7 +150,7 @@ const DrawerContent: React.FC<{
 };
 
 export default function DrawerAppBar(): React.ReactElement {
-  const [mobileOpen, setMobileOpen] = React.useState(true);
+  const [mobileOpen, setMobileOpen] = React.useState(false);
   const [openDialog, setOpenDialog] = React.useState(false);
 
   const navigateTo = useNavigate();

--- a/web-app/src/app/constants/Navigation.ts
+++ b/web-app/src/app/constants/Navigation.ts
@@ -39,12 +39,6 @@ export const navigationItems: NavigationItem[] = [
     external: true,
   },
 ];
-export const navigationHelpItem: NavigationItem = {
-  title: 'Help',
-  target: 'help', // TODO generate help page
-  color: 'inherit',
-  variant: 'text',
-};
 
 export const navigationAccountItem: NavigationItem = {
   title: 'Account',

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -1141,6 +1141,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.23.6":
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.7.tgz#dd7c88deeb218a0f8bd34d5db1aa242e0f203193"
+  integrity sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -2388,6 +2395,19 @@
     clsx "^2.0.0"
     prop-types "^15.8.1"
 
+"@mui/base@^5.0.0-beta.20":
+  version "5.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.30.tgz#8feca6b70f2b9cd4d5cb97799ae9fcb5376c7f83"
+  integrity sha512-dc38W4W3K42atE9nSaOeoJ7/x9wGIfawdwC/UmMxMLlZ1iSsITQ8dQJaTATCbn98YvYPINK/EH541YA5enQIPQ==
+  dependencies:
+    "@babel/runtime" "^7.23.6"
+    "@floating-ui/react-dom" "^2.0.4"
+    "@mui/types" "^7.2.12"
+    "@mui/utils" "^5.15.3"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+
 "@mui/core-downloads-tracker@^5.14.18":
   version "5.14.18"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.18.tgz#f8b187dc89756fa5c0b7d15aea537a6f73f0c2d8"
@@ -2451,10 +2471,25 @@
     csstype "^3.1.2"
     prop-types "^15.8.1"
 
+"@mui/types@^7.2.12":
+  version "7.2.12"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.12.tgz#602acbb5aa3eb56a31f569a19f87f75d33de5c01"
+  integrity sha512-3kaHiNm9khCAo0pVe0RenketDSFoZGAlVZ4zDjB/QNZV0XiCj+sh1zkX0VVhQPgYJDlBEzAag+MHJ1tU3vf0Zw==
+
 "@mui/types@^7.2.9":
   version "7.2.9"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.9.tgz#730ee83a37af292a5973962f78ce5c95f31213a7"
   integrity sha512-k1lN/PolaRZfNsRdAqXtcR71sTnv3z/VCCGPxU8HfdftDkzi335MdJ6scZxvofMAd/K/9EbzCZTFBmlNpQVdCg==
+
+"@mui/utils@^5.14.14", "@mui/utils@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.15.3.tgz#421043be5279d31ca9b221a6398feb7c9d61209b"
+  integrity sha512-mT3LiSt9tZWCdx1pl7q4Q5tNo6gdZbvJel286ZHGuj6LQQXjWNAh8qiF9d+LogvNUI+D7eLkTnj605d1zoazfg==
+  dependencies:
+    "@babel/runtime" "^7.23.6"
+    "@types/prop-types" "^15.7.11"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
 
 "@mui/utils@^5.14.18":
   version "5.14.18"
@@ -2465,6 +2500,19 @@
     "@types/prop-types" "^15.7.10"
     prop-types "^15.8.1"
     react-is "^18.2.0"
+
+"@mui/x-tree-view@^6.17.0":
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-tree-view/-/x-tree-view-6.17.0.tgz#79122e4df90079f31a47d4c9df5d0bf21f2882c6"
+  integrity sha512-09dc2D+Rjg2z8KOaxbUXyPi0aw7fm2jurEtV8Xw48xJ00joLWd5QJm1/v4CarEvaiyhTQzHImNqdgeJW8ZQB6g==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+    "@mui/base" "^5.0.0-beta.20"
+    "@mui/utils" "^5.14.14"
+    "@types/react-transition-group" "^4.4.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -3256,7 +3304,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
   integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.10":
+"@types/prop-types@*", "@types/prop-types@^15.7.10", "@types/prop-types@^15.7.11":
   version "15.7.11"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==


### PR DESCRIPTION
**Summary:**
Closes #205 

**Expected behavior:** 
The hamburger navigation matches the desktop navigation

When the user is not authenticated:
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/fc416883-e86b-40b9-a918-79a05822faec)

When the user is authenticated:
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/18f6dcb3-7a42-42a3-82a7-a03e5cfd4360)

**Testing tips:**
- Reduce page width to <900px
- Click on hamburger navigation 
- Validate that the login button works properly
- Login to your account
- Click on the hamburger navigation once more
- Validate that the account options are available and match the desktop version (which you can see by increasing the page width to >=900px) 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
