### PR TITLE
feat: Modify Mobility Database workflow so when new validator version is released, run the validator on all latest datasets

### DIFF
--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -1,0 +1,43 @@
+name: Validator Update
+on:
+  push: # TODO: remove before merge
+  workflow_dispatch:
+  repository_dispatch:
+    types: [gtfs-validator-release, gtfs-validator-update-stg]
+jobs:
+  validator-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Authenticate to Google Cloud (Dev)
+        if: ${{ github.event.action != 'gtfs-validator-release' }}
+        id: gcloud_auth_dev
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
+
+      - name: Authenticate to Google Cloud (Prod)
+        if: ${{ github.event.action == 'gtfs-validator-release' }}
+        id: gcloud_auth_prod
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+
+      - name: GCloud Setup
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set environment variables
+        run: |
+          echo "ENVIRONMENT=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_ENVIRONMENT : vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}" >> $GITHUB_ENV
+          echo "PROJECT_ID=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_PROJECT_ID : vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}" >> $GITHUB_ENV
+          echo "DEPLOYER_SERVICE_ACCOUNT=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT : vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}" >> $GITHUB_ENV
+
+      - name: Create task to run cloud function
+        run: |
+          gcloud tasks create-http-task \
+            --queue=test-queue-2 \
+            --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
+            --schedule-time=$(date -v +1M -u +%Y-%m-%dT%H:%M:%SZ) \
+            --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT}

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -1,6 +1,5 @@
 name: Update validation reports after GTFS Validator has been updated
 on:
-  push: # TODO: remove before merging
   workflow_dispatch: # Supports manual trigger
   repository_dispatch:
     types: [

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -1,6 +1,6 @@
 name: Validator Update
 on:
-  push: # TODO: remove before merge
+  push: # TODO: remove before merging
   workflow_dispatch:
   repository_dispatch:
     types: [gtfs-validator-release, gtfs-validator-update-stg]
@@ -11,28 +11,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Authenticate to Google Cloud (Dev)
-        if: ${{ github.event.action != 'gtfs-validator-release' }}
-        id: gcloud_auth_dev
+      - name: Authenticate to Google Cloud
+        id: gcloud_auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
-
-      - name: Authenticate to Google Cloud (Prod)
-        if: ${{ github.event.action == 'gtfs-validator-release' }}
-        id: gcloud_auth_prod
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+          credentials_json: ${{ github.event.action == 'gtfs-validator-release' && secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY || secrets.DEV_GCP_MOBILITY_FEEDS_SA_KEY }}
 
       - name: GCloud Setup
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Set environment variables
         run: |
-          echo "ENVIRONMENT=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_ENVIRONMENT : vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}" >> $GITHUB_ENV
-          echo "PROJECT_ID=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_PROJECT_ID : vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}" >> $GITHUB_ENV
-          echo "DEPLOYER_SERVICE_ACCOUNT=${{ github.event.action == 'gtfs-validator-release' ? vars.PROD_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT : vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}" >> $GITHUB_ENV
+          echo "ENVIRONMENT=${{ github.event.action == 'gtfs-validator-release' && vars.PROD_MOBILITY_FEEDS_ENVIRONMENT || vars.DEV_MOBILITY_FEEDS_ENVIRONMENT }}" >> $GITHUB_ENV
+          echo "PROJECT_ID=${{ github.event.action == 'gtfs-validator-release' && vars.PROD_MOBILITY_FEEDS_PROJECT_ID || vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}" >> $GITHUB_ENV
+          echo "DEPLOYER_SERVICE_ACCOUNT=${{ github.event.action == 'gtfs-validator-release' && vars.PROD_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT || vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}" >> $GITHUB_ENV
 
       - name: Create task to run cloud function
         run: |

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -31,5 +31,5 @@ jobs:
           gcloud tasks create-http-task \
             --queue=test-queue-2 \
             --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
-            --schedule-time=$(date -v +1M -u +%Y-%m-%dT%H:%M:%SZ) \
+            --schedule-time=$(date -u -d "+5 minutes" +%Y-%m-%dT%H:%M:%SZ) \
             --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT}

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -28,6 +28,8 @@ jobs:
           echo "PROJECT_ID=${{ github.event.action == 'gtfs-validator-release' && vars.PROD_MOBILITY_FEEDS_PROJECT_ID || vars.DEV_MOBILITY_FEEDS_PROJECT_ID }}" >> $GITHUB_ENV
           echo "DEPLOYER_SERVICE_ACCOUNT=${{ github.event.action == 'gtfs-validator-release' && vars.PROD_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT || vars.DEV_MOBILITY_FEEDS_DEPLOYER_SERVICE_ACCOUNT }}" >> $GITHUB_ENV
 
