### PR TITLE
fix: transaction open generates 500 server error

### DIFF
--- a/api/src/database/database.py
+++ b/api/src/database/database.py
@@ -151,6 +151,7 @@ class Database:
             return results
         except Exception as e:
             logging.error(f"SELECT query failed with exception: \n{e}")
+            global_session.rollback()
             return None
         finally:
             if update_session:

--- a/api/src/database/database.py
+++ b/api/src/database/database.py
@@ -151,7 +151,8 @@ class Database:
             return results
         except Exception as e:
             logging.error(f"SELECT query failed with exception: \n{e}")
-            global_session.rollback()
+            if global_session is not None:
+                global_session.rollback()
             return None
         finally:
             if update_session:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -34,18 +34,18 @@ Ensure your test class is discoverable by adding it to the appropriate module wi
 Use the bash script with necessary arguments to specify the API URL, a refresh token for authentication, and the data file path. An optional argument allows filtering which test classes to execute.
 
 ```bash
-./integration-tests.sh -u <API URL> -t <REFRESH TOKEN> -f <FILE PATH> [-c <CLASS NAMES>]
+export REFRESH_TOKEN="your_refresh_token"
+./integration-tests.sh -u <API URL> -f <FILE PATH> [-c <CLASS NAMES>]
 ```
 
 #### Options
 - `-u` URL of the API to test against
-- `-t` Refresh token for API authentication
 - `-f` File path for the data file to be used in tests
 - `-c` Optional, comma-separated list of test class names to include for targeted testing
 
 ### Example
 ```bash
-./integration-tests.sh -u "http://0.0.0.0:8080" -t "your_refresh_token" -f "/path/to/your/data_file.csv" -c "ClassName1,ClassName2"
+./integration-tests.sh -u "http://0.0.0.0:8080" -f "/path/to/your/data_file.csv" -c "ClassName1,ClassName2"
 ```
 
 This command runs the integration tests against the specified API URL and data file, filtering the tests to only include those from `ClassName1` and `ClassName2`.

--- a/integration-tests/src/endpoints/gtfs_feeds.py
+++ b/integration-tests/src/endpoints/gtfs_feeds.py
@@ -42,139 +42,28 @@ class GTFSFeedsEndpointTests(IntegrationTests):
                 index=f"{i + 1}/{len(country_codes)}",
             )
 
-    def test_filter_by_provider_gtfs(self):
-        """Test GTFS feed retrieval filtered by provider"""
-        providers = self.gtfs_feeds.provider.sample(100).values
-        task_id = self.progress.add_task(
-            "[yellow]Validating GTFS feeds by provider...[/yellow]",
-            total=len(providers),
-        )
-        for i, provider_id in enumerate(providers):
-            self._test_filter_by_provider(
-                provider_id,
-                "v1/gtfs_feeds",
-                task_id=task_id,
-                index=f"{i + 1}/{len(providers)}",
-            )
+    def test_invalid_bb_input_followed_by_valid_request(self):
+        """Tests the API's resilience by first sending invalid input parameters and then a valid request to ensure the
+        error does not affect subsequent requests."""
 
-    def test_filter_by_municipality_gtfs(self):
-        """Test GTFS feed retrieval filter by municipality."""
-        municipalities = self._sample_municipalities(self.gtfs_feeds, 100)
-        task_id = self.progress.add_task(
-            "[yellow]Validating GTFS feeds by municipality...[/yellow]",
-            total=len(municipalities),
-        )
-        for i, municipality in enumerate(municipalities):
-            self._test_filter_by_municipality(
-                municipality,
-                "v1/gtfs_feeds",
-                validate_location=True,
-                task_id=task_id,
-                index=f"{i + 1}/{len(municipalities)}",
-            )
-
-    @staticmethod
-    def _test_order_by_country_code_ascending(response):
-        assert response.status_code == 200, (
-            "Expected 200 status code for GTFS feeds ordered by country code,"
-            " got {response.status_code}."
-        )
-        gtfs_feeds = response.json()
-        assert len(gtfs_feeds) > 1, "Expected more than one GTFS feed for sorting test."
-        prev_country_code = gtfs_feeds[0]["locations"][0]["country_code"]
-        for feed in gtfs_feeds[1:]:
-            current_country_code = feed["locations"][0]["country_code"]
-            assert current_country_code >= prev_country_code, (
-                "Expected GTFS feed country code to be in ascending order, "
-                f"but found '{prev_country_code}' followed by '{current_country_code}'."
-            )
-            prev_country_code = current_country_code
-
-    def test_order_by_country_code_ascending(self):
-        """Test order by country code for GTFS feeds for ascending order."""
+        # Sending a request with invalid bounding box parameters
+        wrong_bounding_lon_lat = "-12,-"
         response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "+country_code"}
