### PR TITLE
fix: bounding box input validation

### DIFF
--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     */test*/*
     src/feeds_gen/*
+    src/database_gen/*
 
 [report]
 exclude_lines =

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -43,3 +43,4 @@ pandas
 cloud-sql-python-connector[pg8000]
 fastapi-filter[sqlalchemy]==0.6.1
 PyJWT
+shapely

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -43,4 +43,3 @@ pandas
 cloud-sql-python-connector[pg8000]
 fastapi-filter[sqlalchemy]==0.6.1
 PyJWT
-shapely

--- a/api/src/feeds/impl/datasets_api_impl.py
+++ b/api/src/feeds/impl/datasets_api_impl.py
@@ -56,7 +56,7 @@ class DatasetsApiImpl(BaseDatasetsApi):
             or len(bounding_longitudes_tokens := bounding_longitudes.split(",")) != 2
         ):
             raise HTTPException(
-                status_code=400,
+                status_code=422,
                 detail=f"Invalid bounding coordinates {bounding_latitudes} {bounding_longitudes}",
             )
         min_latitude, max_latitude = bounding_latitudes_tokens
@@ -68,7 +68,7 @@ class DatasetsApiImpl(BaseDatasetsApi):
             max_longitude = float(max_longitude)
         except ValueError:
             raise HTTPException(
-                status_code=400,
+                status_code=422,
                 detail=f"Invalid bounding coordinates {bounding_latitudes} {bounding_longitudes}",
             )
         points = [

--- a/api/src/feeds/impl/datasets_api_impl.py
+++ b/api/src/feeds/impl/datasets_api_impl.py
@@ -11,7 +11,6 @@ from database_gen.sqlacodegen_models import Gtfsdataset, t_componentgtfsdataset,
 from feeds_gen.apis.datasets_api_base import BaseDatasetsApi
 from feeds_gen.models.bounding_box import BoundingBox
 from feeds_gen.models.gtfs_dataset import GtfsDataset
-from shapely.geometry import Polygon
 
 
 class DatasetsApiImpl(BaseDatasetsApi):
@@ -79,18 +78,6 @@ class DatasetsApiImpl(BaseDatasetsApi):
             (max_longitude, min_latitude),
             (min_longitude, min_latitude),
         ]
-        try:
-            polygon = Polygon(points)
-            if not polygon.is_valid:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid bounding coordinates {bounding_latitudes} {bounding_longitudes}",
-                )
-        except Exception:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid bounding coordinates {bounding_latitudes} {bounding_longitudes}",
-            )
         wkt_polygon = f"POLYGON(({', '.join(f'{lon} {lat}' for lon, lat in points)}))"
         bounding_box = WKTElement(
             wkt_polygon,

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -127,7 +127,7 @@ def test_fetch_gtfs_feeds_with_incorrect_latitude_for_bounding_box(client: TestC
         headers=authHeaders,
         params=params,
     )
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_fetch_gtfs_feeds_with_malformed_bounding_box_coordinates(client: TestClient):
@@ -149,7 +149,7 @@ def test_fetch_gtfs_feeds_with_malformed_bounding_box_coordinates(client: TestCl
         headers=authHeaders,
         params=params,
     )
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_fetch_gtfs_feeds_with_incomplete_latitude_in_bounding_box(client: TestClient):
@@ -171,7 +171,7 @@ def test_fetch_gtfs_feeds_with_incomplete_latitude_in_bounding_box(client: TestC
         headers=authHeaders,
         params=params,
     )
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_feeds_gtfs_rt_id_get(client: TestClient):

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -61,35 +61,121 @@ def test_feeds_gtfs_id_get(client: TestClient):
         headers=authHeaders,
     )
 
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
 
 
-def test_feeds_gtfs_rt_get(client: TestClient):
-    """Test case for feeds_gtfs_get"""
+def test_fetch_gtfs_feeds_with_complete_bounding_box_enclosure(client: TestClient):
+    """Test fetching GTFS feeds with a bounding box filter set to 'completely_enclosed', ensuring that feeds strictly
+    within the specified coordinates are fetched."""
+    params = [
+        ("limit", 10),
+        ("offset", 0),
+        ("filter", "status=active"),
+        ("sort", "+provider"),
+        ("dataset_latitudes", "37.6, 38.24"),
+        ("dataset_longitudes", "-84.9,-84.47"),
+        ("bounding_filter_method", "completely_enclosed"),
+    ]
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds",
+        headers=authHeaders,
+        params=params,
+    )
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+
+
+def test_fetch_gtfs_feeds_with_incorrect_filter_method(client: TestClient):
+    """Test fetching GTFS feeds with an incorrectly formatted latitude value for bounding box filter, expecting a 400
+    error due to malformed latitude coordinates."""
 
     params = [
         ("limit", 10),
         ("offset", 0),
         ("filter", "status=active"),
         ("sort", "+provider"),
-        ("bounding_latitudes", "41.46,42.67"),
-        ("bounding_longitudes", "-78.58,-87-29"),
+        ("dataset_latitudes", "37.6, 38.24"),
+        ("dataset_longitudes", "-84.9,-84.47"),
+        ("bounding_filter_method", "incorrect"),
+    ]
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds",
+        headers=authHeaders,
+        params=params,
+    )
+    assert response.status_code == 400
+
+
+def test_fetch_gtfs_feeds_with_incorrect_latitude_for_bounding_box(client: TestClient):
+    """Test fetching GTFS feeds with an incorrectly formatted latitude value for bounding box filter, expecting a 400
+    error due to malformed latitude coordinates."""
+
+    params = [
+        ("limit", 10),
+        ("offset", 0),
+        ("filter", "status=active"),
+        ("sort", "+provider"),
+        ("dataset_latitudes", "41.46"),
+        ("dataset_longitudes", "-78.58,-87-29"),
         ("bounding_filter_method", "completely_enclosed"),
     ]
     response = client.request(
         "GET",
-        "/v1/gtfs_rt_feeds",
+        "/v1/gtfs_feeds",
         headers=authHeaders,
         params=params,
     )
+    assert response.status_code == 400
 
-    # uncomment below to assert the status code of the HTTP response
-    assert response.status_code == 200
+
+def test_fetch_gtfs_feeds_with_malformed_bounding_box_coordinates(client: TestClient):
+    """Test fetching GTFS feeds with incorrectly formatted bounding box coordinates, expecting a 400 error due to
+    malformed longitude and latitude values."""
+
+    params = [
+        ("limit", 10),
+        ("offset", 0),
+        ("filter", "status=active"),
+        ("sort", "+provider"),
+        ("dataset_latitudes", "41.46,42.67"),
+        ("dataset_longitudes", "-78.58,-87-29"),
+        ("bounding_filter_method", "completely_enclosed"),
+    ]
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds",
+        headers=authHeaders,
+        params=params,
+    )
+    assert response.status_code == 400
+
+
+def test_fetch_gtfs_feeds_with_incomplete_latitude_in_bounding_box(client: TestClient):
+    """Test fetching GTFS feeds with an incomplete latitude value in the bounding box filter, expecting a 400 error due
+    to missing latitude information."""
+
+    params = [
+        ("limit", 10),
+        ("offset", 0),
+        ("filter", "status=active"),
+        ("sort", "+provider"),
+        ("dataset_latitudes", "41.46, -"),
+        ("dataset_longitudes", "-78.58,-87-29"),
+        ("bounding_filter_method", "completely_enclosed"),
+    ]
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds",
+        headers=authHeaders,
+        params=params,
+    )
+    assert response.status_code == 400
 
 
 def test_feeds_gtfs_rt_id_get(client: TestClient):
-    """Test case for feeds_gtfs_id_get"""
+    """Test case for feeds_gtfs_rt_id_get"""
     response = client.request(
         "GET",
         "/v1/gtfs_rt_feeds/{id}".format(id=TEST_GTFS_RT_FEED_STABLE_ID),

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -72,7 +72,7 @@ def test_fetch_gtfs_feeds_with_complete_bounding_box_enclosure(client: TestClien
         ("offset", 0),
         ("filter", "status=active"),
         ("sort", "+provider"),
-        ("dataset_latitudes", "37.6, 38.24"),
+        ("dataset_latitudes", "37.6,38.24"),
         ("dataset_longitudes", "-84.9,-84.47"),
         ("bounding_filter_method", "completely_enclosed"),
     ]


### PR DESCRIPTION
**Summary:**
Closes #282 
✅  Added validation for bounding box filters (`dataset_latitudes` and `dataset_longitudes`) --> should be 2 comma separated floats
✅ Fix coverage on integration tests 

**Expected behavior:** 
API returns a `400` status code when the values of the filters does not match proper formatting. 
API returns an empty array if the coordinates are invalid or do not match any stored dataset.

**Testing tips:**
- Checkout branch
- Run api locally
- Use Swagger UI connected to `localhost` to test `/v1/gtfs_feed`
- Test different types of inputs for `dataset_latitudes` and `dataset_longitudes`
- Validate the behavior. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
