### PR TITLE
fix: liquibase docker failing on db gen steps

### DIFF
--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -225,6 +225,10 @@ jobs:
           name: feeds_gen
           path: api/src/feeds_gen/
 
+      - name: Build python functions
+        run: |
+          scripts/function-python-build.sh --all
+          
       - name: Authenticate to Google Cloud
         id: gcloud_auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -173,18 +173,21 @@ jobs:
           echo "POSTGRES_HOST=localhost" >> config/.env.local
           echo "ENV=dev" >> config/.env.local
 
-      - name: Docker Compose DB/Liquibase for db-gen.sh
-        run: docker-compose --env-file ./config/.env.local up -d liquibase
-        working-directory: ${{ github.workspace }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: database_gen
+          path: api/src/database_gen/
 
-      - name: Generate DB code
+      - name: Copy to db models to functions directory
         run: |
-          scripts/db-gen.sh
+          cp -R api/src/database_gen/ functions-python/ 
+          ls -R api/src/database_gen/
+          ls -R functions-python
 
-      - name: Generate API code
-        run: |
-          scripts/setup-openapi-generator.sh
-          scripts/api-gen.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: feeds_gen
+          path: api/src/feeds_gen/
 
       - name: Set Variables
         run: |

--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Build python functions
         run: |
           scripts/function-python-build.sh --all
-          
+
       - name: Authenticate to Google Cloud
         id: gcloud_auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Copy to db models to functions directory
         run: |
-          cp -R api/src/database_gen/ functions-python/ 
+          cp -R api/src/database_gen/ functions-python/database_gen
 
       - uses: actions/download-artifact@v4
         with:
@@ -218,7 +218,7 @@ jobs:
 
       - name: Copy to db models to functions directory
         run: |
-          cp -R api/src/database_gen/ functions-python/ 
+          cp -R api/src/database_gen/ functions-python/database_gen
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -69,7 +69,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
@@ -126,7 +126,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Persist TF plan
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-artifact-plan.txt
           path: infra/artifact-registry/terraform-plan.txt
@@ -138,7 +138,7 @@ jobs:
     needs: [create-artifact-repo, api-build-test]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
         id: gcloud_auth
@@ -154,7 +154,7 @@ jobs:
           password: ${{ secrets.GCP_MOBILITY_FEEDS_SA_KEY }}
 
       - name: Set up JDK ${{ env.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.java_version }}
           distribution: 'temurin'
@@ -181,8 +181,6 @@ jobs:
       - name: Copy to db models to functions directory
         run: |
           cp -R api/src/database_gen/ functions-python/ 
-          ls -R api/src/database_gen/
-          ls -R functions-python
 
       - uses: actions/download-artifact@v4
         with:
@@ -207,23 +205,25 @@ jobs:
     needs: docker-build-publish
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Docker Compose DB/Liquibase for db-gen.sh
-        run: docker-compose --env-file ./config/.env.local up -d liquibase
-        working-directory: ${{ github.workspace }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: database_gen
+          path: api/src/database_gen/
 
-      - name: Generate DB code
+      - name: Copy to db models to functions directory
         run: |
-          scripts/db-gen.sh
+          cp -R api/src/database_gen/ functions-python/ 
 
-      - name: Build python functions
-        run: |
-          scripts/function-python-build.sh --all
+      - uses: actions/download-artifact@v4
+        with:
+          name: feeds_gen
+          path: api/src/feeds_gen/
 
       - name: Authenticate to Google Cloud
         id: gcloud_auth
@@ -283,7 +283,7 @@ jobs:
           PLAN_OUTPUT: ${{ steps.plan.outputs.stdout }}
 
       - name: Persist TF plan
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-plan.txt
           path: infra/terraform-plan.txt

--- a/.github/workflows/api-deployer.yml
+++ b/.github/workflows/api-deployer.yml
@@ -173,6 +173,7 @@ jobs:
           echo "POSTGRES_HOST=localhost" >> config/.env.local
           echo "ENV=dev" >> config/.env.local
 
+      # db models were generated and uploaded in api-build-test job above.
       - uses: actions/download-artifact@v4
         with:
           name: database_gen
@@ -182,6 +183,7 @@ jobs:
         run: |
           cp -R api/src/database_gen/ functions-python/database_gen
 
+      # api schema was generated and uploaded in api-build-test job above.
       - uses: actions/download-artifact@v4
         with:
           name: feeds_gen
@@ -211,6 +213,7 @@ jobs:
         with:
           python-version: ${{ env.python_version }}
 
+      # db models were generated and uploaded in api-build-test job above.
       - uses: actions/download-artifact@v4
         with:
           name: database_gen
@@ -220,6 +223,7 @@ jobs:
         run: |
           cp -R api/src/database_gen/ functions-python/database_gen
 
+      # api schema was generated and uploaded in api-build-test job above.
       - uses: actions/download-artifact@v4
         with:
           name: feeds_gen

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install liquibase
 
-#      Uncomment the following block to test the loca databases connections
+#      Uncomment the following block to test the local databases connections
 #      - name: Test Database Connection
 #        run: |
 #          sudo apt-get update && sudo apt-get install -y postgresql-client

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,10 +17,10 @@ jobs:
     name: Build & Test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK ${{ env.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.java_version }}
           distribution: 'temurin'
@@ -95,7 +95,19 @@ jobs:
           scripts/api-tests.sh --folder functions-python --html_report
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_report
           path: scripts/coverage_reports/
+
+      - name: Upload DB models
+        uses: actions/upload-artifact@v4
+        with:
+          name: database_gen
+          path: api/src/database_gen/
+
+      - name: API generated code
+        uses: actions/upload-artifact@v4
+        with:
+          name: feeds_gen
+          path: api/src/feeds_gen/

--- a/.github/workflows/datasets-batch-deployer.yml
+++ b/.github/workflows/datasets-batch-deployer.yml
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install liquibase
 
-#      Uncomment the following block to test the loca databases connections
+#      Uncomment the following block to test the local databases connections
 #      - name: Test Database Connection
 #        run: |
 #          sudo apt-get update && sudo apt-get install -y postgresql-client

--- a/.github/workflows/datasets-batch-deployer.yml
+++ b/.github/workflows/datasets-batch-deployer.yml
@@ -75,13 +75,44 @@ jobs:
           scripts/replace-variables.sh -in_file infra/batch/vars.tfvars.rename_me -out_file infra/batch/vars.tfvars -variables REGION,PROJECT_ID,DEPLOYER_SERVICE_ACCOUNT,JOB_SCHEDULE,ENVIRONMENT,DATASETS_BUCKET_NAME
           cat infra/batch/vars.tfvars
 
-      - name: Docker Compose DB/Liquibase for db-gen.sh
-        run: docker-compose --env-file ./config/.env.local up -d liquibase
+      - name: Docker Compose DB
+        run: |
+          docker-compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
+
+      - name: Install Liquibase
+        run: |    
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+      
+          sudo apt-get update
+          sudo apt-get install liquibase
+
+#      Uncomment the following block to test the loca databases connections
+#      - name: Test Database Connection
+#        run: |
+#          sudo apt-get update && sudo apt-get install -y postgresql-client
+#          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
+
+      - name: Run Liquibase on Python functions test DB
+        run: |
+          export LIQUIBASE_CLASSPATH="liquibase"
+          export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabase
+          export LIQUIBASE_COMMAND_USERNAME=postgres
+          export LIQUIBASE_COMMAND_PASSWORD=postgres
+          liquibase update
   
       - name: Generate DB code
         run: |
           scripts/db-gen.sh
+
+      - name: Upload DB models
+        uses: actions/upload-artifact@v4
+        with:
+          name: database_gen
+          path: functions-python/database_gen/
 
       - name: Build python functions
         run: |

--- a/.github/workflows/datasets-batch-deployer.yml
+++ b/.github/workflows/datasets-batch-deployer.yml
@@ -95,11 +95,11 @@ jobs:
 #          sudo apt-get update && sudo apt-get install -y postgresql-client
 #          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d MobilityDatabase -c "SELECT version();"
 
-      - name: Run Liquibase on Python functions test DB
+      - name: Run Liquibase on Python functions DB
         run: |
           export LIQUIBASE_CLASSPATH="liquibase"
           export LIQUIBASE_COMMAND_CHANGELOG_FILE="changelog.xml"
-          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:54320/MobilityDatabase
+          export LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:5432/MobilityDatabase
           export LIQUIBASE_COMMAND_USERNAME=postgres
           export LIQUIBASE_COMMAND_PASSWORD=postgres
           liquibase update


### PR DESCRIPTION
**Summary:**

This PR follows #275, replacing the liquibase docker container used in the rest of the workflows.

**Expected behavior:** 
The following workflows work on GitHub:
- Deploy API - {Environment}, [successful execution](https://github.com/MobilityData/mobility-feed-api/actions/runs/7879448919)
- Deploy Historical Batch Processing - {Environment}, [successful execution](https://github.com/MobilityData/mobility-feed-api/actions/runs/7879472405)

Closes #281

**Testing tips:**

Verify the the mentioned GitHub workflows are running successfully.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
