### PR TITLE
fix: Feed Search endpoint is returning DB id instead of feed.stable_id for feed_references field

### DIFF
--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -308,3 +308,37 @@ def test_search_feeds_filter_combine_filters_and_query(
                 assert result.status == status
             if data_type:
                 assert result.data_type == data_type
+
+
+def test_search_feeds_filter_reference_id(client: TestClient):
+    """
+    Retrieve feeds combining feed ID, status, data type, and search query.
+    """
+    params = [
+        ("limit", 100),
+        ("offset", 0),
+        ("feed_id", TEST_GTFS_RT_FEED_STABLE_ID),
+    ]
+    headers = {
+        "Authentication": "special-key",
+    }
+    response = client.request(
+        "GET",
+        "/v1/search",
+        headers=headers,
+        params=params,
+    )
+
+    # Assert the status code of the HTTP response
+    assert response.status_code == 200
+
+    # Parse the response body into a Python object
+    response_body = SearchFeeds200Response.parse_obj(response.json())
+
+    assert response_body.total == 1
+    assert len(response_body.results) == 1
+    assert response_body.results[0].id == TEST_GTFS_RT_FEED_STABLE_ID
+    assert response_body.results[0].data_type == "gtfs_rt"
+    assert response_body.results[0].status == "active"
+    assert len(response_body.results[0].feed_references) == 1
+    assert response_body.results[0].feed_references[0] == TEST_GTFS_FEED_STABLE_IDS[0]

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -21,4 +21,5 @@
     <include file="changes/feat_327.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_371.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_360.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_389.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_389.sql
+++ b/liquibase/changes/feat_389.sql
@@ -1,0 +1,97 @@
+-- Droping the materialized view is not possible to edit it
+DROP MATERIALIZED VIEW IF EXISTS FeedSearch;
+
+CREATE MATERIALIZED VIEW FeedSearch AS
+SELECT 
+--feed
+Feed.stable_id as feed_stable_id,
+Feed.id as feed_id,
+Feed.data_type,
+Feed.status,
+Feed.feed_name,
+Feed.note,
+Feed.feed_contact_email,
+--source
+Feed.producer_url,
+Feed.authentication_info_url,
+Feed.authentication_type,
+Feed.api_key_parameter_name,
+Feed.license_url,
+Feed.provider,
+--latest_dataset
+Latest_dataset.id as latest_dataset_id,
+Latest_dataset.hosted_url as latest_dataset_hosted_url,
+Latest_dataset.downloaded_at as latest_dataset_downloaded_at,
+Latest_dataset.bounding_box as latest_dataset_bounding_box,
+Latest_dataset.hash as latest_dataset_hash,
+--external_ids
+ExternalIdJoin.external_ids,
+--redirect_ids
+RedirectingIdJoin.redirect_ids,
+--feed gtfs_rt references
+FeedReferenceJoin.feed_reference_ids,
+-- feed gtfs_rt entities
+EntityTypeFeedJoin.entities,
+--locations
+FeedLocationJoin.locations,
+--full-text searchable document	
+setweight(to_tsvector('english', coalesce(Feed.feed_name, '')), 'C') ||
+setweight(to_tsvector('english', coalesce(Feed.provider, '')), 'C') ||
+COALESCE(setweight(to_tsvector('english', coalesce((FeedLocationJoin.locations #>> '{0,country_code}'), '')), 'A'), '') ||
+COALESCE(setweight(to_tsvector('english', coalesce((FeedLocationJoin.locations #>> '{0,subdivision_name}'), '')), 'A'), '') ||
+COALESCE(setweight(to_tsvector('english', coalesce((FeedLocationJoin.locations #>> '{0,municipality}'), '')), 'A'), '')
+AS DOCUMENT
+FROM FEED
+LEFT JOIN (
+	SELECT *
+	FROM gtfsdataset
+	WHERE latest = true
+) AS Latest_dataset on Latest_dataset.feed_id = Feed.id AND Feed.data_type = 'gtfs'
+LEFT JOIN (
+    SELECT 
+        feed_id, 
+		json_agg(json_build_object('external_id', associated_id, 'source', source)) AS external_ids	
+    FROM externalid
+    GROUP BY feed_id
+) AS ExternalIdJoin ON ExternalIdJoin.feed_id = Feed.id
+LEFT JOIN(
+	SELECT 
+		gtfs_rt_feed_id,
+		array_agg(FeedReferenceJoinInnerQuery.stable_id) as feed_reference_ids
+	FROM FeedReference
+	LEFT JOIN Feed as FeedReferenceJoinInnerQuery on FeedReferenceJoinInnerQuery.id = FeedReference.gtfs_feed_id
+	GROUP BY gtfs_rt_feed_id
+) AS FeedReferenceJoin ON FeedReferenceJoin.gtfs_rt_feed_id = Feed.id AND Feed.data_type = 'gtfs_rt'
+LEFT JOIN (
+    SELECT 
+        target_id, 
+		json_agg(json_build_object('target_id', target_id, 'comment', redirect_comment)) AS redirect_ids		
+    FROM RedirectingId
+    GROUP BY target_id
+) AS RedirectingIdJoin ON RedirectingIdJoin.target_id = Feed.id
+LEFT JOIN (
+    SELECT 
+        LocationFeed.feed_id, 
+		json_agg(json_build_object('country_code', country_code, 'subdivision_name',
+								   subdivision_name, 'municipality', municipality)) AS locations		
+    FROM Location
+	LEFT JOIN LocationFeed on LocationFeed.location_id = Location.id
+    GROUP BY LocationFeed.feed_id
+) AS FeedLocationJoin ON FeedLocationJoin.feed_id = Feed.id
+LEFT JOIN (
+    SELECT 
+        feed_id,
+		array_agg(entity_name) as entities
+    FROM EntityTypeFeed
+    GROUP BY feed_id
+) AS EntityTypeFeedJoin ON EntityTypeFeedJoin.feed_id = Feed.id AND Feed.data_type = 'gtfs_rt'
+;
+
+-- This index allows concurrent refresh on the materialized view avoiding table locks
+CREATE UNIQUE INDEX idx_unique_feed_id ON FeedSearch(feed_id);
+
+-- indices for feedsearch view optimization
+CREATE INDEX feedsearch_document_idx ON FeedSearch USING GIN(document);
+CREATE INDEX feedsearch_feed_stable_id ON FeedSearch(feed_stable_id);
+CREATE INDEX feedsearch_data_type ON FeedSearch(data_type);
+CREATE INDEX feedsearch_status ON FeedSearch(status);

--- a/scripts/docker-localdb-rebuild-data.sh
+++ b/scripts/docker-localdb-rebuild-data.sh
@@ -92,7 +92,7 @@ fi
 if [ "$POPULATE_TEST_DATA" = true ]; then
     # populate test data
     $SCRIPT_PATH/populate-db-test-data.sh
-    printf "\n---------\Completed: populating test data.\n---------\n"
+    printf "\n---------\nCompleted: populating test data.\n---------\n"
 fi
 
 printf "\n---------\nSuccess: Rebuilding the database.\n---------\n"


### PR DESCRIPTION
## Summary:

Update the `FeedSearch` view by replacing the internal feed ID with the stable feed ID.

## Expected behavior:

The feed_references field is populated with stable ids. Find a snipped of a local response below,

```
        {
            "id": "mdb-1628",
            "data_type": "gtfs_rt",
            "status": "active",
............

            "feed_references": [
                "mdb-510"
            ]
        },
```

## Testing tips:

- Checkout the branch
- Execute(**Warning your local database content will be deleted),
```
./scripts/docker-localdb-rebuild-data.sh --populate-db
```
- Execute,
```
./scripts/api-start.sh
```
- Test the search endpoints filtering by gtfs_rt feeds. Example curl command,
```
curl --location 'http://localhost:8080/v1/search?search_query=New%20York&offset=10&limit=5&status=active&data_type=gtfs_rt' \
--header 'Accept: application/json'
```
- Verify that stable IDs in the form `mdb-##` are present in the feed_references arrays.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
