### PR TITLE
feat: add location array to gtfs_rt API response

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,7 +4,7 @@ async-exit-stack==1.0.1
 async-generator==1.10
 certifi==2023.7.22
 chardet==4.0.0
-click==7.1.2
+click==8.0.3
 dnspython==2.1.0
 email-validator==1.1.2
 fastapi==0.94.1
@@ -31,7 +31,7 @@ starlette==0.26.1
 typing-extensions==4.6.1
 ujson==5.4.0
 urllib3==2.0.4
-uvicorn==0.13.4
+uvicorn==0.15.0
 uvloop==0.17.0
 watchgod==0.7
 websockets==10.0

--- a/api/src/feeds/filters/gtfs_rt_feed_filter.py
+++ b/api/src/feeds/filters/gtfs_rt_feed_filter.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 from fastapi_filter.contrib.sqlalchemy import Filter
 
 from database_gen.sqlacodegen_models import Gtfsrealtimefeed, Entitytype
+from feeds.filters.gtfs_feed_filter import LocationFilter
 
 
 class EntityTypeFilter(Filter):
@@ -17,6 +18,7 @@ class GtfsRtFeedFilter(Filter):
     provider__ilike: Optional[str]  # case insensitive
     producer_url__ilike: Optional[str]  # case insensitive
     entity_types: Optional[EntityTypeFilter]
+    location: Optional[LocationFilter]
 
     class Constants(Filter.Constants):
         model = Gtfsrealtimefeed

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -243,6 +243,8 @@ class FeedsApiImpl(BaseFeedsApi):
                 referenced_feed.id == t_feedreference.c.gtfs_feed_id,
                 isouter=True,
             )
+            .join(t_locationfeed, t_locationfeed.c.feed_id == Gtfsrealtimefeed.id, isouter=True)
+            .join(Location, t_locationfeed.c.location_id == Location.id, isouter=True)
             .add_columns(Entitytype.name, referenced_feed.stable_id)
             .order_by(Feed.stable_id)
         )
@@ -394,6 +396,9 @@ class FeedsApiImpl(BaseFeedsApi):
         provider: str,
         producer_url: str,
         entity_types: str,
+        country_code: str,
+        subdivision_name: str,
+        municipality: str,
     ) -> List[GtfsRTFeed]:
         """Get some (or all) GTFS feeds from the Mobility Database."""
         return self._get_gtfs_rt_feeds(
@@ -401,6 +406,11 @@ class FeedsApiImpl(BaseFeedsApi):
                 provider__ilike=provider,
                 producer_url__ilike=producer_url,
                 entity_types=EntityTypeFilter(name__in=entity_types),
+                location=LocationFilter(
+                    country_code=country_code,
+                    subdivision_name__ilike=subdivision_name,
+                    municipality__ilike=municipality,
+                ),
             ),
             limit,
             offset,

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -32,6 +32,7 @@ from feeds.impl.error_handling import (
     gtfs_feed_not_found,
     gtfs_rt_feed_not_found,
 )
+from feeds.impl.models.location_impl import LocationImpl
 from feeds_gen.apis.feeds_api_base import BaseFeedsApi
 from feeds_gen.models.basic_feed import BasicFeed
 from feeds_gen.models.bounding_box import BoundingBox
@@ -271,6 +272,11 @@ class FeedsApiImpl(BaseFeedsApi):
             )
             gtfs_rt_feed.entity_types = {entity_type for entity_type in entity_types if entity_type is not None}
             gtfs_rt_feed.feed_references = {reference for reference in feed_references if reference is not None}
+            gtfs_rt_feed.locations = [
+                LocationImpl.from_orm(location)
+                for location in feed_objects[0].locations
+                if feed_objects[0].locations is not None
+            ]
             gtfs_rt_feeds.append(gtfs_rt_feed)
 
         return gtfs_rt_feeds

