### PR TITLE
fix: default sort isn't by mdb-id + limit intermittently works

### DIFF
--- a/api/src/database/database.py
+++ b/api/src/database/database.py
@@ -5,7 +5,7 @@ import uuid
 from typing import Type, Callable
 from dotenv import load_dotenv
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import load_only, Query, class_mapper
+from sqlalchemy.orm import load_only, Query, class_mapper, Session
 
 from database_gen.sqlacodegen_models import Base, Feed, Gtfsfeed, Gtfsrealtimefeed
 from sqlalchemy.orm import sessionmaker
@@ -183,6 +183,19 @@ class Database:
         finally:
             if update_session:
                 self.close_session()
+
+    def get_session(self) -> Session:
+        """
+        :return: the current session
+        """
+        return self.session
+
+    def get_query_model(self, model: Type[Base]) -> Query:
+        """
+        :param model: the sqlalchemy model to query
+        :return: the query model
+        """
+        return self.get_session().query(model)
 
     def select_from_active_session(self, model: Base, conditions: list = None, attributes: list = None):
         """

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -291,10 +291,13 @@ class FeedsApiImpl(BaseFeedsApi):
         """Get some (or all) feeds from the Mobility Database."""
         feed_filter = FeedFilter(status=status, provider__ilike=provider, producer_url__ilike=producer_url)
         feed_query = feed_filter.filter(Database().get_query_model(Feed))
+        # Results are sorted by provider
+        feed_query = feed_query.order_by(Feed.provider, Feed.stable_id)
         if limit is not None:
             feed_query = feed_query.limit(limit)
         if offset is not None:
             feed_query = feed_query.offset(offset)
+
         results = feed_query.all()
         return [BasicFeedImpl.from_orm(feed) for feed in results]
 

--- a/api/src/feeds/impl/models/basic_feed_impl.py
+++ b/api/src/feeds/impl/models/basic_feed_impl.py
@@ -1,0 +1,54 @@
+from database_gen.sqlacodegen_models import Feed
+from feeds.impl.models.external_id_impl import ExternalIdImpl
+from feeds.impl.models.redirect_impl import RedirectImpl
+from feeds_gen.models.basic_feed import BasicFeed
+from feeds_gen.models.source_info import SourceInfo
+
+
+class BaseFeedImpl(BasicFeed):
+    """Base implementation of the feeds models.
+    This class converts a SQLAlchemy row DB object with common feed fields to a Pydantic model.
+    """
+
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True
+
+    @classmethod
+    def from_orm(cls, feed: Feed | None) -> BasicFeed | None:
+        if not feed:
+            return None
+        return cls(
+            id=feed.stable_id,
+            data_type=feed.data_type,
+            status=feed.status,
+            external_ids=[ExternalIdImpl.from_orm(item) for item in feed.externalids],
+            provider=feed.provider,
+            feed_name=feed.feed_name,
+            note=feed.note,
+            feed_contact_email=feed.feed_contact_email,
+            source_info=SourceInfo(
+                producer_url=feed.producer_url,
+                authentication_type=feed.authentication_type,
+                authentication_info_url=feed.authentication_info_url,
+                api_key_parameter_name=feed.api_key_parameter_name,
+                license_url=feed.license_url,
+            ),
+            redirects=[RedirectImpl.from_orm(item) for item in feed.redirectingids],
+        )
+
+
+class BasicFeedImpl(BaseFeedImpl, BasicFeed):
+    """Implementation of the `BasicFeed` model.
+    This class converts a SQLAlchemy row DB object to a Pydantic model.
+    """
+
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True

--- a/api/src/feeds/impl/models/bounding_box_impl.py
+++ b/api/src/feeds/impl/models/bounding_box_impl.py
@@ -22,7 +22,7 @@ class BoundingBoxImpl(BoundingBox):
         if geometry_value is None or geometry_value.data is None:
             return None
         shape = to_shape(geometry_value)
-        return BoundingBox(
+        return BoundingBoxImpl(
             minimum_latitude=shape.bounds[1],
             maximum_latitude=shape.bounds[3],
             minimum_longitude=shape.bounds[0],

--- a/api/src/feeds/impl/models/external_id_impl.py
+++ b/api/src/feeds/impl/models/external_id_impl.py
@@ -1,0 +1,24 @@
+from database_gen.sqlacodegen_models import Externalid
+from feeds_gen.models.external_id import ExternalId
+
+
+class ExternalIdImpl(ExternalId):
+    """Implementation of the `ExternalId` model.
+    This class converts a SQLAlchemy row DB object to a Pydantic model.
+    """
+
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True
+
+    @classmethod
+    def from_orm(cls, external_id: Externalid | None) -> ExternalId | None:
+        if not external_id:
+            return None
+        return cls(
+            external_id=external_id.associated_id,
+            source=external_id.source,
+        )

--- a/api/src/feeds/impl/models/gtfs_feed_impl.py
+++ b/api/src/feeds/impl/models/gtfs_feed_impl.py
@@ -1,0 +1,31 @@
+from database_gen.sqlacodegen_models import Gtfsfeed as GtfsfeedOrm
+from feeds.impl.models.basic_feed_impl import BaseFeedImpl
+from feeds.impl.models.latest_dataset_impl import LatestDatasetImpl
+from feeds.impl.models.location_impl import LocationImpl
+from feeds_gen.models.gtfs_feed import GtfsFeed
+
+
+class GtfsFeedImpl(BaseFeedImpl, GtfsFeed):
+    """Implementation of the `GtfsFeed` model.
+    This class converts a SQLAlchemy row DB object to a Pydantic model.
+    """
+
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True
+
+    @classmethod
+    def from_orm(cls, feed: GtfsfeedOrm | None) -> GtfsFeed | None:
+        gtfs_feed = super().from_orm(feed)
+        if not gtfs_feed:
+            return None
+        gtfs_feed.locations = [LocationImpl.from_orm(item) for item in feed.locations]
+
+        latest_dataset = next(
+            (dataset for dataset in feed.gtfsdatasets if dataset is not None and dataset.latest), None
+        )
+        gtfs_feed.latest_dataset = LatestDatasetImpl.from_orm(latest_dataset)
+        return gtfs_feed

--- a/api/src/feeds/impl/models/redirect_impl.py
+++ b/api/src/feeds/impl/models/redirect_impl.py
@@ -1,0 +1,24 @@
+from database_gen.sqlacodegen_models import Redirectingid
+from feeds_gen.models.redirect import Redirect
+
+
+class RedirectImpl(Redirect):
+    """Implementation of the `Redirect` model.
+    This class converts a SQLAlchemy row DB object to a Pydantic model.
+    """
+
+    class Config:
+        """Pydantic configuration.
+        Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
+
+        from_attributes = True
+        orm_mode = True
+
+    @classmethod
+    def from_orm(cls, redirect: Redirectingid | None) -> Redirect | None:
+        if not redirect:
+            return None
+        return cls(
+            target_id=redirect.target_id,
+            comment=redirect.redirect_comment,
+        )

