### PR TITLE
chore: remove GCP credentials from build-test GH action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,15 +27,6 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Authenticate to Google Cloud
-        id: gcloud_auth
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
-
-      - name: GCloud Setup
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Docker Compose DB/Liquibase for db-gen.sh
         run: docker-compose --env-file ./config/.env.local up -d liquibase
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
+      - name: GCloud Setup
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Docker Compose DB/Liquibase for db-gen.sh
         run: docker-compose --env-file ./config/.env.local up -d liquibase
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
-      - name: GCloud Setup
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Docker Compose DB/Liquibase for db-gen.sh
         run: docker-compose --env-file ./config/.env.local up -d liquibase
         working-directory: ${{ github.workspace }}

--- a/functions-python/batch_datasets/tests/test_batch_datasets_main.py
+++ b/functions-python/batch_datasets/tests/test_batch_datasets_main.py
@@ -16,7 +16,7 @@
 import json
 import os
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 from batch_datasets.src.main import get_active_feeds, batch_datasets
 from test_utils.database_utils import get_testing_session, default_db_url
 
@@ -35,8 +35,9 @@ def test_get_active_feeds():
     {"FEEDS_DATABASE_URL": default_db_url, "FEEDS_PUBSUB_TOPIC_NAME": "test_topic"},
 )
 @patch("batch_datasets.src.main.publish")
-@patch("google.cloud.pubsub_v1.PublisherClient")
+@patch("batch_datasets.src.main.get_pubsub_client")
 def test_batch_datasets(mock_client, mock_publish):
+    mock_client.return_value = MagicMock()
     with get_testing_session() as session:
         active_feeds = get_active_feeds(session)
         with patch(
@@ -51,7 +52,7 @@ def test_batch_datasets(mock_client, mock_publish):
                 # active feeds
                 for i in range(3):
                     message = json.loads(
-                        mock_publish.call_args_list[i][0][1].decode("utf-8")
+                        mock_publish.call_args_list[i][0][2].decode("utf-8")
                     )
                     assert message["feed_stable_id"] in [
                         feed.stable_id for feed in active_feeds

--- a/functions-python/batch_datasets/tests/test_batch_datasets_main.py
+++ b/functions-python/batch_datasets/tests/test_batch_datasets_main.py
@@ -35,7 +35,8 @@ def test_get_active_feeds():
     {"FEEDS_DATABASE_URL": default_db_url, "FEEDS_PUBSUB_TOPIC_NAME": "test_topic"},
 )
 @patch("batch_datasets.src.main.publish")
-def test_batch_datasets(mock_publish):
+@patch("google.cloud.pubsub_v1.PublisherClient")
+def test_batch_datasets(mock_client, mock_publish):
     with get_testing_session() as session:
         active_feeds = get_active_feeds(session)
         with patch(


### PR DESCRIPTION
**Summary:**

The GCP pub-sub global variable was loaded before mocks were applied. This enforced GCP credentials set and blocks external contributors from running tests on the local environment and forks. This PR remove the GCP credentials dependency by making the pub-sub client scoped to the main python function.

**Expected behavior:** 

GCP credentials dependency is removed from local environment and GH forks.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
