### PR TITLE
fix: Removed duplicate locations returned by gtfs-feeds API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This command is very useful when switching branches that potentially have differ
 ```
 
 - Reset the local database and populate it with the catalog content`(Optional)`
+  - Note: the wget command has to be available.
 ```bash
 ./scripts/docker-localdb-rebuild-data.sh --populate-db
 ```

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ scripts/api-tests.sh <my_test_filename>.py
 Note: the tests rely on having an empty local DB instance. If you have data in your local DB, you can run the following command to reset the DB before running the tests
 ```bash
 ./scripts/docker-localdb-rebuild-data.sh
-````
-```bash
+```
+
 
 ## Running with Docker
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ To run a single test file:
 scripts/api-tests.sh <my_test_filename>.py
 ```
 
+Note: the tests rely on having an empty local DB instance. If you have data in your local DB, you can run the following command to reset the DB before running the tests
+```bash
+./scripts/docker-localdb-rebuild-data.sh
+````
+```bash
+
 ## Running with Docker
 
 Before starting the docker container make sure the OpenApi generated files are present by running:

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -188,15 +188,23 @@ class FeedsApiImpl(BaseFeedsApi):
             redirects_list = [Redirect(target_id=redirect, comment=comment) for redirect, comment in redirects_set]
 
             gtfs_feed = FeedsApiImpl._create_common_feed(feed_objects[0], GtfsFeed, redirects_list, set(external_ids))
+
+            # Iterate over locations and put in a set to eliminate duplicates
+            unique_locations = set()
+            for location in locations:
+                if location is not None:
+                    location_tuple = (location.country_code, location.subdivision_name, location.municipality)
+                    unique_locations.add(location_tuple)
+
             gtfs_feed.locations = [
                 ApiLocation(
-                    country_code=location.country_code,
-                    subdivision_name=location.subdivision_name,
-                    municipality=location.municipality,
+                    country_code=country_code,
+                    subdivision_name=subdivision_name,
+                    municipality=municipality,
                 )
-                for location in locations
-                if location is not None
+                for country_code, subdivision_name, municipality in unique_locations
             ]
+
             latest_dataset, bounding_box = next(
                 filter(
                     lambda dataset: dataset[0] is not None and dataset[1] is not None and dataset[0].latest,

--- a/api/tests/test_datasets_api.py
+++ b/api/tests/test_datasets_api.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from fastapi.testclient import TestClient
 
-from .test_utils.database import TEST_DATASET_STABLE_IDS
+from .test_utils.database import TEST_DATASET_STABLE_IDS, TEST_GTFS_FEED_STABLE_IDS
 from .test_utils.token import authHeaders
 
 
@@ -31,7 +31,7 @@ def test_feeds_gtfs_id_datasets_get(client: TestClient):
     ]
     response = client.request(
         "GET",
-        "/v1/gtfs_feeds/{id}/datasets".format(id=TEST_DATASET_STABLE_IDS[0]),
+        "/v1/gtfs_feeds/{id}/datasets".format(id=TEST_GTFS_FEED_STABLE_IDS[0]),
         headers=authHeaders,
         params=params,
     )


### PR DESCRIPTION
**Summary:**
closes #359 

Removed duplicate locations in the python code.

**Expected behavior:** 

In the case of feeds with more than one dataset, there should be only one location in response.
eg for the test data, a call to 
```
curl -X 'GET' 'http://localhost:8080/v1/gtfs_feeds/mdb-1' -H 'accept: application/json'
```
should give something like:
```
{
  "id": "mdb-1",
  "data_type": "gtfs",
  "status": "inactive",

...

  "locations": [
    {
      "country_code": "US",
      "subdivision_name": "Maine",
      "municipality": "Casco Bay"
    }
  ],
  "latest_dataset": null
}
```

**Testing tips:**

Tested using the [test data](https://github.com/MobilityData/mobility-feed-api/blob/main/api/tests/test_data/test_datasets.json)
`./scripts/docker-localdb-rebuild-data.sh --populate-db --populate-test-db`

In the test data it so happens that mdb-1 has multiple datasets.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