--- a/api/tests/test_database.py
+++ b/api/tests/test_database.py
@@ -108,7 +108,10 @@ def test_merge_gtfs_feed(test_database):
     assert feed_1 is not None
 
     assert feed_1.latest_dataset.id == TEST_DATASET_STABLE_IDS[1]
-    assert sorted([redirect.target_id for redirect in feed_1.redirects]) == [TEST_GTFS_FEED_STABLE_IDS[1]]
+    assert sorted([redirect.target_id for redirect in feed_1.redirects]) == [
+        TEST_GTFS_FEED_STABLE_IDS[1],
+        TEST_GTFS_FEED_STABLE_IDS[2],
+    ]
 
     assert feed_2 is not None
 

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -37,6 +37,7 @@ def test_feeds_get(client: TestClient):
 
     assert response.status_code == 200
 
+
 def test_feeds_get_with_limit_and_offset(client: TestClient):
     params = [
         ("limit", 5),

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -41,7 +41,7 @@ def test_feeds_get(client: TestClient):
 def test_feeds_get_with_limit_and_offset(client: TestClient):
     params = [
         ("limit", 5),
-        ("offset", 1),
+        ("offset", 0),
         ("filter", "status=active"),
         ("sort", "+provider"),
     ]

--- a/api/tests/test_feeds_api.py
+++ b/api/tests/test_feeds_api.py
@@ -37,6 +37,23 @@ def test_feeds_get(client: TestClient):
 
     assert response.status_code == 200
 
+def test_feeds_get_with_limit_and_offset(client: TestClient):
+    params = [
+        ("limit", 5),
+        ("offset", 1),
+        ("filter", "status=active"),
+        ("sort", "+provider"),
+    ]
+    response = client.request(
+        "GET",
+        "/v1/feeds",
+        headers=authHeaders,
+        params=params,
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 5
+
 
 def test_feeds_gtfs_get(client: TestClient):
     """Test case for feeds_gtfs_get"""

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -171,6 +171,21 @@ def populate_database(db: Database):
                 f"VALUES ('{gtfs_feed_ids[0]}', '{gtfs_feed_ids[1]}')"
             )
         )
