### PR TITLE
fix: python functions service account reference

### DIFF
--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -43,7 +43,7 @@ data "google_iam_policy" "secret_access" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.containers_service_account.email}"
+      "serviceAccount:${google_service_account.functions_service_account.email}"
     ]
   }
 }
@@ -86,7 +86,7 @@ resource "google_cloudfunctions2_function" "tokens" {
         version    = "latest"
       }
     }
-    service_account_email = google_service_account.containers_service_account.email
+    service_account_email = google_service_account.functions_service_account.email
     ingress_settings = local.function_tokens_config.ingress_settings
   }
 }

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -24,7 +24,7 @@ locals {
 
 # Service account to execute the cloud functions
 resource "google_service_account" "functions_service_account" {
-  account_id   = "containers-service-account"
+  account_id   = "functions-service-account"
   display_name = "Functions Service Account"
 }
 


### PR DESCRIPTION
**Summary:**

PR #196  changed the service account to be used in the Python functions and broke the deployment. 

**Expected behavior:** 

The correct service account is referenced by the python functions.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