+            "v1/gtfs_feeds", params={
+                "dataset_longitudes": wrong_bounding_lon_lat,
+                "dataset_latitudes": wrong_bounding_lon_lat,
+                "bounding_filter_method": "completely_enclosed"
+            }
         )
-        self._test_order_by_country_code_ascending(response)
 
-    def test_order_by_country_code_descending(self):
-        """Test order by country code for GTFS feeds for descending order."""
-        response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "-country_code"}
+        # Expecting an error due to invalid input, but specific status code check is pending implementation
+        assert response.status_code != 200, (
+            f"Expected an error status code for GTFS feeds request with invalid input, got {response.status_code}."
         )
-        assert response.status_code == 200, (
-            "Expected 200 status code for GTFS feeds ordered by country code,"
-            " got {response.status_code}."
-        )
-        gtfs_feeds = response.json()
-        assert len(gtfs_feeds) > 1, "Expected more than one GTFS feed for sorting test."
-        prev_country_code = gtfs_feeds[0]["locations"][0]["country_code"]
-        for feed in gtfs_feeds[1:]:
-            current_country_code = feed["locations"][0]["country_code"]
-            assert current_country_code <= prev_country_code, (
-                "Expected GTFS feed country code to be in descending order, "
-                f"but found '{prev_country_code}' followed by '{current_country_code}'."
-            )
-            prev_country_code = current_country_code
 
-    def test_order_by_country_code_default(self):
-        """Test order by country code for GTFS feeds for default order."""
-        response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "country_code"}
-        )
-        self._test_order_by_country_code_ascending(response)
-
-    @staticmethod
-    def _test_order_by_external_id_ascending(response):
-        assert response.status_code == 200, (
-            "Expected 200 status code for GTFS feeds ordered by external id,"
-            " got {response.status_code}."
-        )
-        gtfs_feeds = response.json()
+        # Sending a subsequent valid request to ensure APIs proper handling of sequences
+        response = self.get_response("v1/gtfs_feeds", params={"limit": 10})
         assert (
-            len(gtfs_feeds) > 1
-        ), "Expected more than one GTFS feed for external id sorting test."
-        prev_external_id = gtfs_feeds[0]["external_ids"][0]["external_id"]
-        for feed in gtfs_feeds[1:]:
-            current_external_id = feed["external_ids"][0]["external_id"]
-            assert current_external_id >= prev_external_id, (
-                "Expected GTFS feed external id to be in ascending order, "
-                f"but found '{prev_external_id}' followed by '{current_external_id}'."
-            )
-            prev_external_id = current_external_id
+                response.status_code == 200
+        ), f"Expected a 200 status code for subsequent valid GTFS feeds request, got {response.status_code}."
 
