### PR TITLE
feat: add email verification workflow in the UI 

### DIFF
--- a/web-app/src/app/constants/Navigation.ts
+++ b/web-app/src/app/constants/Navigation.ts
@@ -3,6 +3,7 @@ import type NavigationItem from '../interface/Navigation';
 export const SIGN_OUT_TARGET = '/sign-out';
 export const SIGN_IN_TARGET = '/sign-in';
 export const ACCOUNT_TARGET = '/account';
+export const POST_REGISTRATION_TARGET = '/verify-email';
 export const COMPLETE_REGISTRATION_TARGET = '/complete-registration';
 
 export const MOBILITY_DATA_LINKS = {

--- a/web-app/src/app/router/ProtectedRoute.tsx
+++ b/web-app/src/app/router/ProtectedRoute.tsx
@@ -1,23 +1,30 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { selectIsAuthenticated } from '../store/selectors';
+import { selectUserProfileStatus } from '../store/selectors';
 import { useEffect } from 'react';
 import { app } from '../../firebase';
 import { useAppDispatch } from '../hooks';
 import { refreshApp, refreshAppSuccess } from '../store/profile-reducer';
 
 /**
- * This component is used to protect routes that require authentication.
+ * Guards routes based on user profile status. Redirects to a specified route if status doesn't match `targetStatus` (default: 'registered').
+ * Redirect route is configurable via the `redirect` prop (default: '/sign-in').
  */
-export const ProtectedRoute = (): JSX.Element => {
-  const isAuthenticated = useSelector(selectIsAuthenticated);
+export const ProtectedRoute = ({
+  targetStatus = 'registered',
+  redirect = '/sign-in',
+}: {
+  targetStatus?: string;
+  redirect?: string;
+}): JSX.Element => {
+  const userProfileStatus = useSelector(selectUserProfileStatus);
   useEffect(() => {
     app.auth();
   });
   const dispatch = useAppDispatch();
 
-  if (!isAuthenticated) {
-    return <Navigate to='/' />;
+  if (userProfileStatus !== targetStatus) {
+    return <Navigate to={redirect} />;
   }
 
   app.auth().onAuthStateChanged((user) => {

--- a/web-app/src/app/router/Router.tsx
+++ b/web-app/src/app/router/Router.tsx
@@ -12,6 +12,7 @@ import ForgotPassword from '../screens/ForgotPassword';
 import FAQ from '../screens/FAQ';
 import About from '../screens/About';
 import Contribute from '../screens/Contribute';
+import PostRegistration from '../screens/PostRegistration';
 
 export const AppRouter: React.FC = () => {
   return (
@@ -19,7 +20,7 @@ export const AppRouter: React.FC = () => {
       <Route path='/' element={<Home />} />
       <Route path='sign-in' element={<SignIn />} />
       <Route path='sign-up' element={<SignUp />} />
-      <Route element={<ProtectedRoute />}>
+      <Route element={<ProtectedRoute targetStatus='authenticated' />}>
         <Route
           path='complete-registration'
           element={<CompleteRegistration />}
@@ -31,6 +32,9 @@ export const AppRouter: React.FC = () => {
       <Route path='contact-info' element={<ContactInformation />} />
       <Route element={<ProtectedRoute />}>
         <Route path='change-password' element={<ChangePassword />} />
+      </Route>
+      <Route element={<ProtectedRoute targetStatus='unverified' />}>
+        <Route path='verify-email' element={<PostRegistration />} />
       </Route>
       <Route path='forgot-password' element={<ForgotPassword />} />
       <Route path='faq' element={<FAQ />} />

--- a/web-app/src/app/screens/PostRegistration.tsx
+++ b/web-app/src/app/screens/PostRegistration.tsx
@@ -3,19 +3,26 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import { EmailOutlined, Sync } from '@mui/icons-material';
+import { EmailOutlined, InfoOutlined, Sync } from '@mui/icons-material';
 import { Alert, Button } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
-import { verifyEmail } from '../store/profile-reducer';
+import { emailVerified, verifyEmail } from '../store/profile-reducer';
 import {
   selectEmailVerificationError,
   selectIsVerificationEmailSent,
+  selectUserProfileStatus,
 } from '../store/profile-selectors';
 import { type AppError } from '../types';
+import { app } from '../../firebase';
+import { useEffect } from 'react';
+import { ACCOUNT_TARGET } from '../constants/Navigation';
+import { useNavigate } from 'react-router-dom';
 export default function PostRegistration(): React.ReactElement {
   const dispatch = useDispatch();
+  const navigateTo = useNavigate();
   const selectResendEmailSuccess = useSelector(selectIsVerificationEmailSent);
   const selectResendEmailError = useSelector(selectEmailVerificationError);
+  const userProfileStatus = useSelector(selectUserProfileStatus);
   const [resendEmailSuccess, setResendEmailSuccess] = React.useState(false);
   const [resendEmailError, setResendEmailError] =
     React.useState<AppError | null>(null);
@@ -25,6 +32,35 @@ export default function PostRegistration(): React.ReactElement {
   React.useEffect(() => {
     setResendEmailError(selectResendEmailError ?? null);
   }, [selectResendEmailError]);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      void app
+        .auth()
+        .currentUser?.reload()
+        .then(() => {
+          const currentUser = app.auth().currentUser;
+
+          if (currentUser !== null && currentUser.emailVerified) {
+            dispatch(emailVerified());
+            clearInterval(intervalId);
+          }
+        });
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (
+      userProfileStatus === 'registered' ||
+      userProfileStatus === 'authenticated'
+    ) {
+      navigateTo(ACCOUNT_TARGET);
+    }
+  }, []);
 
   return (
     <Container component='main' maxWidth='sm'>
@@ -52,8 +88,8 @@ export default function PostRegistration(): React.ReactElement {
           Thank you for registering for an API Account on the Mobility Database.
         </Typography>
         <Box sx={{ mt: 2 }}>
-          An email will be sent to you shortly confirming your account
-          registration.
+          An email has been sent or will be sent to you shortly confirming your
+          account registration.
         </Box>
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
           <Button
@@ -74,6 +110,11 @@ export default function PostRegistration(): React.ReactElement {
           {resendEmailError !== null ? (
             <Alert severity='error'>{resendEmailError?.message}</Alert>
           ) : null}
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <InfoOutlined sx={{ verticalAlign: 'middle' }} /> You will be
+          automatically redirected to your account page once your email is
+          verified.
         </Box>
       </Box>
     </Container>

--- a/web-app/src/app/screens/PostRegistration.tsx
+++ b/web-app/src/app/screens/PostRegistration.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { EmailOutlined, Sync } from '@mui/icons-material';
+import { Alert, Button } from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { verifyEmail } from '../store/profile-reducer';
+import {
+  selectEmailVerificationError,
+  selectIsVerificationEmailSent,
+} from '../store/profile-selectors';
+import { type AppError } from '../types';
+export default function PostRegistration(): React.ReactElement {
+  const dispatch = useDispatch();
+  const selectResendEmailSuccess = useSelector(selectIsVerificationEmailSent);
+  const selectResendEmailError = useSelector(selectEmailVerificationError);
+  const [resendEmailSuccess, setResendEmailSuccess] = React.useState(false);
+  const [resendEmailError, setResendEmailError] =
+    React.useState<AppError | null>(null);
+  React.useEffect(() => {
+    setResendEmailSuccess(selectResendEmailSuccess);
+  }, [selectResendEmailSuccess]);
+  React.useEffect(() => {
+    setResendEmailError(selectResendEmailError ?? null);
+  }, [selectResendEmailError]);
+
+  return (
+    <Container component='main' maxWidth='sm'>
+      <CssBaseline />
+      <Box
+        sx={{
+          mt: 12,
+          ml: 2,
+          mr: 2,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography
+          component='h1'
+          variant='h5'
+          color='primary'
+          fontWeight='bold'
+          sx={{ display: 'flex', alignItems: 'center' }}
+        >
+          <EmailOutlined sx={{ mr: 1 }} />
+          <div>Check your email !</div>
+        </Typography>
+        <Typography color='primary'>
+          Thank you for registering for an API Account on the Mobility Database.
+        </Typography>
+        <Box sx={{ mt: 2 }}>
+          An email will be sent to you shortly confirming your account
+          registration.
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          <Button
+            variant='contained'
+            color='primary'
+            startIcon={<Sync />}
+            onClick={() => {
+              dispatch(verifyEmail());
+            }}
+          >
+            Resend Email
+          </Button>
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          {resendEmailSuccess ? (
+            <Alert severity='success'>Email sent successfully</Alert>
+          ) : null}
+          {resendEmailError !== null ? (
+            <Alert severity='error'>{resendEmailError?.message}</Alert>
+          ) : null}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/web-app/src/app/screens/PostRegistration.tsx
+++ b/web-app/src/app/screens/PostRegistration.tsx
@@ -46,7 +46,7 @@ export default function PostRegistration(): React.ReactElement {
             clearInterval(intervalId);
           }
         });
-    }, 1000);
+    }, 5000);
 
     return () => {
       clearInterval(intervalId);

--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -30,6 +30,7 @@ import { getAuth, signInWithPopup, type UserCredential } from 'firebase/auth';
 import {
   ACCOUNT_TARGET,
   COMPLETE_REGISTRATION_TARGET,
+  POST_REGISTRATION_TARGET,
 } from '../constants/Navigation';
 import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
 
@@ -77,6 +78,9 @@ export default function SignIn(): React.ReactElement {
     }
     if (userProfileStatus === 'authenticated') {
       navigateTo(COMPLETE_REGISTRATION_TARGET);
+    }
+    if (userProfileStatus === 'unverified') {
+      navigateTo(POST_REGISTRATION_TARGET);
     }
   }, [userProfileStatus]);
 

--- a/web-app/src/app/screens/SignUp.tsx
+++ b/web-app/src/app/screens/SignUp.tsx
@@ -20,6 +20,7 @@ import { useSelector } from 'react-redux';
 import {
   ACCOUNT_TARGET,
   COMPLETE_REGISTRATION_TARGET,
+  POST_REGISTRATION_TARGET,
   SIGN_IN_TARGET,
 } from '../constants/Navigation';
 import '../styles/SignUp.css';
@@ -82,8 +83,6 @@ export default function SignUp(): React.ReactElement {
         signUp({
           email: values.email,
           password: values.password,
-          redirectScreen: ACCOUNT_TARGET,
-          navigateTo,
         }),
       );
     },
@@ -95,6 +94,9 @@ export default function SignUp(): React.ReactElement {
     }
     if (userProfileStatus === 'authenticated') {
       navigateTo(COMPLETE_REGISTRATION_TARGET);
+    }
+    if (userProfileStatus === 'unverified') {
+      navigateTo(POST_REGISTRATION_TARGET);
     }
   }, [userProfileStatus]);
 

--- a/web-app/src/app/services/profile-service.ts
+++ b/web-app/src/app/services/profile-service.ts
@@ -5,7 +5,6 @@ import { getFunctions, httpsCallable } from 'firebase/functions';
 
 /**
  * Send an email verification to the current user.
- * This function does nothing if the user is not logged in or if the email is already verified.
  */
 export const sendEmailVerification = async (): Promise<void> => {
   const user = app.auth().currentUser;

--- a/web-app/src/app/services/profile-service.ts
+++ b/web-app/src/app/services/profile-service.ts
@@ -8,15 +8,9 @@ import { getFunctions, httpsCallable } from 'firebase/functions';
  * This function does nothing if the user is not logged in or if the email is already verified.
  */
 export const sendEmailVerification = async (): Promise<void> => {
-  try {
-    const user = app.auth().currentUser;
-    if (user !== null && !user.emailVerified) {
-      await user.sendEmailVerification();
-    }
-  } catch (error) {
-    // Nothing to do if the email verification fails
-    // eslint-disable-next-line no-console
-    console.log(error);
+  const user = app.auth().currentUser;
+  if (user !== null && !user.emailVerified) {
+    await user.sendEmailVerification();
   }
 };
 
@@ -33,6 +27,7 @@ export const getUserFromSession = async (): Promise<User | null> => {
     fullName: currentUser?.displayName ?? undefined,
     email: currentUser?.email ?? '',
     isRegistered: false,
+    isEmailVerified: currentUser?.emailVerified ?? false,
     // Organization cannot be retrieved from the current user
     organization: undefined,
     isRegisteredToReceiveAPIAnnouncements: false,

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -14,6 +14,7 @@ interface UserProfileState {
     | 'unauthenticated'
     | 'login_in'
     | 'authenticated'
+    | 'unverified'
     | 'login_out'
     | 'sign_up'
     | 'loading_organization'
@@ -22,6 +23,7 @@ interface UserProfileState {
   isRefreshingAccessToken: boolean;
   isAppRefreshing: boolean;
   isRecoveryEmailSent: boolean;
+  isVerificationEmailSent: boolean;
   errors: AppErrors;
   user: User | undefined;
   changePasswordStatus: 'idle' | 'loading' | 'success' | 'fail';
@@ -39,8 +41,10 @@ const initialState: UserProfileState = {
     ChangePassword: null,
     Registration: null,
     ResetPassword: null,
+    VerifyEmail: null,
   },
   isRefreshingAccessToken: false,
+  isVerificationEmailSent: false,
   isAppRefreshing: false,
   changePasswordStatus: 'idle',
   isSignedInWithProvider: false,
@@ -54,24 +58,22 @@ export const userProfileSlice = createSlice({
     login: (state, action: PayloadAction<EmailLogin>) => {
       state.status = 'login_in';
       state.errors = { ...initialState.errors };
+      state.isAppRefreshing = true;
     },
     loginSuccess: (state, action: PayloadAction<User>) => {
       state.status = action.payload?.isRegistered
         ? 'registered'
-        : 'authenticated';
+        : action.payload?.isEmailVerified
+          ? 'authenticated'
+          : 'unverified';
       state.errors = { ...initialState.errors };
       state.user = action.payload;
-    },
-    authenticated: (state, action: PayloadAction<User>) => {
-      state.status = action.payload?.isRegistered
-        ? 'registered'
-        : 'authenticated';
-      state.errors = { ...initialState.errors };
-      state.user = action.payload;
+      state.isAppRefreshing = false;
     },
     loginFail: (state, action: PayloadAction<AppError>) => {
       state.errors = { ...initialState.errors, Login: action.payload };
       state.status = 'unauthenticated';
+      state.isAppRefreshing = false;
     },
     logout: (
       state,
@@ -82,36 +84,40 @@ export const userProfileSlice = createSlice({
     ) => {
       state.status = 'login_out';
       state.errors = { ...initialState.errors };
+      state.isAppRefreshing = true;
     },
     logoutSuccess: (state) => {
       state.status = 'unauthenticated';
       state.isSignedInWithProvider = false;
+      state.isAppRefreshing = false;
     },
     logoutFail: (state) => {
       state.status = 'unauthenticated';
+      state.isAppRefreshing = false;
     },
     signUp: (
       state,
       action: PayloadAction<{
         email: string;
         password: string;
-        redirectScreen: string;
-        navigateTo: NavigateFunction;
       }>,
     ) => {
       state.status = 'sign_up';
       state.errors = { ...initialState.errors };
+      state.isAppRefreshing = true;
     },
     signUpSuccess: (state, action: PayloadAction<User>) => {
-      state.status = state.status = action.payload?.isRegistered
-        ? 'registered'
-        : 'authenticated';
+      state.status = state.status = action.payload?.isEmailVerified
+        ? 'authenticated'
+        : 'unverified';
       state.user = action.payload;
       state.errors = { ...initialState.errors };
+      state.isAppRefreshing = false;
     },
     signUpFail: (state, action: PayloadAction<AppError>) => {
       state.status = 'unauthenticated';
       state.errors = { ...initialState.errors, SignUp: action.payload };
+      state.isAppRefreshing = false;
     },
     resetProfileErrors: (state) => {
       state.errors = { ...initialState.errors };
@@ -216,6 +222,21 @@ export const userProfileSlice = createSlice({
       state.errors.ResetPassword = null;
       state.isAppRefreshing = false;
     },
+    verifyEmail: (state) => {
+      state.isAppRefreshing = true;
+      state.isVerificationEmailSent = false;
+      state.errors = { ...initialState.errors };
+    },
+    verifySuccess: (state) => {
+      state.isAppRefreshing = false;
+      state.isVerificationEmailSent = true;
+      state.errors = { ...initialState.errors };
+    },
+    verifyFail: (state, action: PayloadAction<AppError>) => {
+      state.errors.VerifyEmail = action.payload;
+      state.isAppRefreshing = false;
+      state.isVerificationEmailSent = false;
+    },
   },
 });
 
@@ -246,6 +267,9 @@ export const {
   resetPassword,
   resetPasswordFail,
   resetPasswordSuccess,
+  verifyEmail,
+  verifySuccess,
+  verifyFail,
 } = userProfileSlice.actions;
 
 export default userProfileSlice.reducer;

--- a/web-app/src/app/store/profile-reducer.ts
+++ b/web-app/src/app/store/profile-reducer.ts
@@ -237,6 +237,14 @@ export const userProfileSlice = createSlice({
       state.isAppRefreshing = false;
       state.isVerificationEmailSent = false;
     },
+    emailVerified: (state) => {
+      if (state.user !== undefined) {
+        state.user.isEmailVerified = true;
+        state.status = state.user.isRegistered ? 'registered' : 'authenticated';
+        state.errors = { ...initialState.errors };
+      }
+      state.isAppRefreshing = false;
+    },
   },
 });
 
@@ -270,6 +278,7 @@ export const {
   verifyEmail,
   verifySuccess,
   verifyFail,
+  emailVerified,
 } = userProfileSlice.actions;
 
 export default userProfileSlice.reducer;

--- a/web-app/src/app/store/profile-selectors.ts
+++ b/web-app/src/app/store/profile-selectors.ts
@@ -6,7 +6,8 @@ export const selectUserProfile = (state: RootState): User | undefined =>
 
 export const selectIsAuthenticated = (state: RootState): boolean =>
   state.userProfile.status === 'authenticated' ||
-  state.userProfile.status === 'registered';
+  state.userProfile.status === 'registered' ||
+  state.userProfile.status === 'unverified';
 
 export const selectUserProfileStatus = (state: RootState): string =>
   state.userProfile.status;
@@ -15,6 +16,9 @@ export const selectIsTokenRefreshed = (state: RootState): boolean =>
   !state.userProfile.isRefreshingAccessToken &&
   state.userProfile.errors.RefreshingAccessToken === null;
 
+export const selectIsVerificationEmailSent = (state: RootState): boolean =>
+  state.userProfile.isVerificationEmailSent;
+
 export const selectErrorBySource = (
   state: RootState,
   source: ErrorSource,
@@ -22,6 +26,10 @@ export const selectErrorBySource = (
 
 export const selectEmailLoginError = (state: RootState): AppError | null =>
   selectErrorBySource(state, ErrorSource.Login);
+
+export const selectEmailVerificationError = (
+  state: RootState,
+): AppError | null => selectErrorBySource(state, ErrorSource.VerifyEmail);
 
 export const selectResetPasswordError = (state: RootState): AppError | null =>
   selectErrorBySource(state, ErrorSource.ResetPassword);

--- a/web-app/src/app/types.ts
+++ b/web-app/src/app/types.ts
@@ -20,6 +20,7 @@ export interface User {
   refreshToken?: string;
   isRegistered: boolean;
   isRegisteredToReceiveAPIAnnouncements: boolean;
+  isEmailVerified: boolean;
 }
 
 export interface UserData {
@@ -36,8 +37,7 @@ export const USER_PROFILE_LOGIN_FAIL = `${USER_PROFILE}/loginFail`;
 export const USER_PROFILE_LOGOUT = `${USER_PROFILE}/logout`;
 export const USER_PROFILE_LOGOUT_SUCCESS = `${USER_PROFILE}/logoutSuccess`;
 export const USER_PROFILE_SIGNUP = `${USER_PROFILE}/signUp`;
-export const USER_PROFILE_SIGNUP_SUCCESS = `${USER_PROFILE}/signUpSuccess`;
-export const USER_PROFILE_SIGNUP_FAIL = `${USER_PROFILE}/signUpFail`;
+export const USER_PROFILE_SEND_VERIFICATION_EMAIL = `${USER_PROFILE}/verifyEmail`;
 export const USER_REQUEST_REFRESH_ACCESS_TOKEN = `${USER_PROFILE}/requestRefreshAccessToken`;
 export const USER_PROFILE_LOAD_ORGANIZATION_FAIL = `${USER_PROFILE}/loadOrganizationFail`;
 export const USER_PROFILE_LOGIN_WITH_PROVIDER = `${USER_PROFILE}/loginWithProvider`;
@@ -53,6 +53,7 @@ export enum ErrorSource {
   ChangePassword = 'ChangePassword',
   Registration = 'Registration',
   ResetPassword = 'ResetPassword',
+  VerifyEmail = 'VerifyEmail',
 }
 
 export interface AppError {


### PR DESCRIPTION
**Summary:**
Adding the email verification to the UI.
Closes #177 

**Expected behavior:** 

For users that sign up using the email and password method, they are locked out of using their account until email verification is complete. Users are redirected to the `verify-account` page where they can resend the email.

![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/cb7220d0-7a6a-49d8-bce0-4b3848f15a45)

**Testing tips:**
- Create a new account using email and password --> You should be redirected to `/verify-account` if the creation is successful 
- Click on `Resend Email` to validate that you receive a new email --> You should see a success message (see image bellow)
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/fe50f61a-d54a-4b16-809a-a9ca0bcb669d)- Disable your internet connection while on the page and click `Resend Email` --> You should see an error message (see image bellow) 
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/8785ebb1-128a-4dbc-88e5-3a0caf800722)

- Validate your account from your email --> Within a second you should be automatically redirected to the account page

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
