### PR TITLE
fix: latest dataset being null

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -203,12 +203,9 @@ class FeedsApiImpl(BaseFeedsApi):
                 for country_code, subdivision_name, municipality in unique_locations
             ]
 
-            latest_dataset, bounding_box = next(
-                filter(
-                    lambda dataset: dataset[0] is not None and dataset[1] is not None and dataset[0].latest,
-                    zip(datasets, bounding_boxes),
-                ),
-                (None, None),
+            latest_dataset = next(
+                (dataset for dataset in datasets if dataset is not None and dataset.latest),
+                None
             )
             gtfs_feed.latest_dataset = LatestDatasetImpl.from_orm(latest_dataset)
 

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -203,10 +203,7 @@ class FeedsApiImpl(BaseFeedsApi):
                 for country_code, subdivision_name, municipality in unique_locations
             ]
 
-            latest_dataset = next(
-                (dataset for dataset in datasets if dataset is not None and dataset.latest),
-                None
-            )
+            latest_dataset = next((dataset for dataset in datasets if dataset is not None and dataset.latest), None)
             gtfs_feed.latest_dataset = LatestDatasetImpl.from_orm(latest_dataset)
 
             gtfs_feeds.append(gtfs_feed)


### PR DESCRIPTION
**Summary:**
Closes #431 

**Bug Explanation:**
The API code was incorrectly filtering out the latest datasets if their corresponding bounding box was `null`. This issue affected all datasets in `QA` before March. However, after March, all the latest datasets had valid bounding boxes. Ideally, this should have been addressed in February following the merge of #247. Nevertheless, the bug is now fixed. The null bounding boxes investigation should be addressed in a separate issue (#434).

**Testing Instructions:**
- Connect the local API to the QA or DEV database to access datasets.
- Test the `gtfs_feeds` endpoint using a feed with the latest dataset, such as `/v1/gtfs_feeds/mdb-1210` in QA.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