-    def test_order_by_external_id_ascending(self):
-        """Test order by external id for GTFS feeds for ascending order."""
-        response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "+external_id"}
-        )
-        self._test_order_by_external_id_ascending(response)
-
-    def test_order_by_external_id_default(self):
-        """Test order by external id for GTFS feeds for default order."""
-        response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "external_id"}
-        )
-        self._test_order_by_external_id_ascending(response)
-
-    def test_order_by_external_id_descending(self):
-        """Test order by external id for GTFS feeds for descending order."""
-        response = self.get_response(
-            "v1/gtfs_feeds", params={"order_by": "-external_id"}
-        )
-        assert response.status_code == 200, (
-            "Expected 200 status code for GTFS feeds ordered by external id,"
-            " got {response.status_code}."
-        )
-        gtfs_feeds = response.json()
-        assert (
-            len(gtfs_feeds) > 1
-        ), "Expected more than one GTFS feed for external id sorting test."
-        prev_external_id = gtfs_feeds[0]["external_ids"][0]["external_id"]
-        for feed in gtfs_feeds[1:]:
-            current_external_id = feed["external_ids"][0]["external_id"]
-            assert current_external_id <= prev_external_id, (
-                "Expected GTFS feed external id to be in descending order, "
-                f"but found '{prev_external_id}' followed by '{current_external_id}'."
-            )
-            prev_external_id = current_external_id

--- a/integration-tests/src/endpoints/gtfs_feeds.py
+++ b/integration-tests/src/endpoints/gtfs_feeds.py
@@ -49,21 +49,21 @@ class GTFSFeedsEndpointTests(IntegrationTests):
         # Sending a request with invalid bounding box parameters
         wrong_bounding_lon_lat = "-12,-"
         response = self.get_response(
-            "v1/gtfs_feeds", params={
+            "v1/gtfs_feeds",
+            params={
                 "dataset_longitudes": wrong_bounding_lon_lat,
                 "dataset_latitudes": wrong_bounding_lon_lat,
-                "bounding_filter_method": "completely_enclosed"
-            }
+                "bounding_filter_method": "completely_enclosed",
+            },
         )
 
         # Expecting an error due to invalid input, but specific status code check is pending implementation
-        assert response.status_code != 200, (
-            f"Expected an error status code for GTFS feeds request with invalid input, got {response.status_code}."
-        )
+        assert (
+            response.status_code != 200
+        ), f"Expected an error status code for GTFS feeds request with invalid input, got {response.status_code}."
 
         # Sending a subsequent valid request to ensure APIs proper handling of sequences
         response = self.get_response("v1/gtfs_feeds", params={"limit": 10})
         assert (
-                response.status_code == 200
+            response.status_code == 200
         ), f"Expected a 200 status code for subsequent valid GTFS feeds request, got {response.status_code}."
-

--- a/integration-tests/src/endpoints/gtfs_feeds.py
+++ b/integration-tests/src/endpoints/gtfs_feeds.py
@@ -178,3 +178,29 @@ class GTFSFeedsEndpointTests(IntegrationTests):
                 f"but found '{prev_external_id}' followed by '{current_external_id}'."
             )
             prev_external_id = current_external_id
+
+    def test_invalid_bb_input_followed_by_valid_request(self):
+        """Tests the API's resilience by first sending invalid input parameters and then a valid request to ensure the
+        error does not affect subsequent requests."""
+
+        # Sending a request with invalid bounding box parameters
+        wrong_bounding_lon_lat = "-12,-"
+        response = self.get_response(
+            "v1/gtfs_feeds",
+            params={
+                "dataset_longitudes": wrong_bounding_lon_lat,
+                "dataset_latitudes": wrong_bounding_lon_lat,
+                "bounding_filter_method": "completely_enclosed",
+            },
+        )
+
+        # Expecting an error due to invalid input, but specific status code check is pending implementation
+        assert (
+            response.status_code != 200
+        ), f"Expected an error status code for GTFS feeds request with invalid input, got {response.status_code}."
+
+        # Sending a subsequent valid request to ensure APIs proper handling of sequences
+        response = self.get_response("v1/gtfs_feeds", params={"limit": 10})
+        assert (
+            response.status_code == 200
+        ), f"Expected a 200 status code for subsequent valid GTFS feeds request, got {response.status_code}."

--- a/integration-tests/src/endpoints/gtfs_feeds.py
+++ b/integration-tests/src/endpoints/gtfs_feeds.py
@@ -42,28 +42,139 @@ class GTFSFeedsEndpointTests(IntegrationTests):
                 index=f"{i + 1}/{len(country_codes)}",
             )
 
