### PR TITLE
chore: add released type to release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 name: Production Release
 on:
   release:
+    types: [ released ]
 
 jobs:
   bd-deployment:


### PR DESCRIPTION
**Summary:**

This PR fixes the Github trigger release to only released 

**Expected behavior:** 

Release workflow should only be triggered after releases are `released`

**Testing tips:**



Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
