### PR TITLE
fix: downloaded_at filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ To run the server on a Docker container, please execute the following from the r
 ```bash
 (cd api && docker-compose up --build)
 ```
+
+## API error responses
+
+The API HTTP error responses follow the FastAPI structure. Example:
+```
+{
+  "details": "The error message"
+}
+```
+
+To simplify and standardize HTTP error responses use the helpers function located in  [api/src/feeds/impl/error_handling.py](api/src/feeds/impl/error_handling.py). Also keep the error messages as Finals of the mentioned file, this will make it easier to locate and reuse error messages.

--- a/api/src/feeds/impl/error_handling.py
+++ b/api/src/feeds/impl/error_handling.py
@@ -6,12 +6,14 @@ from fastapi import HTTPException
 @dataclass
 class HttpError:
     """A generic HTTP error."""
+
     message: str
 
 
 @dataclass
 class ValidationError(HttpError):
     """A validation error."""
+
     field: str
     message: str
 

--- a/api/src/feeds/impl/error_handling.py
+++ b/api/src/feeds/impl/error_handling.py
@@ -1,26 +1,39 @@
-from dataclasses import dataclass, asdict
+from typing import Final
 
 from fastapi import HTTPException
 
-
-@dataclass
-class HttpError:
-    """A generic HTTP error."""
-
-    message: str
-
-
-@dataclass
-class ValidationError(HttpError):
-    """A validation error."""
-
-    field: str
-    message: str
+invalid_date_message: Final[
+    str
+] = "Invalid date format for '{}'. Expected ISO 8601 format, example: '2021-01-01T00:00:00Z'"
+invalid_bounding_coordinates: Final[str] = "Invalid bounding coordinates {} {}"
+invalid_bounding_method: Final[str] = "Invalid bounding_filter_method {}"
+feed_not_found: Final[str] = "Feed '{}' not found"
+gtfs_feed_not_found: Final[str] = "GTFS feed '{}' not found"
+gtfs_rt_feed_not_found: Final[str] = "GTFS realtime Feed '{}' not found"
+dataset_not_found: Final[str] = "Dataset '{}' not found"
 
 
-def raise_http_errors(errors: HttpError):
-    """Raise a HTTPException with a list of errors."""
+def raise_http_error(status_code: int, error: str):
+    """Raise a HTTPException.
+    :param status_code: The status code of the error.
+    :param error: The error message to be raised.
+    example of output:
+    {
+        "detail": "Invalid date format for 'field_name'. Expected ISO 8601 format, example: '2021-01-01T00:00:00Z'"
+    }
+    """
     raise HTTPException(
-        status_code=422,
-        detail=asdict(errors),
+        status_code=status_code,
+        detail=error,
     )
+
+
+def raise_http_validation_error(error: str):
+    """Raise a HTTPException with status code 422 and the error message.
+    :param error: The error message to be raised.
+    example of output:
+    {
+        "detail": "Invalid date format for 'field_name'. Expected ISO 8601 format, example: '2021-01-01T00:00:00Z'"
+    }
+    """
+    raise_http_error(422, error)

--- a/api/src/feeds/impl/error_handling.py
+++ b/api/src/feeds/impl/error_handling.py
@@ -16,10 +16,9 @@ class ValidationError(HttpError):
     message: str
 
 
-def raise_http_errors(errors: [HttpError]):
+def raise_http_errors(errors: HttpError):
     """Raise a HTTPException with a list of errors."""
-    errors = [asdict(error) for error in errors]
     raise HTTPException(
         status_code=422,
-        detail=errors,
+        detail=asdict(errors),
     )

--- a/api/src/feeds/impl/error_handling.py
+++ b/api/src/feeds/impl/error_handling.py
@@ -6,14 +6,12 @@ from fastapi import HTTPException
 @dataclass
 class HttpError:
     """A generic HTTP error."""
-
     message: str
 
 
 @dataclass
 class ValidationError(HttpError):
     """A validation error."""
-
     field: str
     message: str
 