-    def test_invalid_bb_input_followed_by_valid_request(self):
-        """Tests the API's resilience by first sending invalid input parameters and then a valid request to ensure the
-        error does not affect subsequent requests."""
-
-        # Sending a request with invalid bounding box parameters
-        wrong_bounding_lon_lat = "-12,-"
-        response = self.get_response(
-            "v1/gtfs_feeds",
-            params={
-                "dataset_longitudes": wrong_bounding_lon_lat,
-                "dataset_latitudes": wrong_bounding_lon_lat,
-                "bounding_filter_method": "completely_enclosed",
-            },
+    def test_filter_by_provider_gtfs(self):
+        """Test GTFS feed retrieval filtered by provider"""
+        providers = self.gtfs_feeds.provider.sample(100).values
+        task_id = self.progress.add_task(
+            "[yellow]Validating GTFS feeds by provider...[/yellow]",
+            total=len(providers),
         )
+        for i, provider_id in enumerate(providers):
+            self._test_filter_by_provider(
+                provider_id,
+                "v1/gtfs_feeds",
+                task_id=task_id,
+                index=f"{i + 1}/{len(providers)}",
+            )
 
-        # Expecting an error due to invalid input, but specific status code check is pending implementation
-        assert (
-            response.status_code != 200
-        ), f"Expected an error status code for GTFS feeds request with invalid input, got {response.status_code}."
+    def test_filter_by_municipality_gtfs(self):
+        """Test GTFS feed retrieval filter by municipality."""
+        municipalities = self._sample_municipalities(self.gtfs_feeds, 100)
+        task_id = self.progress.add_task(
+            "[yellow]Validating GTFS feeds by municipality...[/yellow]",
+            total=len(municipalities),
+        )
+        for i, municipality in enumerate(municipalities):
+            self._test_filter_by_municipality(
+                municipality,
+                "v1/gtfs_feeds",
+                validate_location=True,
+                task_id=task_id,
+                index=f"{i + 1}/{len(municipalities)}",
+            )
 
-        # Sending a subsequent valid request to ensure APIs proper handling of sequences
-        response = self.get_response("v1/gtfs_feeds", params={"limit": 10})
+    @staticmethod
+    def _test_order_by_country_code_ascending(response):
+        assert response.status_code == 200, (
+            "Expected 200 status code for GTFS feeds ordered by country code,"
+            " got {response.status_code}."
+        )
+        gtfs_feeds = response.json()
+        assert len(gtfs_feeds) > 1, "Expected more than one GTFS feed for sorting test."
+        prev_country_code = gtfs_feeds[0]["locations"][0]["country_code"]
+        for feed in gtfs_feeds[1:]:
+            current_country_code = feed["locations"][0]["country_code"]
+            assert current_country_code >= prev_country_code, (
+                "Expected GTFS feed country code to be in ascending order, "
+                f"but found '{prev_country_code}' followed by '{current_country_code}'."
+            )
+            prev_country_code = current_country_code
+
+    def test_order_by_country_code_ascending(self):
+        """Test order by country code for GTFS feeds for ascending order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "+country_code"}
+        )
+        self._test_order_by_country_code_ascending(response)
+
+    def test_order_by_country_code_descending(self):
+        """Test order by country code for GTFS feeds for descending order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "-country_code"}
+        )
+        assert response.status_code == 200, (
+            "Expected 200 status code for GTFS feeds ordered by country code,"
+            " got {response.status_code}."
+        )
+        gtfs_feeds = response.json()
+        assert len(gtfs_feeds) > 1, "Expected more than one GTFS feed for sorting test."
+        prev_country_code = gtfs_feeds[0]["locations"][0]["country_code"]
+        for feed in gtfs_feeds[1:]:
+            current_country_code = feed["locations"][0]["country_code"]
+            assert current_country_code <= prev_country_code, (
+                "Expected GTFS feed country code to be in descending order, "
+                f"but found '{prev_country_code}' followed by '{current_country_code}'."
+            )
+            prev_country_code = current_country_code
+
+    def test_order_by_country_code_default(self):
+        """Test order by country code for GTFS feeds for default order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "country_code"}
+        )
+        self._test_order_by_country_code_ascending(response)
+
+    @staticmethod
+    def _test_order_by_external_id_ascending(response):
+        assert response.status_code == 200, (
+            "Expected 200 status code for GTFS feeds ordered by external id,"
+            " got {response.status_code}."
+        )
+        gtfs_feeds = response.json()
         assert (
-            response.status_code == 200
-        ), f"Expected a 200 status code for subsequent valid GTFS feeds request, got {response.status_code}."
+            len(gtfs_feeds) > 1
+        ), "Expected more than one GTFS feed for external id sorting test."
+        prev_external_id = gtfs_feeds[0]["external_ids"][0]["external_id"]
+        for feed in gtfs_feeds[1:]:
+            current_external_id = feed["external_ids"][0]["external_id"]
+            assert current_external_id >= prev_external_id, (
+                "Expected GTFS feed external id to be in ascending order, "
+                f"but found '{prev_external_id}' followed by '{current_external_id}'."
+            )
+            prev_external_id = current_external_id
+
+    def test_order_by_external_id_ascending(self):
+        """Test order by external id for GTFS feeds for ascending order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "+external_id"}
+        )
+        self._test_order_by_external_id_ascending(response)
+
+    def test_order_by_external_id_default(self):
+        """Test order by external id for GTFS feeds for default order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "external_id"}
+        )
+        self._test_order_by_external_id_ascending(response)
+
+    def test_order_by_external_id_descending(self):
+        """Test order by external id for GTFS feeds for descending order."""
+        response = self.get_response(
+            "v1/gtfs_feeds", params={"order_by": "-external_id"}
+        )
+        assert response.status_code == 200, (
+            "Expected 200 status code for GTFS feeds ordered by external id,"
+            " got {response.status_code}."
+        )
+        gtfs_feeds = response.json()
+        assert (
+            len(gtfs_feeds) > 1
+        ), "Expected more than one GTFS feed for external id sorting test."
+        prev_external_id = gtfs_feeds[0]["external_ids"][0]["external_id"]
+        for feed in gtfs_feeds[1:]:
+            current_external_id = feed["external_ids"][0]["external_id"]
+            assert current_external_id <= prev_external_id, (
+                "Expected GTFS feed external id to be in descending order, "
+                f"but found '{prev_external_id}' followed by '{current_external_id}'."
+            )
+            prev_external_id = current_external_id

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -10,7 +10,7 @@
 #   -c  Optional, comma-separated list of test class names to include
 
 function print_help() {
-  echo "Usage: $0 -u <API URL> -t <REFRESH TOKEN> -f <FILE PATH> [-c <CLASS NAMES>]"
+  echo "Usage: $0 -u <API URL> -f <FILE PATH> [-c <CLASS NAMES>]"
   echo ""
   echo "Options:"
   echo "  -u  URL of the API to test against"


### PR DESCRIPTION
**Summary:**
Closes #283 

✅ Introduces session rollback to avoid leaving transactions open when an error is thrown
✅ Added an integration test

**Expected behavior:** 
When the server runs into an error related to a database call, the subsequent request remain unaffected by the previous error.

**Testing tips:**
- Redeploy API QA
- Follow steps in `integration-tests/README.md` and run tests in QA using the filter `-c "GTFSFeedsEndpointTests"`-- test `GTFSFeedsEndpointTests.test_invalid_bb_input_followed_by_valid_request` should fail
- Follow steps in `integration-tests/README.md` and run tests in DEV using the filter `-c "GTFSFeedsEndpointTests"`-- test `GTFSFeedsEndpointTests.test_invalid_bb_input_followed_by_valid_request` should pass
<img width="1672" alt="Screenshot 2024-02-13 at 5 29 57 PM" src="https://github.com/MobilityData/mobility-feed-api/assets/60586858/8e76af90-efb6-4ca2-a8dd-8ae0d552ebe9">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
