### PR TITLE
fix: unit tests failing due to local connection issues

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,9 +30,26 @@ jobs:
           python-version: ${{ env.python_version }}
 
       - name: Docker Compose DB/Liquibase for db-gen.sh
-        run: docker-compose --env-file ./config/.env.local up -d liquibase
+        run: docker-compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
 
+      - name: Run Liquibase
+        run: |    
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+      
+          sudo apt-get update
+          sudo apt-get install liquibase
+      
+          export LIQUIBASE_CLASSPATH="liquibase"
+          export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:5432/MobilityDatabase
+          export LIQUIBASE_COMMAND_USERNAME=postgres
+          export LIQUIBASE_COMMAND_PASSWORD=postgres
+          export LIQUIBASE_LOG_LEVEL=FINE
+      
+          liquibase update
       - name: Generate DB code
         run: |
           scripts/db-gen.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,15 +39,17 @@ jobs:
           sudo apt-get install liquibase
 
       - name: Docker Compose DB
-        run: docker-compose --env-file ./config/.env.local up -d postgres postgres-test
+        run: |
+          docker-compose --env-file ./config/.env.local up -d postgres postgres-test
+          sleep 10 # Wait for the containers to start
         working-directory: ${{ github.workspace }}
 
 #      Uncomment the following block to test the database connection through the tunnel
-      - name: Test Database Connection
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-client
-          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
-          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
+#      - name: Test Database Connection
+#        run: |
+#          sudo apt-get update && sudo apt-get install -y postgresql-client
+#          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
+#          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
 
       - name: Run Liquibase on Python functions test DB
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install liquibase
 
-#      Uncomment the following block to test the databases
+#      Uncomment the following block to test the loca databases connections
 #      - name: Test Database Connection
 #        run: |
 #          sudo apt-get update && sudo apt-get install -y postgresql-client
@@ -74,15 +74,6 @@ jobs:
           export LIQUIBASE_LOG_LEVEL=FINE
       
           liquibase update
-
-#      - name: Install Liquibase
-#        run: |
-#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-#
-#          sudo apt-get update
-#          sudo apt-get install liquibase
 
       - name: Generate DB code
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,9 +29,17 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
+      - name: Install Liquibase
+        run: |    
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+      
+          sudo apt-get update
+          sudo apt-get install liquibase
 
       - name: Docker Compose DB for python function tests
-        run: docker-compose --env-file ./config/.env.local up -d postgres-test
+        run: docker-compose --env-file ./config/.env.local up -d postgres postgres-test
         working-directory: ${{ github.workspace }}
 
       - name: Test Database Connection Through Tunnel
@@ -53,14 +61,14 @@ jobs:
         run: docker-compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
 
-      - name: Install Liquibase
-        run: |    
-          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-      
-          sudo apt-get update
-          sudo apt-get install liquibase
+#      - name: Install Liquibase
+#        run: |
+#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+#
+#          sudo apt-get update
+#          sudo apt-get install liquibase
 
       - name: Run Liquibase on API test DB
         run: |      

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install liquibase
 
-#      Uncomment the following block to test the database connection through the tunnel
+#      Uncomment the following block to test the databases
 #      - name: Test Database Connection
 #        run: |
 #          sudo apt-get update && sudo apt-get install -y postgresql-client

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,11 +43,11 @@ jobs:
         working-directory: ${{ github.workspace }}
 
 #      Uncomment the following block to test the database connection through the tunnel
-#      - name: Test Database Connection
-#        run: |
-#          sudo apt-get update && sudo apt-get install -y postgresql-client
-#          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
-#          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
+      - name: Test Database Connection
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-client
+          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
+          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
 
       - name: Run Liquibase on Python functions test DB
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,11 +29,11 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Docker Compose DB/Liquibase for db-gen.sh
+      - name: Docker Compose DB for db-gen.sh
         run: docker-compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
 
-      - name: Run Liquibase
+      - name: Install Liquibase
         run: |    
           wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
           cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
@@ -41,7 +41,9 @@ jobs:
       
           sudo apt-get update
           sudo apt-get install liquibase
-      
+
+      - name: Run Liquibase on API test DB
+        run: |      
           export LIQUIBASE_CLASSPATH="liquibase"
           export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
           export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:5432/MobilityDatabase
@@ -50,14 +52,11 @@ jobs:
           export LIQUIBASE_LOG_LEVEL=FINE
       
           liquibase update
+
       - name: Generate DB code
         run: |
           scripts/db-gen.sh
 
-      - name: Docker Compose DB/Liquibase for unit tests
-        run: docker-compose --env-file ./config/.env.local up -d liquibase-test
-        working-directory: ${{ github.workspace }}
-            
       - name: Generate API code
         run: |
           scripts/setup-openapi-generator.sh
@@ -72,6 +71,21 @@ jobs:
         shell: bash
         run: |
           scripts/api-tests.sh --folder api --html_report