--- a/api/src/feeds/impl/error_handling.py
+++ b/api/src/feeds/impl/error_handling.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, asdict
+
+from fastapi import HTTPException
+
+
+@dataclass
+class HttpError:
+    """A generic HTTP error."""
+
+    message: str
+
+
+@dataclass
+class ValidationError(HttpError):
+    """A validation error."""
+
+    field: str
+    message: str
+
+
+def raise_http_errors(errors: [HttpError]):
+    """Raise a HTTPException with a list of errors."""
+    errors = [asdict(error) for error in errors]
+    raise HTTPException(
+        status_code=422,
+        detail=errors,
+    )

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -313,12 +313,12 @@ class FeedsApiImpl(BaseFeedsApi):
         """Get a list of datasets related to a feed."""
         if downloaded_before and not valid_iso_date(downloaded_before):
             raise_http_errors(
-                [ValidationError(field="downloaded_before", message="Invalid date format. Expected ISO 8601 format.")]
+                ValidationError(field="downloaded_before", message="Invalid date format. Expected ISO 8601 format.")
             )
 
         if downloaded_after and not valid_iso_date(downloaded_after):
             raise_http_errors(
-                [ValidationError(field="downloaded_after", message="Invalid date format. Expected ISO 8601 format.")]
+                ValidationError(field="downloaded_after", message="Invalid date format. Expected ISO 8601 format.")
             )
         query = GtfsDatasetFilter(
             downloaded_at__lte=datetime.fromisoformat(downloaded_before) if downloaded_before else None,

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -322,9 +322,15 @@ class FeedsApiImpl(BaseFeedsApi):
         if downloaded_after and not valid_iso_date(downloaded_after):
             raise_http_validation_error(invalid_date_message.format("downloaded_after"))
 
+        # Replace Z with +00:00 to make the datetime object timezone aware
+        # Due to https://github.com/python/cpython/issues/80010, once migrate to Python 3.11, we can use fromisoformat
         query = GtfsDatasetFilter(
-            downloaded_at__lte=datetime.fromisoformat(downloaded_before) if downloaded_before else None,
-            downloaded_at__gte=datetime.fromisoformat(downloaded_after) if downloaded_after else None,
+            downloaded_at__lte=datetime.fromisoformat(downloaded_before.replace("Z", "+00:00"))
+            if downloaded_before
+            else None,
+            downloaded_at__gte=datetime.fromisoformat(downloaded_after.replace("Z", "+00:00"))
+            if downloaded_after
+            else None,
         ).filter(DatasetsApiImpl.create_dataset_query().filter(Feed.stable_id == id))
 
         if latest:

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -15,7 +15,9 @@
 #
 # This files allows to add extra application decorators aside from the generated code.
 # The app created here is intended to replace the generated feeds_gen.main:app variable.
+import os
 
+import uvicorn
 from fastapi import FastAPI
 
 from feeds_gen.apis.datasets_api import router as DatasetsApiRouter
@@ -49,3 +51,6 @@ app.add_middleware(RequestContextMiddleware)
 app.include_router(DatasetsApiRouter)
 app.include_router(FeedsApiRouter)
 app.include_router(MetadataApiRouter)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=os.getenv("PORT", 8080))

--- a/api/src/utils/date_utils.py
+++ b/api/src/utils/date_utils.py
@@ -1,0 +1,12 @@
+from typing import Final
+import re
+
+iso_pattern: Final[str] = (
+    r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)("
+    r"\.\d+)?(Z|[+-](["
+    r"01]\d|2[0-3]):([0-5]\d))?$"
+)
+
+
+def valid_iso_date(date_string: str):
+    return re.match(iso_pattern, date_string)

