### PR TITLE
fix: displayed an alert if no public email provided in Github account; ver…

### DIFF
--- a/web-app/src/app/screens/PostRegistration.tsx
+++ b/web-app/src/app/screens/PostRegistration.tsx
@@ -60,7 +60,7 @@ export default function PostRegistration(): React.ReactElement {
     ) {
       navigateTo(ACCOUNT_TARGET);
     }
-  }, []);
+  }, [userProfileStatus]);
 
   return (
     <Container component='main' maxWidth='sm'>

--- a/web-app/src/app/screens/SignUp.tsx
+++ b/web-app/src/app/screens/SignUp.tsx
@@ -14,7 +14,12 @@ import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 import { useFormik } from 'formik';
 import { useAppDispatch } from '../hooks';
-import { loginFail, loginWithProvider, signUp } from '../store/profile-reducer';
+import {
+  loginFail,
+  loginWithProvider,
+  signUp,
+  verifyEmail,
+} from '../store/profile-reducer';
 import { Alert, IconButton, InputAdornment, Tooltip } from '@mui/material';
 import { useSelector } from 'react-redux';
 import {
@@ -105,7 +110,16 @@ export default function SignUp(): React.ReactElement {
     const provider = oathProviders[oauthProvider];
     signInWithPopup(auth, provider)
       .then((userCredential: UserCredential) => {
-        dispatch(loginWithProvider({ oauthProvider, userCredential }));
+        if (!userCredential.user.emailVerified) {
+          dispatch(verifyEmail());
+        }
+        if (userCredential.user.email == null) {
+          alert(
+            'No public email provided in Github account. Please use a different registration method.',
+          );
+        } else {
+          dispatch(loginWithProvider({ oauthProvider, userCredential }));
+        }
       })
       .catch((error) => {
         dispatch(

--- a/web-app/src/app/screens/SignUp.tsx
+++ b/web-app/src/app/screens/SignUp.tsx
@@ -20,7 +20,13 @@ import {
   signUp,
   verifyEmail,
 } from '../store/profile-reducer';
-import { Alert, IconButton, InputAdornment, Tooltip } from '@mui/material';
+import {
+  Alert,
+  IconButton,
+  InputAdornment,
+  Snackbar,
+  Tooltip,
+} from '@mui/material';
 import { useSelector } from 'react-redux';
 import {
   ACCOUNT_TARGET,
@@ -43,6 +49,7 @@ import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
 export default function SignUp(): React.ReactElement {
   const [showPassword, setShowPassword] = React.useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
+  const [showNoEmailSnackbar, setShowNoEmailSnackbar] = React.useState(false);
 
   const navigateTo = useNavigate();
   const dispatch = useAppDispatch();
@@ -114,9 +121,7 @@ export default function SignUp(): React.ReactElement {
           dispatch(verifyEmail());
         }
         if (userCredential.user.email == null) {
-          alert(
-            'No public email provided in Github account. Please use a different registration method.',
-          );
+          setShowNoEmailSnackbar(true);
         } else {
           dispatch(loginWithProvider({ oauthProvider, userCredential }));
         }
@@ -148,6 +153,23 @@ export default function SignUp(): React.ReactElement {
 
   return (
     <Container component='main' maxWidth='xs'>
+      <Snackbar
+        open={showNoEmailSnackbar}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={() => {
+          setShowNoEmailSnackbar(false);
+        }}
+      >
+        <Alert
+          severity='error'
+          onClose={() => {
+            setShowNoEmailSnackbar(false);
+          }}
+        >
+          No public email provided in Github account. Please use a different
+          registration method.
+        </Alert>
+      </Snackbar>
       <CssBaseline />
       <Box
         sx={{


### PR DESCRIPTION
**Summary:**
Closes #280 
display an alert if user doesn't have public email in GitHub account
<img width="1546" alt="image" src="https://github.com/MobilityData/mobility-feed-api/assets/5789435/7f1df85a-0d9d-4054-80ba-481021039053">
If user has public email in GitHub account, verify email and provide feedback of email verification
<img width="691" alt="image" src="https://github.com/MobilityData/mobility-feed-api/assets/5789435/51f43903-ab55-4a15-b34f-b0a948c6f905">

**Testing tips:**
Case 1: No Public email in GitHub account

- Go to https://github.com/settings/profile
- Public Email section, choose "Select a verified email to display", click update profile button
- goto MobilityDatabase API,  click signup with Github, you should see an alert "No public email provided in Github account. Please use a different registration method." as in screenshot 1.

<img width="629" alt="image" src="https://github.com/MobilityData/mobility-feed-api/assets/5789435/be213524-1b7b-4f78-af82-d9a9bac69943">

Case 2: user has a public email in GitHub account

- go to https://github.com/settings/profile
- Public Email section, choose an email as public email, click update profile button
- goto MobilityDatabase API,  click signup with Github, you should see an message about the status of email verification, either Success or Error, as in screenshot 2.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