+
+      - name: Docker Compose DB for python function tests
+        run: docker-compose --env-file ./config/.env.local up -d postgres-test
+        working-directory: ${{ github.workspace }}
+
+      - name: Run Liquibase on API test DB
+        run: |
+          export LIQUIBASE_CLASSPATH="liquibase"
+          export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabase
+          export LIQUIBASE_COMMAND_USERNAME=postgres
+          export LIQUIBASE_COMMAND_PASSWORD=postgres
+          export LIQUIBASE_LOG_LEVEL=FINE
+      
+          liquibase update
 
       - name: Unit tests - Python Functions
         shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,26 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
+
+      - name: Docker Compose DB for python function tests
+        run: docker-compose --env-file ./config/.env.local up -d postgres-test
+        working-directory: ${{ github.workspace }}
+
+      - name: Test Database Connection Through Tunnel
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-client
+          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
+
+      - name: Run Liquibase on Python functions test DB
+        run: |
+          export LIQUIBASE_CLASSPATH="liquibase"
+          export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabaseTest
+          export LIQUIBASE_COMMAND_USERNAME=postgres
+          export LIQUIBASE_COMMAND_PASSWORD=postgres
+          liquibase update
+
+
       - name: Docker Compose DB for db-gen.sh
         run: docker-compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
@@ -76,6 +96,11 @@ jobs:
         run: docker-compose --env-file ./config/.env.local up -d postgres-test
         working-directory: ${{ github.workspace }}
 
+      - name: Test Database Connection Through Tunnel
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-client
+          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
+
       - name: Run Liquibase on Python functions test DB
         run: |
           export LIQUIBASE_CLASSPATH="liquibase"
@@ -83,9 +108,9 @@ jobs:
           export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabaseTest
           export LIQUIBASE_COMMAND_USERNAME=postgres
           export LIQUIBASE_COMMAND_PASSWORD=postgres
-          export LIQUIBASE_LOG_LEVEL=FINE
-      
           liquibase update
+      
+          export LIQUIBASE_LOG_LEVEL=FINE
 
       - name: Unit tests - Python Functions
         shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,11 +76,11 @@ jobs:
         run: docker-compose --env-file ./config/.env.local up -d postgres-test
         working-directory: ${{ github.workspace }}
 
-      - name: Run Liquibase on API test DB
+      - name: Run Liquibase on Python functions test DB
         run: |
           export LIQUIBASE_CLASSPATH="liquibase"
           export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
-          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabase
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabaseTest
           export LIQUIBASE_COMMAND_USERNAME=postgres
           export LIQUIBASE_COMMAND_PASSWORD=postgres
           export LIQUIBASE_LOG_LEVEL=FINE

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,16 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
+      - name: Docker Compose DB
+        run: |
+          docker-compose --env-file ./config/.env.local up -d postgres postgres-test
+        working-directory: ${{ github.workspace }}
+
+      - name: Run lint checks
+        shell: bash
+        run: |
+          scripts/lint-tests.sh
+
       - name: Install Liquibase
         run: |    
           wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
@@ -37,12 +47,6 @@ jobs:
       
           sudo apt-get update
           sudo apt-get install liquibase
-
-      - name: Docker Compose DB
-        run: |
-          docker-compose --env-file ./config/.env.local up -d postgres postgres-test
-          sleep 10 # Wait for the containers to start
-        working-directory: ${{ github.workspace }}
 
 #      Uncomment the following block to test the database connection through the tunnel
 #      - name: Test Database Connection
@@ -88,11 +92,6 @@ jobs:
         run: |
           scripts/setup-openapi-generator.sh
           scripts/api-gen.sh
-
-      - name: Run lint checks
-        shell: bash
-        run: |
-          scripts/lint-tests.sh
 
       - name: Unit tests - API
         shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,14 +38,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install liquibase
 
-      - name: Docker Compose DB for python function tests
+      - name: Docker Compose DB
         run: docker-compose --env-file ./config/.env.local up -d postgres postgres-test
         working-directory: ${{ github.workspace }}
 
-      - name: Test Database Connection Through Tunnel
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-client
-          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
+#      Uncomment the following block to test the database connection through the tunnel
+#      - name: Test Database Connection
+#        run: |
+#          sudo apt-get update && sudo apt-get install -y postgresql-client
+#          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
+#          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
 
       - name: Run Liquibase on Python functions test DB
         run: |
@@ -55,20 +57,6 @@ jobs:
           export LIQUIBASE_COMMAND_USERNAME=postgres
           export LIQUIBASE_COMMAND_PASSWORD=postgres
           liquibase update
-
-
-      - name: Docker Compose DB for db-gen.sh
-        run: docker-compose --env-file ./config/.env.local up -d postgres
-        working-directory: ${{ github.workspace }}
-
-#      - name: Install Liquibase
-#        run: |
-#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-#
-#          sudo apt-get update
-#          sudo apt-get install liquibase
 
       - name: Run Liquibase on API test DB
         run: |      