--- a/api/src/utils/date_utils.py
+++ b/api/src/utils/date_utils.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Final, Optional
 import re
 
 iso_pattern: Final[str] = (
@@ -8,9 +8,9 @@ iso_pattern: Final[str] = (
 )
 
 
-def valid_iso_date(date_string: str):
+def valid_iso_date(date_string: Optional[str]) -> bool:
     """Check if a date string is a valid ISO 8601 date format."""
     # Validators are not required to check for None or empty strings
     if date_string is None or date_string.strip() == "":
         return True
-    return re.match(iso_pattern, date_string)
+    return re.match(iso_pattern, date_string) is not None

--- a/api/src/utils/date_utils.py
+++ b/api/src/utils/date_utils.py
@@ -9,4 +9,8 @@ iso_pattern: Final[str] = (
 
 
 def valid_iso_date(date_string: str):
+    """Check if a date string is a valid ISO 8601 date format."""
+    # Validators are not required to check for None or empty strings
+    if date_string is None or date_string.strip() == "":
+        return True
     return re.match(iso_pattern, date_string)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from database.database import Database
-from feeds_gen.main import app as application
+from main import app as application
 from .test_utils.database import populate_database
 
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -7,6 +7,19 @@ from .test_utils.token import authHeaders
 from .test_utils.database import datasets_download_first_date
 
 
+def get_all_datasets(client):
+    unfiltered_response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets".format(id=TEST_GTFS_FEED_STABLE_IDS[0]),
+        headers=authHeaders,
+    )
+    datasets = []
+    for dataset in unfiltered_response.json():
+        if dataset["feed_id"] == TEST_GTFS_FEED_STABLE_IDS[0]:
+            datasets.append(dataset)
+    return datasets
+
+
 def test_feeds_get(client: TestClient):
     """Test case for feeds_get"""
     params = [
@@ -182,8 +195,8 @@ def test_feeds_id_get(client: TestClient):
     assert response.status_code == 200
 
 
-def test_get_gtfs_feed_datasets_with_download_at_before_before(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at filter by date before all downloads
+def test_get_gtfs_feed_datasets_with_downloaded_before_before(client: TestClient):
+    """Test case for get_gtfs_feed_datasets filter by downloaded_before with date before all downloads
     Expected result: empty list
     """
     date = datasets_download_first_date - timedelta(days=10)
@@ -199,8 +212,8 @@ def test_get_gtfs_feed_datasets_with_download_at_before_before(client: TestClien
     assert response.json() == []
 
 
-def test_get_gtfs_feed_datasets_with_download_at_before_after(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at filter by the date before after all downloads
+def test_get_gtfs_feed_datasets_with_downloaded_before_after(client: TestClient):
+    """Test case for get_gtfs_feed_datasets filter by downloaded_before with date after all downloads
     Expected result: the full list of datasets
     """
     datasets = get_all_datasets(client)
@@ -217,20 +230,7 @@ def test_get_gtfs_feed_datasets_with_download_at_before_after(client: TestClient
     assert response.json() == datasets
 
 
-def get_all_datasets(client):
-    unfiltered_response = client.request(
-        "GET",
-        "/v1/gtfs_feeds/{id}/datasets".format(id=TEST_GTFS_FEED_STABLE_IDS[0]),
-        headers=authHeaders,
-    )
-    datasets = []
-    for dataset in unfiltered_response.json():
-        if dataset["feed_id"] == TEST_GTFS_FEED_STABLE_IDS[0]:
-            datasets.append(dataset)
-    return datasets
-
-
-def test_get_gtfs_feed_datasets_with_download_at_before_the_first_dataset(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_before_the_first_dataset(client: TestClient):
     """Test case for get_gtfs_feed_datasets filter by downloaded_before with date before of the first dataset
     Expected result: the first dataset
     """
@@ -248,7 +248,7 @@ def test_get_gtfs_feed_datasets_with_download_at_before_the_first_dataset(client
     assert response.json()[0]["id"] == TEST_DATASET_STABLE_IDS[0]
 
 
-def test_get_gtfs_feed_datasets_with_download_at_after_after(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_after_after(client: TestClient):
     """Test case for get_gtfs_feed_datasets filter downloaded_after with date after all downloads
     Expected result: empty list
     """
@@ -265,7 +265,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_after(client: TestClient)
     assert response.json() == []
 
 
-def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_after_before(client: TestClient):
     """Test case for get_gtfs_feed_datasets filter by downloaded_after with date before
      all downloads
     Expected result: the full list of datasets
@@ -284,7 +284,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient
     assert response.json() == datasets
 
 
-def test_get_gtfs_feed_datasets_with_download_at_after_first(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_after_first(client: TestClient):
     """Test case for get_gtfs_feed_datasets filter by downloaded_after date after the first dataset
     Expected result: the full list of datasets
     """
@@ -304,7 +304,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_first(client: TestClient)
     assert response.json() == datasets
 
 
-def test_get_gtfs_feed_datasets_with_download_before_invalid_date(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_before_invalid_date(client: TestClient):
     """Test case for get_gtfs_feed_datasets with an invalid date in download_before
     Expected result: the full list of datasets
     """
@@ -322,7 +322,7 @@ def test_get_gtfs_feed_datasets_with_download_before_invalid_date(client: TestCl
     }
 
 
-def test_get_gtfs_feed_datasets_with_download_after_invalid_date(client: TestClient):
+def test_get_gtfs_feed_datasets_with_downloaded_after_invalid_date(client: TestClient):
     """Test case for get_gtfs_feed_datasets with an invalid date in download_after
     filter by the after operation with date after the first dataset
     Expected result: the full list of datasets
@@ -347,12 +347,12 @@ def test_get_gtfs_feed_datasets_with_downloaded_date_between(client: TestClient)
     Expected result: the full list of datasets
     """
     datasets = get_all_datasets(client)
-    date = datasets_download_first_date - timedelta(days=1)
     response = client.request(
         "GET",
         "/v1/gtfs_feeds/{id}/datasets?downloaded_after={first}&downloaded_before={last}".format(
-            id=TEST_GTFS_FEED_STABLE_IDS[0], first=datasets_download_first_date.isoformat(),
-            last=(datasets_download_first_date + timedelta(days=len(datasets) - 1)).isoformat()
+            id=TEST_GTFS_FEED_STABLE_IDS[0],
+            first=datasets_download_first_date.isoformat(),
+            last=(datasets_download_first_date + timedelta(days=len(datasets) - 1)).isoformat(),
         ),
         headers=authHeaders,
     )

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -318,7 +318,7 @@ def test_get_gtfs_feed_datasets_with_download_before_invalid_date(client: TestCl
 
     assert response.status_code == 422
     assert response.json() == {
-        "detail": [{"field": "downloaded_before", "message": "Invalid date format. Expected ISO 8601 format."}]
+        "detail": {"field": "downloaded_before", "message": "Invalid date format. Expected ISO 8601 format."}
     }
 
 
@@ -337,5 +337,25 @@ def test_get_gtfs_feed_datasets_with_download_after_invalid_date(client: TestCli
 
     assert response.status_code == 422
     assert response.json() == {
-        "detail": [{"field": "downloaded_after", "message": "Invalid date format. Expected ISO 8601 format."}]
+        "detail": {"field": "downloaded_after", "message": "Invalid date format. Expected ISO 8601 format."}
     }
+
+
+def test_get_gtfs_feed_datasets_with_downloaded_date_between(client: TestClient):
+    """Test case for get_gtfs_feed_datasets filter by downloaded_before and downloaded_after containing
+     all downloads
+    Expected result: the full list of datasets
+    """
+    datasets = get_all_datasets(client)
+    date = datasets_download_first_date - timedelta(days=1)
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={first}&downloaded_before={last}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], first=datasets_download_first_date.isoformat(),
+            last=(datasets_download_first_date + timedelta(days=len(datasets) - 1)).isoformat()
+        ),
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == datasets

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -189,7 +189,7 @@ def test_get_gtfs_feed_datasets_with_download_at_before_before(client: TestClien
     before_all_downloads = datasets_download_first_date - timedelta(days=10)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_lte={date}".format(
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
             id=TEST_GTFS_FEED_STABLE_IDS[0], date=before_all_downloads
         ),
         headers=authHeaders,
@@ -207,7 +207,7 @@ def test_get_gtfs_feed_datasets_with_download_at_before_after(client: TestClient
     date = datasets_download_first_date + timedelta(days=10)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_lte={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
         headers=authHeaders,
     )
 
@@ -234,7 +234,7 @@ def test_get_gtfs_feed_datasets_with_download_at_before_the_first_dataset(client
     """
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_lte={date}".format(
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
             id=TEST_GTFS_FEED_STABLE_IDS[0], date=datasets_download_first_date
         ),
         headers=authHeaders,
@@ -253,7 +253,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_after(client: TestClient)
     date = datasets_download_first_date + timedelta(days=10)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_gte={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
         headers=authHeaders,
     )
 
@@ -270,7 +270,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient
     date = datasets_download_first_date - timedelta(days=1)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_gte={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
         headers=authHeaders,
     )
 
@@ -288,7 +288,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_first(client: TestClient)
     date = datasets_download_first_date + timedelta(days=1)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_at_gte={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
         headers=authHeaders,
     )
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -104,7 +104,7 @@ def test_fetch_gtfs_feeds_with_incorrect_filter_method(client: TestClient):
         headers=authHeaders,
         params=params,
     )
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_fetch_gtfs_feeds_with_incorrect_latitude_for_bounding_box(client: TestClient):
@@ -318,7 +318,8 @@ def test_get_gtfs_feed_datasets_with_downloaded_before_invalid_date(client: Test
 
     assert response.status_code == 422
     assert response.json() == {
-        "detail": {"field": "downloaded_before", "message": "Invalid date format. Expected ISO 8601 format."}
+        "detail": "Invalid date format for 'downloaded_before'. Expected ISO 8601 format, example: "
+        "'2021-01-01T00:00:00Z'"
     }
 
 
@@ -337,7 +338,8 @@ def test_get_gtfs_feed_datasets_with_downloaded_after_invalid_date(client: TestC
 
     assert response.status_code == 422
     assert response.json() == {
-        "detail": {"field": "downloaded_after", "message": "Invalid date format. Expected ISO 8601 format."}
+        "detail": "Invalid date format for 'downloaded_after'. Expected ISO 8601 format, example: "
+        "'2021-01-01T00:00:00Z'"
     }
 
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -186,11 +186,11 @@ def test_get_gtfs_feed_datasets_with_download_at_before_before(client: TestClien
     """Test case for get_gtfs_feed_datasets with a download_at filter by date before all downloads
     Expected result: empty list
     """
-    before_all_downloads = datasets_download_first_date - timedelta(days=10)
+    date = datasets_download_first_date - timedelta(days=10)
     response = client.request(
         "GET",
         "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
-            id=TEST_GTFS_FEED_STABLE_IDS[0], date=before_all_downloads
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=date.isoformat()
         ),
         headers=authHeaders,
     )
@@ -207,7 +207,9 @@ def test_get_gtfs_feed_datasets_with_download_at_before_after(client: TestClient
     date = datasets_download_first_date + timedelta(days=10)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=date.isoformat()
+        ),
         headers=authHeaders,
     )
 
@@ -229,13 +231,13 @@ def get_all_datasets(client):
 
 
 def test_get_gtfs_feed_datasets_with_download_at_before_the_first_dataset(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at filter by the date before of the first dataset
+    """Test case for get_gtfs_feed_datasets filter by downloaded_before with date before of the first dataset
     Expected result: the first dataset
     """
     response = client.request(
         "GET",
         "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
-            id=TEST_GTFS_FEED_STABLE_IDS[0], date=datasets_download_first_date
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=datasets_download_first_date.isoformat()
         ),
         headers=authHeaders,
     )
@@ -247,13 +249,15 @@ def test_get_gtfs_feed_datasets_with_download_at_before_the_first_dataset(client
 
 
 def test_get_gtfs_feed_datasets_with_download_at_after_after(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at filter that is after all downloads
+    """Test case for get_gtfs_feed_datasets filter downloaded_after with date after all downloads
     Expected result: empty list
     """
     date = datasets_download_first_date + timedelta(days=10)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=date.isoformat()
+        ),
         headers=authHeaders,
     )
 
@@ -262,7 +266,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_after(client: TestClient)
 
 
 def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at filter by the after operation with date before
+    """Test case for get_gtfs_feed_datasets filter by downloaded_after with date before
      all downloads
     Expected result: the full list of datasets
     """
@@ -270,7 +274,9 @@ def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient
     date = datasets_download_first_date - timedelta(days=1)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=date.isoformat()
+        ),
         headers=authHeaders,
     )
 
@@ -279,8 +285,7 @@ def test_get_gtfs_feed_datasets_with_download_at_after_before(client: TestClient
 
 
 def test_get_gtfs_feed_datasets_with_download_at_after_first(client: TestClient):
-    """Test case for get_gtfs_feed_datasets with a download_at
-    filter by the after operation with date after the first dataset
+    """Test case for get_gtfs_feed_datasets filter by downloaded_after date after the first dataset
     Expected result: the full list of datasets
     """
     datasets = get_all_datasets(client)
@@ -288,10 +293,49 @@ def test_get_gtfs_feed_datasets_with_download_at_after_first(client: TestClient)
     date = datasets_download_first_date + timedelta(days=1)
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(id=TEST_GTFS_FEED_STABLE_IDS[0], date=date),
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date=date.isoformat()
+        ),
         headers=authHeaders,
     )
 
     assert response.status_code == 200
     assert len(response.json()) == len(datasets)
     assert response.json() == datasets
+
+
+def test_get_gtfs_feed_datasets_with_download_before_invalid_date(client: TestClient):
+    """Test case for get_gtfs_feed_datasets with an invalid date in download_before
+    Expected result: the full list of datasets
+    """
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_before={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date="invalid_date"
+        ),
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [{"field": "downloaded_before", "message": "Invalid date format. Expected ISO 8601 format."}]
+    }
+
+
+def test_get_gtfs_feed_datasets_with_download_after_invalid_date(client: TestClient):
+    """Test case for get_gtfs_feed_datasets with an invalid date in download_after
+    filter by the after operation with date after the first dataset
+    Expected result: the full list of datasets
+    """
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets?downloaded_after={date}".format(
+            id=TEST_GTFS_FEED_STABLE_IDS[0], date="invalid_date"
+        ),
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [{"field": "downloaded_after", "message": "Invalid date format. Expected ISO 8601 format."}]
+    }

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -48,6 +48,7 @@ def populate_database(db: Database):
                 feed_id=gtfs_feed_ids[idx // 2],
                 latest=idx % 2 == 1,
                 bounding_box=WKTElement(polygon, srid=4326),
+                # This makes downloaded_at predictable and unique for each dataset
                 downloaded_at=(datasets_download_first_date + idx * one_day),
             ),
             auto_commit=True,

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -1,4 +1,6 @@
 import contextlib
+from datetime import datetime, timedelta
+from typing import Final
 
 from geoalchemy2 import WKTElement
 
@@ -9,6 +11,11 @@ TEST_GTFS_FEED_STABLE_IDS = ["mdb-1", "mdb-10", "mdb-20", "mdb-30"]
 TEST_DATASET_STABLE_IDS = ["mdb-2", "mdb-3", "mdb-11", "mdb-12"]
 TEST_GTFS_RT_FEED_STABLE_ID = "mdb-1561"
 TEST_EXTERNAL_IDS = ["external_id_1", "external_id_2", "external_id_3", "external_id_4"]
+
+date_string: Final[str] = "2024-01-31 00:00:00"
+date_format: Final[str] = "%Y-%m-%d %H:%M:%S"
+one_day: Final[timedelta] = timedelta(days=1)
+datasets_download_first_date: Final[datetime] = datetime.strptime(date_string, date_format)
 
 
 @contextlib.contextmanager
@@ -41,6 +48,7 @@ def populate_database(db: Database):
                 feed_id=gtfs_feed_ids[idx // 2],
                 latest=idx % 2 == 1,
                 bounding_box=WKTElement(polygon, srid=4326),
+                downloaded_at=(datasets_download_first_date + idx * one_day),
             ),
             auto_commit=True,
         )

--- a/api/tests/utils/test_date_utils.py
+++ b/api/tests/utils/test_date_utils.py
@@ -1,0 +1,35 @@
+from utils.date_utils import valid_iso_date
+
+
+def test_valid_iso_date_valid_format():
+    """Test valid_iso_date function with valids ISO 8601 date formats."""
+    # Validators are not required to check for None or empty strings
+    assert valid_iso_date("")
+    assert valid_iso_date("   ")
+    assert valid_iso_date(None)
+
+    assert valid_iso_date("2021-01-01T00:00:00")
+    assert valid_iso_date("2021-01-01T00:00:00Z")
+    assert valid_iso_date("2021-01-01T00:00:00+00:00")
+    assert valid_iso_date("2021-01-01T00:00:00-00:00")
+    assert valid_iso_date("2021-01-01T00:00:00+01:00")
+    assert valid_iso_date("2021-01-01T00:00:00-01:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000Z")
+    assert valid_iso_date("2021-01-01T00:00:00.000+00:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000-00:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000+01:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000-01:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000Z")
+    assert valid_iso_date("2021-01-01T00:00:00.000000+00:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000-00:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000+01:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000-01:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000000Z")
+    assert valid_iso_date("2021-01-01T00:00:00.000000000+00:00")
+    assert valid_iso_date("2021-01-01T00:00:00.000000000-00:00")
+
+
+def test_valid_iso_date_valid_format():
+    """Test valid_iso_date function with invalids ISO 8601 date formats."""
+    assert not valid_iso_date("2021-01-01")
+    assert not valid_iso_date("June 2021")

--- a/api/tests/utils/test_date_utils.py
+++ b/api/tests/utils/test_date_utils.py
@@ -29,7 +29,7 @@ def test_valid_iso_date_valid_format():
     assert valid_iso_date("2021-01-01T00:00:00.000000000-00:00")
 
 
-def test_valid_iso_date_valid_format():
+def test_invalid_iso_date_valid_format():
     """Test valid_iso_date function with invalids ISO 8601 date formats."""
     assert not valid_iso_date("2021-01-01")
     assert not valid_iso_date("June 2021")

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -176,8 +176,8 @@ paths:
         - $ref: "#/components/parameters/latest_query_param"
         - $ref: "#/components/parameters/limit_query_param"
         - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/downloaded_at_gte"
-        - $ref: "#/components/parameters/downloaded_at_lte"
+        - $ref: "#/components/parameters/downloaded_after"
+        - $ref: "#/components/parameters/downloaded_before"
 
       security:
         -  Authentication: []
@@ -682,8 +682,8 @@ components:
       schema:
         type: string
         example: Los Angeles
-    downloaded_at_gte:
-      name: downloaded_at_gte
+    downloaded_after:
+      name: downloaded_after
       in: query
       description: Filter feed datasets with downloaded date greater or equal to given date.
       schema:

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -696,7 +696,7 @@ components:
       description: Filter feed datasets with downloaded date less or equal to given date. Date should be in ISO 8601 format.
       schema:
         type: string
-        format: datetime
+        format: date-time
         example: 2023-07-20T22:06:00Z
 
     dataset_latitudes:

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -369,7 +369,7 @@ components:
         bounding_box:
           $ref: "#/components/schemas/BoundingBox"
         downloaded_at:
-          description: The date and time the dataset was downloaded from the producer, in ISO 8601 format.
+          description: The date and time the dataset was downloaded from the producer, in ISO 8601 date-time format.
           type: string
           example: 2023-07-10T22:06:00Z
           format: date-time
@@ -522,7 +522,7 @@ components:
               description: A note to clarify complex use cases for consumers.
               type: string
             downloaded_at:
-              description: The date and time the dataset was downloaded from the producer, in ISO 8601 format.
+              description: The date and time the dataset was downloaded from the producer, in ISO 8601 date-time format.
               type: string
               example: 2023-07-10T22:06:00Z
               format: date-time
@@ -573,7 +573,7 @@ components:
       type: object
       properties:
         validated_at:
-          description: The date and time the report was generated, in ISO 8601 format.
+          description: The date and time the report was generated, in ISO 8601 date-time format.
           type: string
           example: 2023-07-10T22:06:00Z
           format: date-time
@@ -685,7 +685,7 @@ components:
     downloaded_after:
       name: downloaded_after
       in: query
-      description: Filter feed datasets with downloaded date greater or equal to given date. Date should be in ISO 8601 format.
+      description: Filter feed datasets with downloaded date greater or equal to given date. Date should be in ISO 8601 date-time format.
       schema:
         type: string
         format: date-time
@@ -693,7 +693,7 @@ components:
     downloaded_before:
       name: downloaded_before
       in: query
-      description: Filter feed datasets with downloaded date less or equal to given date. Date should be in ISO 8601 format.
+      description: Filter feed datasets with downloaded date less or equal to given date. Date should be in ISO 8601 date-time format.
       schema:
         type: string
         format: date-time

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -372,7 +372,7 @@ components:
           description: The date and time the dataset was downloaded from the producer, in ISO 8601 format.
           type: string
           example: 2023-07-10T22:06:00Z
-          format: datetime
+          format: date-time
         hash:
           description: A hash of the dataset.
           type: string
@@ -525,7 +525,7 @@ components:
               description: The date and time the dataset was downloaded from the producer, in ISO 8601 format.
               type: string
               example: 2023-07-10T22:06:00Z
-              format: datetime
+              format: date-time
             hash:
               description: A hash of the dataset.
               type: string
@@ -576,7 +576,7 @@ components:
           description: The date and time the report was generated, in ISO 8601 format.
           type: string
           example: 2023-07-10T22:06:00Z
-          format: datetime
+          format: date-time
         components:
           description: An array of components for this dataset.
           type: array
@@ -685,17 +685,19 @@ components:
     downloaded_after:
       name: downloaded_after
       in: query
-      description: Filter feed datasets with downloaded date greater or equal to given date.
+      description: Filter feed datasets with downloaded date greater or equal to given date. Date should be in ISO 8601 format.
       schema:
         type: string
-        example: 2024-02-11T18:16:05Z
-    downloaded_at_lte:
-      name: downloaded_at_lte
+        format: date-time
+        example: 2023-07-00T22:06:00Z
+    downloaded_before:
+      name: downloaded_before
       in: query
-      description: Filter feed datasets with downloaded date less or equal to given date.
+      description: Filter feed datasets with downloaded date less or equal to given date. Date should be in ISO 8601 format.
       schema:
         type: string
-        example: 2024-02-20T18:16:05Z
+        format: datetime
+        example: 2023-07-20T22:06:00Z
 
     dataset_latitudes:
       name: dataset_latitudes


### PR DESCRIPTION
**Summary:**

Changes:
- [x] Fix downloaded_at filtering (remove 2 underscores in the code to make this work) It was not necessary as QA was already working. This was verified with the added unit tests.
- [x] Update downloaded at queries from downloaded_at_gte and downloaded_at_lte to downloaded_before and downloaded_ after
- [x] Includes datetime format in the description of both queries: e.g 2024-02-10T01:06:00Z
- ~In testing steps, make sure that we can do partial matches (e.g just the date with no timestamp)~
- [x] Refactor error handling to standardize status codes and formatting
- [x] Enhance local debugging


Fixes #285 

**Expected behavior:** 


**Testing tips:**

- Start application locally 
- Open Postman hit the following endpoints:
   -  http://localhost:8080/v1/gtfs_feeds/mdb-1/datasets?downloaded_before=2024-12-01T00:00:00Z
   Expect HTTP 200 with body
```
[
{
.. all your 2024 datasets for mdb1 feed
}
]
```
   -  http://localhost:8080/v1/gtfs_feeds/mdb-1/datasets?downloaded_before=2024
   Expect HTTP 422 with body
```
{
    "detail": "Invalid date format for 'downloaded_before'. Expected ISO 8601 format, example: '2021-01-01T00:00:00Z'"
}
```
   -  http://localhost:8080/v1/gtfs_feeds/{id}/datasets?downloaded_after=2024
   Expect HTTP 422 with body
```
{
    "detail": "Invalid date format for 'downloaded_after'. Expected ISO 8601 format, example: '2021-01-01T00:00:00Z'"
}
```
   -  http://localhost:8080/dataset_latitudes=2024-01-30T00:00:00&dataset_longitudes=00&bounding_filter_method=completely_enclosed
   Expect HTTP 422 with body
```
{
    "detail": "Invalid bounding coordinates 2024-01-30T00:00:00 00"
}
```
   -  http://localhost:8080/v1/gtfs_feeds/invalid_id
   Expect HTTP 422 with body
```
{
    "detail": "GTFS feed '2' not found"
}
```
    -  http://localhost:8080/v1/gtfs_rt_feeds/invalid
   Expect HTTP 422 with body
```
{
    "detail": "GTFS realtime Feed 'invalid' not found"
}
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