--- a/api/src/feeds/impl/models/location_impl.py
+++ b/api/src/feeds/impl/models/location_impl.py
@@ -1,0 +1,22 @@
+from feeds_gen.models.location import Location
+from database_gen.sqlacodegen_models import Location as LocationOrm
+
+
+class LocationImpl(Location):
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True
+
+    @classmethod
+    def from_orm(cls, location: LocationOrm | None) -> Location | None:
+        """Create a model instance from a SQLAlchemy a Location row object."""
+        if not location:
+            return None
+        return cls(
+            country_code=location.country_code,
+            subdivision_name=location.subdivision_name,
+            municipality=location.municipality,
+        )

--- a/api/tests/unittest/models/test_location_impl.py
+++ b/api/tests/unittest/models/test_location_impl.py
@@ -1,0 +1,15 @@
+import unittest
+
+from feeds.impl.models.location_impl import LocationImpl
+from database_gen.sqlacodegen_models import Location as LocationOrm
+from feeds_gen.models.location import Location
+
+
+class TestLocationImpl(unittest.TestCase):
+    def test_from_orm(self):
+        result = LocationImpl.from_orm(
+            LocationOrm(country_code="US", subdivision_name="California", municipality="Los Angeles")
+        )
+        assert result == Location(country_code="US", subdivision_name="California", municipality="Los Angeles")
+
+        assert LocationImpl.from_orm(None) is None

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -377,6 +377,8 @@ components:
               items:
                 type: string
                 example: "mdb-20"
+            locations:
+              $ref: "#/components/schemas/Locations"
 
     BasicFeeds:
       type: array

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -120,6 +120,9 @@ paths:
         - $ref: "#/components/parameters/provider"
         - $ref: "#/components/parameters/producer_url"
         - $ref: "#/components/parameters/entity_types"
+        - $ref: "#/components/parameters/country_code"
+        - $ref: "#/components/parameters/subdivision_name"
+        - $ref: "#/components/parameters/municipality"
       security:
         - Authentication: []
       responses:

--- a/integration-tests/src/endpoints/gtfs_rt_feeds.py
+++ b/integration-tests/src/endpoints/gtfs_rt_feeds.py
@@ -23,7 +23,7 @@ class GTFSRTFeedsEndpointTests(IntegrationTests):
 
     def test_filter_by_country_code_gtfs_rt(self):
         """Test GTFS Realtime feed retrieval filtered by country code"""
-        country_codes = self._sample_country_codes(self.gtfs_feeds, 100)
+        country_codes = self._sample_country_codes(self.gtfs_rt_feeds, 100)
         task_id = self.progress.add_task(
             "[yellow]Validating GTFS Realtime feeds by country code...[/yellow]",
             total=len(country_codes),
@@ -32,7 +32,7 @@ class GTFSRTFeedsEndpointTests(IntegrationTests):
         for i, country_code in enumerate(country_codes):
             self._test_filter_by_country_code(
                 country_code,
-                "v1/gtfs_rt_feeds",
+                "v1/gtfs_rt_feeds?country_code={country_code}",
                 task_id=task_id,
                 index=f"{i + 1}/{len(country_codes)}",
             )
@@ -47,7 +47,7 @@ class GTFSRTFeedsEndpointTests(IntegrationTests):
         for i, municipality in enumerate(municipalities):
             self._test_filter_by_municipality(
                 municipality,
-                "v1/gtfs_rt_feeds",
+                "v1/gtfs_rt_feeds?municipality={municipality}",
                 task_id=task_id,
                 index=f"{i + 1}/{len(municipalities)}",
             )

--- a/integration-tests/src/endpoints/integration_tests.py
+++ b/integration-tests/src/endpoints/integration_tests.py
@@ -37,7 +37,7 @@ class IntegrationTests:
         self.progress = progress
 
     def _test_filter_by_country_code(
-            self, country_code, endpoint, validate_location=False, task_id=None, index="1/1"
+        self, country_code, endpoint, validate_location=False, task_id=None, index="1/1"
     ):
         """Helper function for filtering the response by country code."""
         response = self.get_response(endpoint, params={"country_code": country_code})
@@ -47,7 +47,7 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-                len(feeds) > 0
+            len(feeds) > 0
         ), f"Expected at least one feed with country code '{country_code}', got 0."
         if validate_location:
             for feed in feeds:
