### PR TITLE
fix: Signin with GitHub - show a snackbar if user doesn't have public …

### DIFF
--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -20,7 +20,13 @@ import {
 import { useSelector } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
-import { Alert, IconButton, InputAdornment, Tooltip } from '@mui/material';
+import {
+  Alert,
+  IconButton,
+  InputAdornment,
+  Snackbar,
+  Tooltip,
+} from '@mui/material';
 import '../styles/SignUp.css';
 import {
   selectEmailLoginError,
@@ -41,6 +47,7 @@ export default function SignIn(): React.ReactElement {
   const emailLoginError = useSelector(selectEmailLoginError);
   const [isSubmitted, setIsSubmitted] = React.useState(false);
   const [showPassword, setShowPassword] = React.useState(false);
+  const [showNoEmailSnackbar, setShowNoEmailSnackbar] = React.useState(false);
 
   const SignInSchema = Yup.object().shape({
     email: Yup.string()
@@ -89,7 +96,12 @@ export default function SignIn(): React.ReactElement {
     const provider = oathProviders[oauthProvider];
     signInWithPopup(auth, provider)
       .then((userCredential: UserCredential) => {
-        dispatch(loginWithProvider({ oauthProvider, userCredential }));
+        console.log(userCredential.user);
+        if (userCredential.user.email == null) {
+          setShowNoEmailSnackbar(true);
+        } else {
+          dispatch(loginWithProvider({ oauthProvider, userCredential }));
+        }
       })
       .catch((error) => {
         dispatch(
@@ -104,6 +116,23 @@ export default function SignIn(): React.ReactElement {
 
   return (
     <Container component='main' maxWidth='xs'>
+      <Snackbar
+        open={showNoEmailSnackbar}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={() => {
+          setShowNoEmailSnackbar(false);
+        }}
+      >
+        <Alert
+          severity='error'
+          onClose={() => {
+            setShowNoEmailSnackbar(false);
+          }}
+        >
+          No public email provided in Github account. Please use a different
+          registration method.
+        </Alert>
+      </Snackbar>
       <CssBaseline />
       <Box
         sx={{

--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -130,7 +130,7 @@ export default function SignIn(): React.ReactElement {
           }}
         >
           No public email provided in Github account. Please use a different
-          registration method.
+          login method.
         </Alert>
       </Snackbar>
       <CssBaseline />


### PR DESCRIPTION
Closes #300 

**Summary:**
added a snackbar in Signin screen so that a message show up if user doesn't set public email in Github account.

**Expected behavior:** 
<img width="1593" alt="image" src="https://github.com/MobilityData/mobility-feed-api/assets/5789435/ee10e586-eada-43a5-97de-c0162b86e083">

**Testing tips:**

1. goto GitHub account - Public Profile
2. Don't set a public email
3. Update profile
4. goto Mobility databse API, click signin with Github
5. you should stay in signin screen and see the alert "No public email provided in Github account. Please use a different
          login method."

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
