### PR TITLE
fix: input validation error display issue

### DIFF
--- a/web-app/cypress/e2e/resetpassword.cy.ts
+++ b/web-app/cypress/e2e/resetpassword.cy.ts
@@ -9,7 +9,7 @@ describe('Reset Password Screen', () => {
 
   it('should show error when email no email is provided', () => {
     cy.get('input[id="email"]').type('not an email', { force: true });
-
+    cy.get('[type="submit"]').click();
     cy.get('[data-testid=emailError]').should('exist');
   });
 

--- a/web-app/cypress/e2e/signup.cy.ts
+++ b/web-app/cypress/e2e/signup.cy.ts
@@ -14,7 +14,7 @@ describe('Sign up screen', () => {
 
   it('should show the password error when password length is less than 12', () => {
     cy.get('input[id="password"]').type('short', { force: true });
-
+    cy.get('button[id="sign-up-button"]').click();
     cy.get('[data-testid=passwordError]')
       .should('exist')
       .contains('Password must');
@@ -22,7 +22,7 @@ describe('Sign up screen', () => {
 
   it('should show the password error when password do not contain lowercase', () => {
     cy.get('input[id="password"]').type('UPPERCASE_10_!', { force: true });
-
+    cy.get('button[id="sign-up-button"]').click();
     cy.get('[data-testid=passwordError]')
       .should('exist')
       .contains('Password must');
@@ -30,7 +30,7 @@ describe('Sign up screen', () => {
 
   it('should show the password error when password do not contain uppercase', () => {
     cy.get('input[id="password"]').type('lowercase_10_!', { force: true });
-
+    cy.get('button[id="sign-up-button"]').click();
     cy.get('[data-testid=passwordError]')
       .should('exist')
       .contains('Password must');
@@ -38,13 +38,12 @@ describe('Sign up screen', () => {
 
   it('should not show the password error when password is valid', () => {
     cy.get('input[id="password"]').type('UP_lowercase_10_!', { force: true });
-
     cy.get('[data-testid=passwordError]').should('not.exist');
   });
 
   it('should show the password error when password do not match', () => {
     cy.get('input[id="password"]').type('UP_lowercase_10_!', { force: true });
-
+    cy.get('button[id="sign-up-button"]').click();
     cy.get('input[id="confirmPassword"]').type('UP_lowercase_11_!', {
       force: true,
     });

--- a/web-app/src/app/screens/ChangePassword.tsx
+++ b/web-app/src/app/screens/ChangePassword.tsx
@@ -37,11 +37,16 @@ export default function ChangePassword(): React.ReactElement {
   const navigateTo = useNavigate();
   const changePasswordError = useSelector(selectChangePasswordError);
   const changePasswordStatus = useSelector(selectChangePasswordStatus);
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
   const ChangePasswordSchema = Yup.object().shape({
     currentPassword: Yup.string().required('Password is required'),
     newPassword: Yup.string()
       .required('New Password is required')
-      .min(12, 'Password is too short - should be 12 chars minimum')
+      .min(
+        12,
+        'Password is too short. Password should be 12 characters minimum',
+      )
       .matches(passwordValidationRegex, 'Password error'),
     confirmNewPassword: Yup.string()
       .required('Confirm New Password is required')
@@ -56,6 +61,8 @@ export default function ChangePassword(): React.ReactElement {
       confirmNewPassword: '',
     },
     validationSchema: ChangePasswordSchema,
+    validateOnChange: isSubmitted,
+    validateOnBlur: true,
     onSubmit: (values) => {
       dispatch(
         changePassword({
@@ -229,7 +236,9 @@ export default function ChangePassword(): React.ReactElement {
               marginLeft: 'auto',
               marginRight: 'auto',
             }}
-            onClick={() => formik.handleChange}
+            onClick={() => {
+              setIsSubmitted(true);
+            }}
           >
             Save Changes
           </Button>

--- a/web-app/src/app/screens/CompleteRegistration.tsx
+++ b/web-app/src/app/screens/CompleteRegistration.tsx
@@ -33,6 +33,8 @@ export default function CompleteRegistration(): React.ReactElement {
   const userProfileStatus = useSelector(selectUserProfileStatus);
   const registrationError = useSelector(selectRegistrationError);
 
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
   React.useEffect(() => {
     if (userProfileStatus === 'registered') {
       navigateTo(ACCOUNT_TARGET);
@@ -59,6 +61,8 @@ export default function CompleteRegistration(): React.ReactElement {
       agreeToPrivacyPolicy: false,
     },
     validationSchema: CompleteRegistrationSchema,
+    validateOnChange: isSubmitted,
+    validateOnBlur: true,
     onSubmit: async (values) => {
       if (user != null) {
         dispatch(
@@ -175,7 +179,13 @@ export default function CompleteRegistration(): React.ReactElement {
               justifyContent: 'center',
             }}
           >
-            <Button type='submit' variant='contained'>
+            <Button
+              type='submit'
+              variant='contained'
+              onClick={() => {
+                setIsSubmitted(true);
+              }}
+            >
               Finish Account Setup
             </Button>
           </Box>

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -31,9 +31,12 @@ export default function ForgotPassword(): React.ReactElement {
   const userProfileStatus = useSelector(selectUserProfileStatus);
   const resetPasswordError = useSelector(selectResetPasswordError);
   const resetPasswordSuccess = useSelector(selectIsRecoveryEmailSent);
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
 
   const ForgotPasswordScheme = Yup.object().shape({
-    email: Yup.string().email().required('Email is required'),
+    email: Yup.string()
+      .email('Email format is invalid.')
+      .required('Email is required'),
     reCaptcha: Yup.string().required('You must verify you are not a robot.'),
   });
 
@@ -42,6 +45,8 @@ export default function ForgotPassword(): React.ReactElement {
       email: '',
       reCaptcha: null,
     },
+    validateOnChange: isSubmitted,
+    validateOnBlur: true,
     validationSchema: ForgotPasswordScheme,
     onSubmit: (values) => {
       dispatch(resetPassword(values.email));
@@ -130,7 +135,9 @@ export default function ForgotPassword(): React.ReactElement {
             type='submit'
             variant='contained'
             sx={{ mt: 3, mb: 2 }}
-            onClick={() => formik.handleChange}
+            onClick={() => {
+              setIsSubmitted(true);
+            }}
             data-testid='signin'
           >
             Send Recovery Email

--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -38,14 +38,20 @@ export default function SignIn(): React.ReactElement {
   const navigateTo = useNavigate();
   const userProfileStatus = useSelector(selectUserProfileStatus);
   const emailLoginError = useSelector(selectEmailLoginError);
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
   const [showPassword, setShowPassword] = React.useState(false);
 
   const SignInSchema = Yup.object().shape({
-    email: Yup.string().email().required('Email is required'),
+    email: Yup.string()
+      .email('Email format is invalid.')
+      .required('Email is required'),
 
     password: Yup.string()
       .required('Password is required')
-      .min(12, 'Password is too short - should be 12 chars minimum'),
+      .min(
+        12,
+        'Password is too short. Your password should be 12 characters minimum',
+      ),
   });
 
   const formik = useFormik({
@@ -54,6 +60,8 @@ export default function SignIn(): React.ReactElement {
       password: '',
     },
     validationSchema: SignInSchema,
+    validateOnChange: isSubmitted,
+    validateOnBlur: true,
     onSubmit: (values) => {
       const emailLogin: EmailLogin = {
         email: values.email,
@@ -196,7 +204,9 @@ export default function SignIn(): React.ReactElement {
             type='submit'
             variant='contained'
             sx={{ mt: 3, mb: 2 }}
-            onClick={() => formik.handleChange}
+            onClick={() => {
+              setIsSubmitted(true);
+            }}
             data-testid='signin'
           >
             Sign In

--- a/web-app/src/app/screens/SignUp.tsx
+++ b/web-app/src/app/screens/SignUp.tsx
@@ -42,8 +42,12 @@ export default function SignUp(): React.ReactElement {
   const dispatch = useAppDispatch();
   const signUpError = useSelector(selectSignUpError);
   const userProfileStatus = useSelector(selectUserProfileStatus);
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
   const SignUpSchema = Yup.object().shape({
-    email: Yup.string().email().required('Email is required'),
+    email: Yup.string()
+      .email('Email format is invalid.')
+      .required('Email is required'),
     confirmEmail: Yup.string().oneOf(
       [Yup.ref('email'), ''],
       'Emails do not match',
@@ -71,6 +75,8 @@ export default function SignUp(): React.ReactElement {
       reCaptcha: null,
     },
     validationSchema: SignUpSchema,
+    validateOnChange: isSubmitted,
+    validateOnBlur: true,
     onSubmit: (values) => {
       dispatch(
         signUp({
@@ -293,7 +299,9 @@ export default function SignUp(): React.ReactElement {
             type='submit'
             variant='contained'
             sx={{ mt: 3, mb: 2, alignSelf: 'center' }}
-            onClick={formik.handleChange}
+            onClick={() => {
+              setIsSubmitted(true);
+            }}
             id='sign-up-button'
           >
             Sign Up


### PR DESCRIPTION
**Summary:**
Closes #206 
- validation error display fix on `SignIn`, `SignUp`, `CompleteRegistration`, `ResetPassword`, `ForgotPassword`
- changed error messages to be consistent
- updated e2e tests to reflect the changes

**Expected behavior:** 
The validation error displays once the user submits the forms. Once the user has submitted the form once, the error will update upon any change to guide the user and let them know when the input's validation error was fixed.

**Testing tips:**
Try the input boxes on any (or all) of the following pages:
- Sign In
- Sign Up
- Complete Registration (create a new account to see this page when you login for the first time)
- Reset Password
- Forgot Password (login to your account using the email and password method and click on `Change Password` from the account page)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