+
+        db.session.execute(
+            text(
+                f"INSERT INTO redirectingid (source_id, target_id) "
+                f"VALUES ('{gtfs_feed_ids[0]}', '{gtfs_feed_ids[1]}')"
+            )
+        )
+
+        db.session.execute(
+            text(
+                f"INSERT INTO redirectingid (source_id, target_id) "
+                f"VALUES ('{gtfs_feed_ids[1]}', '{gtfs_feed_ids[2]}')"
+            )
+        )
+
         db.session.execute(
             text(
                 f"INSERT INTO redirectingid (source_id, target_id) "

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -175,7 +175,7 @@ def populate_database(db: Database):
         db.session.execute(
             text(
                 f"INSERT INTO redirectingid (source_id, target_id) "
-                f"VALUES ('{gtfs_feed_ids[0]}', '{gtfs_feed_ids[1]}')"
+                f"VALUES ('{gtfs_feed_ids[0]}', '{gtfs_feed_ids[2]}')"
             )
         )
 
@@ -186,12 +186,6 @@ def populate_database(db: Database):
             )
         )
 
-        db.session.execute(
-            text(
-                f"INSERT INTO redirectingid (source_id, target_id) "
-                f"VALUES ('{gtfs_feed_ids[1]}', '{gtfs_feed_ids[2]}')"
-            )
-        )
         db.session.execute(
             text(
                 f"INSERT INTO redirectingid "

--- a/api/tests/unittest/models/test_basic_feed_impl.py
+++ b/api/tests/unittest/models/test_basic_feed_impl.py
@@ -1,0 +1,146 @@
+import copy
+import unittest
+from datetime import datetime
+
+from database_gen.sqlacodegen_models import (
+    Feed,
+    Externalid,
+    Location,
+    Gtfsdataset,
+    Validationreport,
+    Redirectingid,
+    Feature,
+)
+from feeds.impl.models.basic_feed_impl import BasicFeedImpl
+from feeds.impl.models.external_id_impl import ExternalIdImpl
+from feeds_gen.models.redirect import Redirect
+from feeds_gen.models.source_info import SourceInfo
+
+feed_orm = Feed(
+    id="id",
+    data_type="data_type",
+    feed_name="feed_name",
+    note="note",
+    producer_url="producer_url",
+    authentication_type=1,
+    authentication_info_url="authentication_info_url",
+    api_key_parameter_name="api_key_parameter_name",
+    license_url="license_url",
+    stable_id="stable_id",
+    status="status",
+    feed_contact_email="feed_contact_email",
+    provider="provider",
+    locations=[
+        Location(
+            id="id",
+            country_code="country_code",
+            subdivision_name="subdivision_name",
+            municipality="municipality",
+        )
+    ],
+    externalids=[
+        Externalid(
+            feed_id="feed_id",
+            associated_id="associated_id",
+            source="source",
+        )
+    ],
+    gtfsdatasets=[
+        Gtfsdataset(
+            id="id",
+            stable_id="stable_id",
+            feed_id="feed_id",
+            hosted_url="hosted_url",
+            note="note",
+            downloaded_at="downloaded_at",
+            hash="hash",
+            bounding_box="bounding_box",
+            validation_reports=[
+                Validationreport(
+                    id="id",
+                    validator_version="validator_version",
+                    validated_at=datetime(year=2022, month=12, day=31, hour=13, minute=45, second=56),
+                    html_report="html_report",
+                    json_report="json_report",
+                    features=[Feature(name="feature")],
+                    notices=[],
+                )
+            ],
+        )
+    ],
+    redirectingids=[
+        Redirectingid(
+            source_id="source_id",
+            target_id="target_id",
+            redirect_comment="redirect_comment",
+        )
+    ],
+)
+
+expected_base_feed_result = BasicFeedImpl(
+    id="stable_id",
+    data_type="data_type",
+    status="status",
+    external_ids=[ExternalIdImpl(external_id="associated_id", source="source")],
+    provider="provider",
+    feed_name="feed_name",
+    note="note",
+    feed_contact_email="feed_contact_email",
+    source_info=SourceInfo(
+        producer_url="producer_url",
+        authentication_type=1,
+        authentication_info_url="authentication_info_url",
+        api_key_parameter_name="api_key_parameter_name",
+        license_url="license_url",
+    ),
+    redirects=[
+        Redirect(
+            target_id="target_id",
+            comment="redirect_comment",
+        )
+    ],
+)
+
+
+class TestBasicFeedImpl(unittest.TestCase):
+    """Test the `BasicFeedImpl` model."""
+
+    def test_from_orm_all_fields(self):
+        """Test the `from_orm` method with all fields."""
+        result = BasicFeedImpl.from_orm(feed_orm)
+        assert result == expected_base_feed_result
+
+    def test_from_orm_empty_fields(self):
+        """Test the `from_orm` method with not provided fields."""
+        # Test with empty fields and None values
+        # No error should be raised
+        target_feed_orm = copy.deepcopy(feed_orm)
+        target_feed_orm.feed_name = ""
+        target_feed_orm.provider = None
+        target_feed_orm.externalids = []
+        target_feed_orm.redirectingids = []
+
+        target_expected_base_feed_result = copy.deepcopy(expected_base_feed_result)
+        target_expected_base_feed_result.feed_name = ""
+        target_expected_base_feed_result.provider = None
+        target_expected_base_feed_result.external_ids = []
+        target_expected_base_feed_result.redirects = []
+
+        result = BasicFeedImpl.from_orm(target_feed_orm)
+        assert result == target_expected_base_feed_result
+
+        # Test all None values
+        # No error should be raised
+        # Resulting list must be empty and not None
+        empty_feed_orm = Feed()
+        expected_empty_feed = BasicFeedImpl(
+            external_ids=[],
+            redirects=[],
+            source_info=SourceInfo(),
+        )
+        empty_result = BasicFeedImpl.from_orm(empty_feed_orm)
+        assert empty_result == expected_empty_feed
+
+    def test_from_orm_none(self):
+        """Test the `from_orm` method with None."""
+        assert BasicFeedImpl.from_orm(None) is None

--- a/api/tests/unittest/models/test_external_id_impl.py
+++ b/api/tests/unittest/models/test_external_id_impl.py
@@ -1,0 +1,41 @@
+import unittest
+
+from database_gen.sqlacodegen_models import Externalid
+from feeds.impl.models.external_id_impl import ExternalIdImpl
+
+external_id_orm = Externalid(
+    feed_id="feed_id",
+    associated_id="associated_id",
+    source="source",
+)
+
+expected_external_id = ExternalIdImpl(
+    external_id="associated_id",
+    source="source",
+)
+
+
+class TestExternalIdImpl(unittest.TestCase):
+    """Test the `ExternalIdImpl` model."""
+
+    def test_external_id_impl(self):
+        assert ExternalIdImpl.from_orm(external_id_orm) == expected_external_id
+
+    def test_external_id_impl_none_empty(self):
+        """Test the `from_orm` method with empty and none value fields."""
+        external_id_orm_empty = Externalid(
+            feed_id="feed_id",
+            associated_id="",
+            source=None,
+        )
+
+        expected_external_id_empty = ExternalIdImpl(
+            external_id="",
+            source=None,
+        )
+
+        assert ExternalIdImpl.from_orm(external_id_orm_empty) == expected_external_id_empty
+
+    def test_external_id_impl_none(self):
+        """Test the `from_orm` method with None."""
+        assert ExternalIdImpl.from_orm(None) is None

--- a/api/tests/unittest/models/test_gtfs_feed_impl.py
+++ b/api/tests/unittest/models/test_gtfs_feed_impl.py
@@ -1,0 +1,193 @@
+import copy
+import unittest
+from datetime import datetime
+
+from geoalchemy2 import WKTElement
+
+from database_gen.sqlacodegen_models import (
+    Redirectingid,
+    Feature,
+    Validationreport,
+    Gtfsdataset,
+    Externalid,
+    Location,
+    Gtfsfeed,
+    Gtfsrealtimefeed,
+    Entitytype,
+    Notice,
+)
+from feeds.impl.models.bounding_box_impl import BoundingBoxImpl
+from feeds.impl.models.external_id_impl import ExternalIdImpl
+from feeds.impl.models.gtfs_feed_impl import GtfsFeedImpl
+from feeds.impl.models.latest_dataset_impl import LatestDatasetImpl
+from feeds.impl.models.location_impl import LocationImpl
+from feeds.impl.models.redirect_impl import RedirectImpl
+from feeds_gen.models.latest_dataset_validation_report import LatestDatasetValidationReport
+from feeds_gen.models.source_info import SourceInfo
+
+POLYGON = "POLYGON ((3.0 1.0, 4.0 1.0, 4.0 2.0, 3.0 2.0, 3.0 1.0))"
+
+
+def create_test_notice(notice_code: str, total_notices: int, severity: str):
+    return Notice(
+        dataset_id="dataset_id",
+        validation_report_id="validation_report_id",
+        notice_code=notice_code,
+        total_notices=total_notices,
+        severity=severity,
+    )
+
+
+gtfs_feed_orm = Gtfsfeed(
+    id="id",
+    data_type="data_type",
+    feed_name="feed_name",
+    note="note",
+    producer_url="producer_url",
+    authentication_type=1,
+    authentication_info_url="authentication_info_url",
+    api_key_parameter_name="api_key_parameter_name",
+    license_url="license_url",
+    stable_id="stable_id",
+    status="status",
+    feed_contact_email="feed_contact_email",
+    provider="provider",
+    locations=[
+        Location(
+            id="id",
+            country_code="country_code",
+            subdivision_name="subdivision_name",
+            municipality="municipality",
+        )
+    ],
+    externalids=[
+        Externalid(
+            feed_id="feed_id",
+            associated_id="associated_id",
+            source="source",
+        )
+    ],
+    gtfsdatasets=[
+        Gtfsdataset(
+            id="id",
+            stable_id="dataset_stable_id",
+            feed_id="feed_id",
+            hosted_url="hosted_url",
+            note="note",
+            downloaded_at=datetime(year=2022, month=12, day=31, hour=13, minute=45, second=56),
+            hash="hash",
+            bounding_box=WKTElement(POLYGON, srid=4326),
+            latest=True,
+            validation_reports=[
+                Validationreport(
+                    id="id",
+                    validator_version="validator_version",
+                    validated_at=datetime(year=2022, month=12, day=31, hour=13, minute=45, second=56),
+                    html_report="html_report",
+                    json_report="json_report",
+                    features=[Feature(name="feature")],
+                    notices=[
+                        create_test_notice("notice_code1", 1, "INFO"),
+                        create_test_notice("notice_code2", 3, "INFO"),
+                        create_test_notice("notice_code3", 7, "ERROR"),
+                        create_test_notice("notice_code4", 9, "ERROR"),
+                        create_test_notice("notice_code5", 11, "ERROR"),
+                        create_test_notice("notice_code6", 13, "WARNING"),
+                        create_test_notice("notice_code7", 15, "WARNING"),
+                        create_test_notice("notice_code8", 17, "WARNING"),
+                        create_test_notice("notice_code9", 19, "WARNING"),
+                    ],
+                )
+            ],
+        )
+    ],
+    redirectingids=[
+        Redirectingid(
+            source_id="source_id",
+            target_id="target_id",
+            redirect_comment="redirect_comment",
+        )
+    ],
+    gtfs_rt_feeds=[
+        Gtfsrealtimefeed(
+            id="id",
+            entitytypes=[Entitytype(name="entitytype")],
+        )
+    ],
+)
+
+expected_gtfs_feed_result = GtfsFeedImpl(
+    id="stable_id",
+    data_type="data_type",
+    status="status",
+    external_ids=[ExternalIdImpl(external_id="associated_id", source="source")],
+    provider="provider",
+    feed_name="feed_name",
+    note="note",
+    feed_contact_email="feed_contact_email",
+    source_info=SourceInfo(
+        producer_url="producer_url",
+        authentication_type=1,
+        authentication_info_url="authentication_info_url",
+        api_key_parameter_name="api_key_parameter_name",
+        license_url="license_url",
+    ),
+    redirects=[
+        RedirectImpl(
+            target_id="target_id",
+            comment="redirect_comment",
+        )
+    ],
+    locations=[
+        LocationImpl(
+            country_code="country_code",
+            subdivision_name="subdivision_name",
+            municipality="municipality",
+        )
+    ],
+    latest_dataset=LatestDatasetImpl(
+        id="dataset_stable_id",
+        hosted_url="hosted_url",
+        bounding_box=BoundingBoxImpl(
+            minimum_latitude=1.0, maximum_latitude=2.0, minimum_longitude=3.0, maximum_longitude=4.0
+        ),
+        downloaded_at=datetime(year=2022, month=12, day=31, hour=13, minute=45, second=56),
+        hash="hash",
+        validation_report=LatestDatasetValidationReport(
+            total_error=27,
+            total_warning=64,
+            total_info=4,
+            unique_error_count=3,
+            unique_warning_count=4,
+            unique_info_count=2,
+        ),
+    ),
+)
+
+
+class TestGtfsFeedImpl(unittest.TestCase):
+    """Test the `GtfsFeedImpl` model."""
+
+    def test_from_orm_all_fields(self):
+        """Test the `from_orm` method with all fields."""
+        result = GtfsFeedImpl.from_orm(gtfs_feed_orm)
+        assert result == expected_gtfs_feed_result
+
+    def test_from_orm_empty_fields(self):
+        """Test the `from_orm` method with not provided fields."""
+        # Test with empty fields and None values
+        # No error should be raised
+        target_feed_orm = copy.deepcopy(gtfs_feed_orm)
+        target_feed_orm.feed_name = ""
+        target_feed_orm.provider = None
+        target_feed_orm.externalids = []
+        target_feed_orm.redirectingids = []
+
+        target_expected_gtfs_feed_result = copy.deepcopy(expected_gtfs_feed_result)
+        target_expected_gtfs_feed_result.feed_name = ""
+        target_expected_gtfs_feed_result.provider = None
+        target_expected_gtfs_feed_result.external_ids = []
+        target_expected_gtfs_feed_result.redirects = []
+
+        result = GtfsFeedImpl.from_orm(target_feed_orm)
+        assert result == target_expected_gtfs_feed_result

--- a/api/tests/unittest/models/test_redirect_id_impl.py
+++ b/api/tests/unittest/models/test_redirect_id_impl.py
@@ -1,0 +1,42 @@
+import unittest
+
+from database_gen.sqlacodegen_models import Redirectingid
+from feeds.impl.models.redirect_impl import RedirectImpl
+
+redirect_orm = Redirectingid(
+    source_id="source_id",
+    target_id="target_id",
+    redirect_comment="comment",
+)
+
+expected_redirect = RedirectImpl(
+    target_id="target_id",
+    comment="comment",
+)
+
+
+class TestRedirectImpl(unittest.TestCase):
+    """Test the `RedirectImpl` model."""
+
+    def test_redirect_impl(self):
+        assert RedirectImpl.from_orm(redirect_orm) == expected_redirect
+
+    def test_redirect_impl_none_empty(self):
+        """Test the `from_orm` method with empty and none value fields."""
+        redirect_orm_empty = Redirectingid(
+            source_id="",
+            target_id="",
+            redirect_comment=None,
+        )
+
+        expected_redirect_empty = RedirectImpl(
+            source_id="",
+            target_id="",
+            comment=None,
+        )
+
+        assert RedirectImpl.from_orm(redirect_orm_empty) == expected_redirect_empty
+
+    def test_redirect_impl_none(self):
+        """Test the `from_orm` method with None."""
+        assert RedirectImpl.from_orm(None) is None

--- a/api/tests/unittest/test_feeds.py
+++ b/api/tests/unittest/test_feeds.py
@@ -1,8 +1,8 @@
 import copy
 import json
+from unittest.mock import Mock
 
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Query
 
 from database.database import Database
 from database_gen.sqlacodegen_models import Feed, Externalid, Location, Gtfsdataset, Redirectingid
@@ -62,7 +62,10 @@ def test_feeds_get(client: TestClient, mocker):
     Unit test for get_feeds
     """
     mock_filter = mocker.patch.object(FeedFilter, "filter")
-    mock_filter_offset = mock_filter.return_value.offset.return_value = mocker.patch.object(Query, "offset")
+    mock_filter_offset = Mock()
+    mock_filter_order_by = Mock()
+    mock_filter.return_value.order_by.return_value = mock_filter_order_by
+    mock_filter_order_by.offset.return_value = mock_filter_offset
     mock_feed_2 = copy.deepcopy(mock_feed)
     mock_feed_2.stable_id = "test_id_2"
     mock_filter_offset.all.return_value = [mock_feed, mock_feed_2]

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -37,7 +37,7 @@ tags:
 paths:
   /v1/feeds:
     get:
-      description: Get some (or all) feeds from the Mobility Database.
+      description: Get some (or all) feeds from the Mobility Database. The items are sorted by provider in alphabetical ascending order.
       tags:
         - "feeds"
       operationId: getFeeds

--- a/scripts/docker-localdb-rebuild-data.sh
+++ b/scripts/docker-localdb-rebuild-data.sh
@@ -36,7 +36,7 @@ display_usage() {
   echo "Usage: $0 [options]"
   echo "Options:"
   echo "  --populate-db <TEST_FILE>   Populate the database with the latest csv file."
-  echo "  --populate-test-data <FOLDER>   Populate the database with the test data."
+  echo "  --populate-test-data  Populate the database with the test data."
   echo "  --help                    Display help content."
   exit 1
 }


### PR DESCRIPTION
## Summary:

This PR fixes the limit and offsets issues for endpoints `feeds`. The _"previous"_ implementation uses joins to bring entities from related tables. As there are a couple of x-to-many relations, the resulting data contained multiple rows from the same feed. Example datasets, locations, and redirects. One solution explorer was to apply limits and offsets in memory, but it was discarded due to the inefficiency of loading data upfront and making it hard to apply sorting. 
The solution proposed in the PR removes the need for joins, as Alchemy 2.x will do the join and load data when necessary. This makes the implementation simpler, see snipped below to follow a general pattern:
```python
# Create query filter
        feed_filter = FeedFilter(status=status, provider__ilike=provider, producer_url__ilike=producer_url)
# Base query with just the entity type
        feed_query = feed_filter.filter(Database().get_query_model(Feed))
# Apply limit and offset to the query. At this point, no data is retrieved yet, this is just a query change
        if limit is not None:
            feed_query = feed_query.limit(limit)
        if offset is not None:
            feed_query = feed_query.offset(offset)
# Retrieve all data applying limit, offset, and filters at database level
        results = feed_query.all()
# Use transformers to get the API response from the ORM instances
        return [BasicFeedImpl.from_orm(feed) for feed in results]
```
 As a side effect the refactor affected `feeds/:id`, this endpoint need to be tested too.
 As part of this PR the `v1/feeds` response is sorted by provider and stable_id.

## Observations
 Cases like the [latest_dataset transformation](https://github.com/MobilityData/mobility-feed-api/blob/8b650e6ac0c79c73d65812a94cb601f33f7b3c50/api/src/feeds/impl/models/gtfs_feed_impl.py#L27) might be a performance risk, as the code iterates over all datasets to filter the latest one.  This is done as the transformers don't have access to the DB and only transform what is provided in the `from_orm` function's parameter. Let's monitor this and make future changes to optimize it.  We need to keep a balance between easy-to-implement solutions and performance optimization.

Part of: #445 

## Out of Scope
 - `/v1/gtfs_feeds`
 - `v1/gtfs_rt_feeds`

**Expected behavior:** 

The limit parameter works as expected. 

**Testing tips:**

 Local testing:
- Setup your local DB and add multiple datasets to multiple feeds.
- Execute:
```
curl --location 'http://localhost:8080/v1/feeds?limit=10' \
--header 'Accept: application/json'
```
- Expect the limit parameter to be respected
- Test with multiple combinations of limit and offset parameters

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