@@ -80,6 +68,15 @@ jobs:
           export LIQUIBASE_LOG_LEVEL=FINE
       
           liquibase update
+
+#      - name: Install Liquibase
+#        run: |
+#          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+#          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+#          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+#
+#          sudo apt-get update
+#          sudo apt-get install liquibase
 
       - name: Generate DB code
         run: |
@@ -99,26 +96,6 @@ jobs:
         shell: bash
         run: |
           scripts/api-tests.sh --folder api --html_report
-
-      - name: Docker Compose DB for python function tests
-        run: docker-compose --env-file ./config/.env.local up -d postgres-test
-        working-directory: ${{ github.workspace }}
-
-      - name: Test Database Connection Through Tunnel
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-client
-          PGPASSWORD=postgres psql -h localhost -p 54320 -U postgres -d MobilityDatabaseTest -c "SELECT version();"
-
-      - name: Run Liquibase on Python functions test DB
-        run: |
-          export LIQUIBASE_CLASSPATH="liquibase"
-          export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
-          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabaseTest
-          export LIQUIBASE_COMMAND_USERNAME=postgres
-          export LIQUIBASE_COMMAND_PASSWORD=postgres
-          liquibase update
-      
-          export LIQUIBASE_LOG_LEVEL=FINE
 
       - name: Unit tests - Python Functions
         shell: bash

--- a/scripts/db-gen.sh
+++ b/scripts/db-gen.sh
@@ -21,8 +21,7 @@ ENV_PATH=$SCRIPT_PATH/../config/.env.local
 source "$ENV_PATH"
 rm -rf "$SCRIPT_PATH/../api/src/database_gen/"
 mkdir "$SCRIPT_PATH/../api/src/database_gen/"
-pip3 install -r "${SCRIPT_PATH}/../api/requirements.txt"
-#> /dev/null
+pip3 install -r "${SCRIPT_PATH}/../api/requirements.txt" > /dev/null
 
 # removing sqlacodegen.log file
 if [ -s ${SCRIPT_PATH}/sqlacodegen.log ]
@@ -34,7 +33,10 @@ echo "Generating SQLAlchemy models using sqlacodegen..."
 # Running sqlacodegen and capturing errors and warnings in the sqlacodegen.log file
 sqlacodegen "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}" --outfile "${OUT_FILE}" &> ${SCRIPT_PATH}/sqlacodegen.log
 echo "Completed SQLAlchemy models generation"
+
+printf "/n--- Generated models ---/n"
 cat ${OUT_FILE}
+echo "/n---End of generated models ---/n"
 
 rm -rf "${COPY_TO_PATH}"
 mkdir -p "${COPY_TO_PATH}"

--- a/scripts/db-gen.sh
+++ b/scripts/db-gen.sh
@@ -21,7 +21,8 @@ ENV_PATH=$SCRIPT_PATH/../config/.env.local
 source "$ENV_PATH"
 rm -rf "$SCRIPT_PATH/../api/src/database_gen/"
 mkdir "$SCRIPT_PATH/../api/src/database_gen/"
-pip3 install -r "${SCRIPT_PATH}/../api/requirements.txt" > /dev/null
+pip3 install -r "${SCRIPT_PATH}/../api/requirements.txt"
+#> /dev/null
 
 # removing sqlacodegen.log file
 if [ -s ${SCRIPT_PATH}/sqlacodegen.log ]
@@ -29,8 +30,12 @@ then
   rm ${SCRIPT_PATH}/sqlacodegen.log
 fi
 
+echo "Generating SQLAlchemy models using sqlacodegen..."
 # Running sqlacodegen and capturing errors and warnings in the sqlacodegen.log file
 sqlacodegen "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}" --outfile "${OUT_FILE}" &> ${SCRIPT_PATH}/sqlacodegen.log
+echo "Completed SQLAlchemy models generation"
+cat ${OUT_FILE}
+
 rm -rf "${COPY_TO_PATH}"
 mkdir -p "${COPY_TO_PATH}"
 cp "${OUT_FILE}" "${COPY_TO_PATH}"


### PR DESCRIPTION
# Summary:

`Build & Test` workflow started to fail with no code changes related to the workflow, [failing example](https://github.com/MobilityData/mobility-feed-api/actions/runs/7849817029/job/21423960180?pr=275).  I found multiple causes. The main issue is related to failures of the Liquibase container service at the starting time. This failure has been registered sporadically in local machines but, starting from today, is constantly reproduced at GitHub actions. The second issue found was a race condition between Liquibase and the testing database's healthy state.

# The fix:
- Replace the Liquibase service container with a locally installed package at Github actions.
- Reorder steps to allow enough time between docker-compose and Liquibase execution


Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).

**Testing tips:**

`Build & Test` should be green consistently on PRs.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
