### PR TITLE
fix: Upload integration tests results if tests fail

### DIFF
--- a/.github/workflows/api-dev.yml
+++ b/.github/workflows/api-dev.yml
@@ -9,22 +9,22 @@ on:
         default: 'false'
 
 jobs:
-  api-build-deployment:
-    uses: ./.github/workflows/api-deployer.yml
-    with:
-      ENVIRONMENT: ${{ vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}
-      BUCKET_NAME: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_BUCKET }}
-      OBJECT_PREFIX: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_OBJECT_PREFIX }}
-      PROJECT_ID: ${{ vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}
-      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-      DEPLOYER_SERVICE_ACCOUNT: ${{ vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}
-      FEED_API_IMAGE_VERSION: ${{ github.sha }}
-      GLOBAL_RATE_LIMIT_REQ_PER_MINUTE: ${{ vars.GLOBAL_RATE_LIMIT_REQ_PER_MINUTE }}
-      TF_APPLY: true
-    secrets:
-      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
-      OAUTH2_CLIENT_ID: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_ID}}
-      OAUTH2_CLIENT_SECRET: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_SECRET}}
+#  api-build-deployment:
+#    uses: ./.github/workflows/api-deployer.yml
+#    with:
+#      ENVIRONMENT: ${{ vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}
+#      BUCKET_NAME: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_BUCKET }}
+#      OBJECT_PREFIX: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_OBJECT_PREFIX }}
+#      PROJECT_ID: ${{ vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}
+#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+#      DEPLOYER_SERVICE_ACCOUNT: ${{ vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}
+#      FEED_API_IMAGE_VERSION: ${{ github.sha }}
+#      GLOBAL_RATE_LIMIT_REQ_PER_MINUTE: ${{ vars.GLOBAL_RATE_LIMIT_REQ_PER_MINUTE }}
+#      TF_APPLY: true
+#    secrets:
+#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      OAUTH2_CLIENT_ID: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_ID}}
+#      OAUTH2_CLIENT_SECRET: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_SECRET}}
 
   integration-tests:
     if: ${{ github.event.inputs.run_integration_tests == 'true' }}

--- a/.github/workflows/api-dev.yml
+++ b/.github/workflows/api-dev.yml
@@ -9,28 +9,28 @@ on:
         default: 'false'
 
 jobs:
-#  api-build-deployment:
-#    uses: ./.github/workflows/api-deployer.yml
-#    with:
-#      ENVIRONMENT: ${{ vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}
-#      BUCKET_NAME: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_BUCKET }}
-#      OBJECT_PREFIX: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_OBJECT_PREFIX }}
-#      PROJECT_ID: ${{ vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}
-#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-#      DEPLOYER_SERVICE_ACCOUNT: ${{ vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}
-#      FEED_API_IMAGE_VERSION: ${{ github.sha }}
-#      GLOBAL_RATE_LIMIT_REQ_PER_MINUTE: ${{ vars.GLOBAL_RATE_LIMIT_REQ_PER_MINUTE }}
-#      TF_APPLY: true
-#    secrets:
-#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      OAUTH2_CLIENT_ID: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_ID}}
-#      OAUTH2_CLIENT_SECRET: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_SECRET}}
+  api-build-deployment:
+    uses: ./.github/workflows/api-deployer.yml
+    with:
+      ENVIRONMENT: ${{ vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}
+      BUCKET_NAME: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_BUCKET }}
+      OBJECT_PREFIX: ${{ vars.DEV_MOBILITY_FEEDS_TF_STATE_OBJECT_PREFIX }}
+      PROJECT_ID: ${{ vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}
+      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+      DEPLOYER_SERVICE_ACCOUNT: ${{ vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}
+      FEED_API_IMAGE_VERSION: ${{ github.sha }}
+      GLOBAL_RATE_LIMIT_REQ_PER_MINUTE: ${{ vars.GLOBAL_RATE_LIMIT_REQ_PER_MINUTE }}
+      TF_APPLY: true
+    secrets:
+      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
+      OAUTH2_CLIENT_ID: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_ID}}
+      OAUTH2_CLIENT_SECRET: ${{ secrets.DEV_MOBILITY_FEEDS_OAUTH2_CLIENT_SECRET}}
 
   integration-tests:
     if: ${{ github.event.inputs.run_integration_tests == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
-#    needs:
-#      - api-build-deployment
+    needs:
+      - api-build-deployment
     with:
       API_URL: 'https://api-dev.mobilitydatabase.org'
     secrets:

--- a/.github/workflows/api-dev.yml
+++ b/.github/workflows/api-dev.yml
@@ -29,8 +29,8 @@ jobs:
   integration-tests:
     if: ${{ github.event.inputs.run_integration_tests == 'true' }}
     uses: ./.github/workflows/integration-tests.yml
-    needs:
-      - api-build-deployment
+#    needs:
+#      - api-build-deployment
     with:
       API_URL: 'https://api-dev.mobilitydatabase.org'
     secrets:

--- a/.github/workflows/db-prod.yml
+++ b/.github/workflows/db-prod.yml
@@ -1,4 +1,4 @@
-# Deploys the Mobility Database to the DEV environment
+# Deploys the Mobility Database to the PROD environment
 name: Deploy DB - PROD
 on:
   workflow_dispatch: # Supports manual deployment

--- a/.github/workflows/db-qa.yml
+++ b/.github/workflows/db-qa.yml
@@ -1,4 +1,4 @@
-# Deploys the Mobility Database to the DEV environment
+# Deploys the Mobility Database to the QA environment
 name: Deploy DB - QA
 on:
   workflow_dispatch:  # Supports manual deployment

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,9 +43,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Integration Tests
-      run: |
-        ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
-        exit 1
+      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
       env:
         FILE_PATH: ${{ env.FILE_PATH }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,9 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run Integration Tests
-      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
+      run: |
+        ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
+        exit 1
       env:
         FILE_PATH: ${{ env.FILE_PATH }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,6 +49,7 @@ jobs:
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
 
     - name: Upload Test Logs
+      if: ${{ always() }} # always upload the available logs even if the integration tests failed.
       uses: actions/upload-artifact@v4
       with:
         name: integration-tests-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     needs: bd-deployment
     uses: ./.github/workflows/db-update-prod.yml
     secrets: inherit
-  bash-deployment:
-    name: Bash Processes Deployment
+  batch-deployment:
+    name: Batch Processes Deployment
     needs: bd-update
     uses: ./.github/workflows/datasets-batch-deployer-prod.yml
     secrets: inherit
   api-deployment:
     name: API Deployment
-    needs: bash-deployment
+    needs: batch-deployment
     uses: ./.github/workflows/api-prod.yml
     secrets: inherit
   integration-tests:
@@ -33,6 +33,6 @@ jobs:
       REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}
   web-deployment:
     name: Web Deployment
-    needs: bash-deployment
+    needs: batch-deployment
     uses: ./.github/workflows/web-prod.yml
     secrets: inherit


### PR DESCRIPTION
**Summary:**

Modified GH actions to upload integration tests logs in case of a failure of the tests. That should help to know what went wrong.
This was asked for in https://github.com/MobilityData/mobility-feed-api/issues/319

Also corrected some typos here and there.

**Expected behavior:** 

If the integration tests fail during the api deployment the integration tests results should still be uploaded to Github. 

**Testing tips:**

To test this properly we would need to have the API integration tests fail. 
I tested by introducing an artificial error in integration-tests.yml (added an exit 1). But that requires changes to the codebase then push. This can be done in a throwaway branch.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