+      # Schedule a task to update the validation report in 24 hours from now to allow runners of the web validator
+      # to be properly updated with the new version of the GTFS Validator
       - name: Create task to run cloud function
         run: |
           gcloud tasks create-http-task \

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -1,9 +1,12 @@
-name: Validator Update
+name: Update validation reports after GTFS Validator has been updated
 on:
   push: # TODO: remove before merging
-  workflow_dispatch:
+  workflow_dispatch: # Supports manual trigger
   repository_dispatch:
-    types: [gtfs-validator-release, gtfs-validator-update-stg]
+    types: [
+      gtfs-validator-release, # Triggered by a release from the Canonical GTFS Validator
+      gtfs-validator-update-stg # Triggered by a merge to `master` in the Canonical GTFS Validator
+    ]
 jobs:
   validator-update:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
       - name: Create task to run cloud function
         run: |
           gcloud tasks create-http-task \
-            --queue=test-queue-2 \
+            --queue=update-validation-report \
             --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
-            --schedule-time=$(date -u -d "+5 minutes" +%Y-%m-%dT%H:%M:%SZ) \
+            --schedule-time=$(date -u -d "+24 hours" +%Y-%m-%dT%H:%M:%SZ) \
             --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT}

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -372,7 +372,7 @@ resource "google_cloud_run_service_iam_member" "extract_bb_cloud_run_invoker" {
 }
 
 # Task queue to invoke update_validation_report function
-resource "google_cloudtasks_queue" "update_validation_report" {
+resource "google_cloud_tasks_queue" "update_validation_report" {
   project = var.project_id
   location = var.gcp_region
   queue = "update-validation-report"

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -370,3 +370,10 @@ resource "google_cloud_run_service_iam_member" "extract_bb_cloud_run_invoker" {
   role           = "roles/run.invoker"
   member         = "serviceAccount:${google_service_account.functions_service_account.email}"
 }
+
+# Task queue to invoke update_validation_report function
+resource "google_cloudtasks_queue" "update_validation_report" {
+  project = var.project_id
+  location = var.gcp_region
+  queue = "update-validation-report"
+}

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -373,7 +373,7 @@ resource "google_cloud_run_service_iam_member" "extract_bb_cloud_run_invoker" {
 
 # Task queue to invoke update_validation_report function
 resource "google_cloud_tasks_queue" "update_validation_report" {
-  project = var.project_id
+  project  = var.project_id
   location = var.gcp_region
-  queue = "update-validation-report"
+  name     = "update-validation-report"
 }

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -372,8 +372,8 @@ resource "google_cloud_run_service_iam_member" "extract_bb_cloud_run_invoker" {
 }
 
 # Task queue to invoke update_validation_report function
-resource "google_cloud_tasks_queue" "update_validation_report" {
+resource "google_cloud_tasks_queue" "update_validation_report_task_queue" {
   project  = var.project_id
   location = var.gcp_region
-  name     = "update-validation-report"
+  name     = "update-validation-report-task-queue"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -52,7 +52,8 @@ locals {
     "cloudbuild.googleapis.com",
     "artifactregistry.googleapis.com",
     "vpcaccess.googleapis.com",
-    "workflows.googleapis.com"
+    "workflows.googleapis.com",
+    "cloudtasks.googleapis.com",
   ]
 }
 

--- a/infra/terraform-init/main.tf
+++ b/infra/terraform-init/main.tf
@@ -229,6 +229,12 @@ resource "google_project_iam_member" "ci_binding_compute_storage_admin" {
   member  = "serviceAccount:${google_service_account.ci_service_account.email}"
 }
 
+resource "google_project_iam_member" "cloud_tasks_admin" {
+  project = var.project_id
+  role    = "roles/cloudtasks.admin"
+  member  = "serviceAccount:${google_service_account.ci_service_account.email}"
+}
+
 resource "google_storage_bucket" "tf_state_bucket" {
   name          = "${var.terraform_state_bucket_name_prefix}-${var.environment}"
   force_destroy = false


### PR DESCRIPTION
**Summary:**

Closes [issue #1746](https://github.com/MobilityData/gtfs-validator/issues/1746). This PR introduces functionality to run an update of the validation report when the GTFS Canonical Validator Web Services are updated.

**Expected Behavior:**

- When the staging environment of the web services is updated, a Cloud Task is created in the `dev` project within the `update-validation-report` queue, set to run 24 hours after the trigger.
- When the GTFS Validator is released, the same process is followed in the production environment.

Working example from `dev`:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/9a6d41b9-a050-469c-a09b-a03da9f4840e)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