@@ -73,8 +73,10 @@ class IntegrationTests:
     def _sample_country_codes(df, n):
         """Helper function for sampling random unique country codes."""
         filtered_country_codes = df["location.country_code"].dropna()
-        filtered_country_codes = filtered_country_codes[filtered_country_codes != '']
-        filtered_country_codes = filtered_country_codes[~filtered_country_codes.str.isnumeric()]
+        filtered_country_codes = filtered_country_codes[filtered_country_codes != ""]
+        filtered_country_codes = filtered_country_codes[
+            ~filtered_country_codes.str.isnumeric()
+        ]
 
         unique_country_codes = filtered_country_codes.unique()
 
@@ -91,16 +93,16 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-                len(feeds) > 0
+            len(feeds) > 0
         ), f"Expected at least one feed with provider '{provider}', got 0."
         for feed in feeds:
             assert (
-                    provider.lower() in feed.get("provider").lower()
+                provider.lower() in feed.get("provider").lower()
             ), f"Expected all feeds to be provided by '{provider}', but found '{feed.get('provider')}'"
         self._update_progression(task_id, f"Validated provider {provider}", index)
 
     def _test_filter_by_municipality(
-            self, municipality, endpoint, validate_location=False, task_id=None, index="1/1"
+        self, municipality, endpoint, validate_location=False, task_id=None, index="1/1"
     ):
         """Helper function for filtering the response by municipality."""
         response = self.get_response(endpoint, params={"municipality": municipality})
@@ -110,7 +112,7 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-                len(feeds) > 0
+            len(feeds) > 0
         ), f"Expected at least one feed with municipality '{municipality}', got 0."
 
         lowercase_municipality = municipality.lower()
@@ -152,8 +154,8 @@ class IntegrationTests:
             method_name
             for method_name in dir(cls)
             if callable(getattr(cls, method_name))
-               and method_name.startswith("test_")
-               and method_name != "test_all"
+            and method_name.startswith("test_")
+            and method_name != "test_all"
         ]
 
     def test_all(self, target_classes=[]):
@@ -197,13 +199,13 @@ class IntegrationTests:
         n_tests = sum(len(methods) for _, methods in test_methods)
 
         with Progress(
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(),
-                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-                TimeElapsedColumn(),
-                console=console,
-                transient=True,
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            console=console,
+            transient=True,
         ) as progress:
             test_task = progress.add_task("[cyan]Running tests...", total=n_tests)
 

--- a/integration-tests/src/endpoints/integration_tests.py
+++ b/integration-tests/src/endpoints/integration_tests.py
@@ -37,7 +37,7 @@ class IntegrationTests:
         self.progress = progress
 
     def _test_filter_by_country_code(
-        self, country_code, endpoint, validate_location=False, task_id=None, index="1/1"
+            self, country_code, endpoint, validate_location=False, task_id=None, index="1/1"
     ):
         """Helper function for filtering the response by country code."""
         response = self.get_response(endpoint, params={"country_code": country_code})
@@ -47,7 +47,7 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-            len(feeds) > 0
+                len(feeds) > 0
         ), f"Expected at least one feed with country code '{country_code}', got 0."
         if validate_location:
             for feed in feeds:
@@ -72,7 +72,11 @@ class IntegrationTests:
     @staticmethod
     def _sample_country_codes(df, n):
         """Helper function for sampling random unique country codes."""
-        unique_country_codes = df["location.country_code"].unique()
+        filtered_country_codes = df["location.country_code"].dropna()
+        filtered_country_codes = filtered_country_codes[filtered_country_codes != '']
+        filtered_country_codes = filtered_country_codes[~filtered_country_codes.str.isnumeric()]
+
+        unique_country_codes = filtered_country_codes.unique()
 
         # Sample min(n, len(unique values)) country codes
         num_samples = min(len(unique_country_codes), n)
