### PR TITLE
fix: onboarding config and readme updates for web-app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,6 +56,7 @@ services:
     command:
       - --url=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_DB}
       - --changeLogFile=changelog.xml
+      - --searchpath=changelog
       - --username=${POSTGRES_USER}
       - --password=${POSTGRES_PASSWORD}
       - --log-level=1
@@ -74,6 +75,7 @@ services:
     command:
       - --url=jdbc:postgresql://postgres-test:${POSTGRES_PORT}/${POSTGRES_DB}Test
       - --changeLogFile=changelog.xml
+      - --searchpath=changelog
       - --username=${POSTGRES_USER}
       - --password=${POSTGRES_PASSWORD}
       - --log-level=1

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -3,6 +3,9 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 Using node v18.16.0 (npm v9.5.1)
 
+## Installing packages
+It is preferred to install the packages using `yarn` over `npm install`
+
 ## Configuration variables
 React scripts can inject all necessary environment variables into the application in development mode and the JS bundle files. 
 Steps to set environment variables:


### PR DESCRIPTION
**Summary:**

When setting up the mobility-feed-api using the readme, I ran into an issue running the command `docker-compose --env-file ./config/.env.local  up -d --force-recreate` where the error was that it couldn't find the changelog.xml. With the help of @davidgamez it was discovered that the file structure changed in liquibase 4.27 and that the solution was to include 'changelog' into the search-path. It was tested on David's machine that this addition did not break the existing functionality

For the addition in the `web-app` if you build the package with `npm install` it will return an error as `react-scripts` seems to not be compatible with the latest typescript (https://github.com/facebook/create-react-app/issues/13080). Installing with `yarn` seems to use smart alternatives to this mismatch

**Expected behavior:** 

Be able to run `docker-compose --env-file ./config/.env.local  up -d --force-recreate` without error when setting up the project as per the readme

**Testing tips:**

Go through the readme and assure that nothing is broken

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [X] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