@@ -87,16 +91,16 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-            len(feeds) > 0
+                len(feeds) > 0
         ), f"Expected at least one feed with provider '{provider}', got 0."
         for feed in feeds:
             assert (
-                provider.lower() in feed.get("provider").lower()
+                    provider.lower() in feed.get("provider").lower()
             ), f"Expected all feeds to be provided by '{provider}', but found '{feed.get('provider')}'"
         self._update_progression(task_id, f"Validated provider {provider}", index)
 
     def _test_filter_by_municipality(
-        self, municipality, endpoint, validate_location=False, task_id=None, index="1/1"
+            self, municipality, endpoint, validate_location=False, task_id=None, index="1/1"
     ):
         """Helper function for filtering the response by municipality."""
         response = self.get_response(endpoint, params={"municipality": municipality})
@@ -106,7 +110,7 @@ class IntegrationTests:
         )
         feeds = response.json()
         assert (
-            len(feeds) > 0
+                len(feeds) > 0
         ), f"Expected at least one feed with municipality '{municipality}', got 0."
 
         lowercase_municipality = municipality.lower()
@@ -148,8 +152,8 @@ class IntegrationTests:
             method_name
             for method_name in dir(cls)
             if callable(getattr(cls, method_name))
-            and method_name.startswith("test_")
-            and method_name != "test_all"
+               and method_name.startswith("test_")
+               and method_name != "test_all"
         ]
 
     def test_all(self, target_classes=[]):
@@ -193,13 +197,13 @@ class IntegrationTests:
         n_tests = sum(len(methods) for _, methods in test_methods)
 
         with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TimeElapsedColumn(),
-            console=console,
-            transient=True,
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+                TimeElapsedColumn(),
+                console=console,
+                transient=True,
         ) as progress:
             test_task = progress.add_task("[cyan]Running tests...", total=n_tests)
 

--- a/scripts/docker-localdb-rebuild-data.sh
+++ b/scripts/docker-localdb-rebuild-data.sh
@@ -22,6 +22,8 @@
 #       ./docker-localdb-rebuild-data.sh --populate-db
 # Options:
 #       --populate-db: populate the database with the latest csv file
+# Dependencies:
+#      docker, docker-compose, wget
 
 container_name="database"
 target_csv_file="catalogs.csv"
@@ -80,7 +82,7 @@ $SCRIPT_PATH/db-gen.sh
 
 
 if [ "$POPULATE_DB" = true ]; then
-    download the latest csv file and populate the db
+    # download the latest csv file and populate the db
     mkdir $SCRIPT_PATH/../data/
     wget -O $SCRIPT_PATH/../data/$target_csv_file https://bit.ly/catalogs-csv
     # populate db


### PR DESCRIPTION
## Summary:

Add location to API response for GTFS Realtime feeds and to the endpoint parameters.
Closes #380 

## Expected behavior:
Locations field is present in endpoints: v1/gtfs_rt_feeds and v1/gtfs_rt_feeds/{feed_id}

## Testing tips:
- Checkout the branch
- Execute(**Warning your local database content will be deleted**),
```
docker-compose --env-file ./config/.env.local  up -d --force-recreate
scripts/api-gen.sh
scripts/db-gen.sh
```
- Execute,
```
./scripts/api-start.sh
```
- Test the gtfs_rt_feed for individual id endpoint. Example curl command,
```
curl --location 'http://localhost:8080/v1/gtfs_rt_feeds/mdb-1336' \
--header 'Accept: application/json'
```
- Verify that the locations' field is populated
- Test the gtfs_rt_feeds endpoint. Example curl command,
```
curl --location 'http://localhost:8080/v1/gtfs_rt_feeds?key=AIzaSyC8Q08qFJZcSZMctY5ksAXfDSiZkqzi5NA' \
--header 'Accept: application/json'
```
- Verify that the locations' fields are populated

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
