### PR TITLE
fix: feature flag 'feeds' page

### DIFF
--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -22,10 +22,10 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import LogoutIcon from '@mui/icons-material/Logout';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import {
-  navigationItems,
   navigationAccountItem,
   SIGN_IN_TARGET,
   ACCOUNT_TARGET,
+  buildNavigationItems
 } from '../constants/Navigation';
 import type NavigationItem from '../interface/Navigation';
 import { useNavigate } from 'react-router-dom';
@@ -38,13 +38,15 @@ import { TreeView } from '@mui/x-tree-view/TreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { OpenInNew } from '@mui/icons-material';
 import '../styles/Header.css';
+import { useRemoteConfig } from '../context/RemoteConfigProvider';
 
 const drawerWidth = 240;
 const websiteTile = 'Mobility Database';
 const DrawerContent: React.FC<{
   onLogoutClick: React.MouseEventHandler;
   onNavigationClick: (target: NavigationItem | string) => void;
-}> = ({ onLogoutClick, onNavigationClick }) => {
+  navigationItems: NavigationItem[];
+}> = ({ onLogoutClick, onNavigationClick, navigationItems }) => {
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const navigateTo = useNavigate();
   return (
@@ -144,6 +146,12 @@ const DrawerContent: React.FC<{
 export default function DrawerAppBar(): React.ReactElement {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [openDialog, setOpenDialog] = React.useState(false);
+  const [navigationItems, setNavigationItems] = React.useState<NavigationItem[]>([]);
+  const { config } = useRemoteConfig();
+
+  React.useEffect(() => {
+    setNavigationItems(buildNavigationItems(config))
+  }, [config]);
 
   const navigateTo = useNavigate();
   const isAuthenticated = useSelector(selectIsAuthenticated);
@@ -299,6 +307,7 @@ export default function DrawerAppBar(): React.ReactElement {
           <DrawerContent
             onLogoutClick={handleLogoutClick}
             onNavigationClick={handleNavigation}
+            navigationItems={navigationItems}
           />
         </Drawer>
       </nav>

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -245,7 +245,7 @@ export default function DrawerAppBar(): React.ReactElement {
                 onClick={() => {
                   handleNavigation(item);
                 }}
-                variant={item.variant}
+                variant={'text'}
                 endIcon={item.external === true ? <OpenInNew /> : null}
               >
                 {item.title}

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -25,7 +25,7 @@ import {
   navigationAccountItem,
   SIGN_IN_TARGET,
   ACCOUNT_TARGET,
-  buildNavigationItems
+  buildNavigationItems,
 } from '../constants/Navigation';
 import type NavigationItem from '../interface/Navigation';
 import { useNavigate } from 'react-router-dom';
@@ -146,11 +146,13 @@ const DrawerContent: React.FC<{
 export default function DrawerAppBar(): React.ReactElement {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [openDialog, setOpenDialog] = React.useState(false);
-  const [navigationItems, setNavigationItems] = React.useState<NavigationItem[]>([]);
+  const [navigationItems, setNavigationItems] = React.useState<
+    NavigationItem[]
+  >([]);
   const { config } = useRemoteConfig();
 
   React.useEffect(() => {
-    setNavigationItems(buildNavigationItems(config))
+    setNavigationItems(buildNavigationItems(config));
   }, [config]);
 
   const navigateTo = useNavigate();

--- a/web-app/src/app/constants/Navigation.spec.ts
+++ b/web-app/src/app/constants/Navigation.spec.ts
@@ -1,0 +1,25 @@
+import { buildNavigationItems } from "./Navigation";
+
+describe('Navigation Elements', () => {
+  describe('building navigation items', () => {
+    it('should return feed nav item if feature flag enabled', () => {
+        const featureFlags = {
+            enableFeedsPage: true
+        }
+        const navigationItems = buildNavigationItems(featureFlags);
+        const feedsNavigation = navigationItems.find(item => item.title === 'Feeds');
+        expect(feedsNavigation).toBeDefined();
+    });
+
+    it('should not return feed nav item if feature flag disabled', () => {
+        const featureFlags = {
+            enableFeedsPage: false
+        }
+        const navigationItems = buildNavigationItems(featureFlags);
+        const feedsNavigation = navigationItems.find(item => item.title === 'Feeds');
+        expect(feedsNavigation).toBeUndefined();
+    });
+  });
+
+
+});

--- a/web-app/src/app/constants/Navigation.spec.ts
+++ b/web-app/src/app/constants/Navigation.spec.ts
@@ -4,30 +4,35 @@ import {
 } from '../interface/RemoteConfig';
 import { buildNavigationItems } from './Navigation';
 
-describe('Navigation Elements', () => {
-  describe('building navigation items', () => {
-    it('should return feed nav item if feature flag enabled', () => {
-      const featureFlags: RemoteConfigValues = {
-        ...defaultRemoteConfigValues,
-        enableFeedsPage: true,
-      };
-      const navigationItems = buildNavigationItems(featureFlags);
-      const feedsNavigation = navigationItems.find(
-        (item) => item.title === 'Feeds',
-      );
-      expect(feedsNavigation).toBeDefined();
-    });
+jest.mock('firebase/compat/app', () => ({
+  initializeApp: jest.fn(),
+  remoteConfig: jest.fn(() => ({
+    settings: { minimumFetchIntervalMillis: 3600000 },
+  })),
+}));
 
-    it('should not return feed nav item if feature flag disabled', () => {
-      const featureFlags: RemoteConfigValues = {
-        ...defaultRemoteConfigValues,
-        enableFeedsPage: false,
-      };
-      const navigationItems = buildNavigationItems(featureFlags);
-      const feedsNavigation = navigationItems.find(
-        (item) => item.title === 'Feeds',
-      );
-      expect(feedsNavigation).toBeUndefined();
-    });
+describe('Navigation Elements', () => {
+  it('should return feed nav item if feature flag enabled', () => {
+    const featureFlags: RemoteConfigValues = {
+      ...defaultRemoteConfigValues,
+      enableFeedsPage: true,
+    };
+    const navigationItems = buildNavigationItems(featureFlags);
+    const feedsNavigation = navigationItems.find(
+      (item) => item.title === 'Feeds',
+    );
+    expect(feedsNavigation).toBeDefined();
+  });
+
+  it('should not return feed nav item if feature flag disabled', () => {
+    const featureFlags: RemoteConfigValues = {
+      ...defaultRemoteConfigValues,
+      enableFeedsPage: false,
+    };
+    const navigationItems = buildNavigationItems(featureFlags);
+    const feedsNavigation = navigationItems.find(
+      (item) => item.title === 'Feeds',
+    );
+    expect(feedsNavigation).toBeUndefined();
   });
 });

--- a/web-app/src/app/constants/Navigation.spec.ts
+++ b/web-app/src/app/constants/Navigation.spec.ts
@@ -1,25 +1,33 @@
-import { buildNavigationItems } from "./Navigation";
+import {
+  defaultRemoteConfigValues,
+  type RemoteConfigValues,
+} from '../interface/RemoteConfig';
+import { buildNavigationItems } from './Navigation';
 
 describe('Navigation Elements', () => {
   describe('building navigation items', () => {
     it('should return feed nav item if feature flag enabled', () => {
-        const featureFlags = {
-            enableFeedsPage: true
-        }
-        const navigationItems = buildNavigationItems(featureFlags);
-        const feedsNavigation = navigationItems.find(item => item.title === 'Feeds');
-        expect(feedsNavigation).toBeDefined();
+      const featureFlags: RemoteConfigValues = {
+        ...defaultRemoteConfigValues,
+        enableFeedsPage: true,
+      };
+      const navigationItems = buildNavigationItems(featureFlags);
+      const feedsNavigation = navigationItems.find(
+        (item) => item.title === 'Feeds',
+      );
+      expect(feedsNavigation).toBeDefined();
     });
 
     it('should not return feed nav item if feature flag disabled', () => {
-        const featureFlags = {
-            enableFeedsPage: false
-        }
-        const navigationItems = buildNavigationItems(featureFlags);
-        const feedsNavigation = navigationItems.find(item => item.title === 'Feeds');
-        expect(feedsNavigation).toBeUndefined();
+      const featureFlags: RemoteConfigValues = {
+        ...defaultRemoteConfigValues,
+        enableFeedsPage: false,
+      };
+      const navigationItems = buildNavigationItems(featureFlags);
+      const feedsNavigation = navigationItems.find(
+        (item) => item.title === 'Feeds',
+      );
+      expect(feedsNavigation).toBeUndefined();
     });
   });
-
-
 });

--- a/web-app/src/app/constants/Navigation.ts
+++ b/web-app/src/app/constants/Navigation.ts
@@ -1,4 +1,6 @@
 import type NavigationItem from '../interface/Navigation';
+import { NavigationItemVariant } from '../interface/Navigation';
+import { RemoteConfigValues } from '../interface/RemoteConfig';
 
 export const SIGN_OUT_TARGET = '/sign-out';
 export const SIGN_IN_TARGET = '/sign-in';
@@ -14,38 +16,46 @@ export const MOBILITY_DATA_LINKS = {
   github: 'https://github.com/MobilityData/mobility-database-catalogs',
 };
 
-export const navigationItems: NavigationItem[] = [
-  { title: 'About', target: 'about', color: 'inherit', variant: 'text' },
-  { title: 'Feeds', target: 'feeds', color: 'inherit', variant: 'text' },
-  { title: 'FAQ', target: 'faq', color: 'inherit', variant: 'text' },
-  {
-    title: 'Add a Feed',
-    target: 'contribute',
-    color: 'inherit',
-    variant: 'text',
-  },
-  {
-    title: 'API Docs',
-    target:
-      'https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html',
-    color: 'inherit',
-    variant: 'text',
-    external: true,
-  },
-  {
-    title: 'Contact Us',
-    target: 'mailto:api@mobilitydata.org',
-    color: 'inherit',
-    variant: 'text',
-    external: true,
-  },
-];
+export function buildNavigationItems(featureFlags: RemoteConfigValues): NavigationItem[] {
+  const navigationItems: NavigationItem[] = [
+    { title: 'About', target: 'about', color: 'inherit', variant: NavigationItemVariant.Text },
+  ];
+
+  if (featureFlags.enableFeedsPage) {
+    navigationItems.push({ title: 'Feeds', target: 'feeds', color: 'inherit', variant: NavigationItemVariant.Text })
+  }
+
+  navigationItems.push(...[
+    { title: 'FAQ', target: 'faq', color: 'inherit', variant: NavigationItemVariant.Text },
+    {
+      title: 'Add a Feed',
+      target: 'contribute',
+      color: 'inherit',
+      variant: NavigationItemVariant.Text,
+    },
+    {
+      title: 'API Docs',
+      target:
+        'https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html',
+      color: 'inherit',
+      variant: NavigationItemVariant.Text,
+      external: true,
+    },
+    {
+      title: 'Contact Us',
+      target: 'mailto:api@mobilitydata.org',
+      color: 'inherit',
+      variant: NavigationItemVariant.Text,
+      external: true,
+    }]);
+  return navigationItems;
+}
 
 export const navigationAccountItem: NavigationItem = {
   title: 'Account',
   target: ACCOUNT_TARGET,
   color: 'inherit',
-  variant: 'text',
+  variant: NavigationItemVariant.Text,
 };
 
 export type NavigationHandler = (navigationItem: NavigationItem) => void;

--- a/web-app/src/app/constants/Navigation.ts
+++ b/web-app/src/app/constants/Navigation.ts
@@ -1,5 +1,4 @@
 import type NavigationItem from '../interface/Navigation';
-import { NavigationItemVariant } from '../interface/Navigation';
 import { type RemoteConfigValues } from '../interface/RemoteConfig';
 
 export const SIGN_OUT_TARGET = '/sign-out';
@@ -24,7 +23,6 @@ export function buildNavigationItems(
       title: 'About',
       target: 'about',
       color: 'inherit',
-      variant: NavigationItemVariant.Text,
     },
   ];
 
@@ -33,7 +31,6 @@ export function buildNavigationItems(
       title: 'Feeds',
       target: 'feeds',
       color: 'inherit',
-      variant: NavigationItemVariant.Text,
     });
   }
 
@@ -43,27 +40,23 @@ export function buildNavigationItems(
         title: 'FAQ',
         target: 'faq',
         color: 'inherit',
-        variant: NavigationItemVariant.Text,
       },
       {
         title: 'Add a Feed',
         target: 'contribute',
         color: 'inherit',
-        variant: NavigationItemVariant.Text,
       },
       {
         title: 'API Docs',
         target:
           'https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html',
         color: 'inherit',
-        variant: NavigationItemVariant.Text,
         external: true,
       },
       {
         title: 'Contact Us',
         target: 'mailto:api@mobilitydata.org',
         color: 'inherit',
-        variant: NavigationItemVariant.Text,
         external: true,
       },
     ],
@@ -75,7 +68,6 @@ export const navigationAccountItem: NavigationItem = {
   title: 'Account',
   target: ACCOUNT_TARGET,
   color: 'inherit',
-  variant: NavigationItemVariant.Text,
 };
 
 export type NavigationHandler = (navigationItem: NavigationItem) => void;

--- a/web-app/src/app/constants/Navigation.ts
+++ b/web-app/src/app/constants/Navigation.ts
@@ -1,6 +1,6 @@
 import type NavigationItem from '../interface/Navigation';
 import { NavigationItemVariant } from '../interface/Navigation';
-import { RemoteConfigValues } from '../interface/RemoteConfig';
+import { type RemoteConfigValues } from '../interface/RemoteConfig';
 
 export const SIGN_OUT_TARGET = '/sign-out';
 export const SIGN_IN_TARGET = '/sign-in';
@@ -16,38 +16,58 @@ export const MOBILITY_DATA_LINKS = {
   github: 'https://github.com/MobilityData/mobility-database-catalogs',
 };
 
-export function buildNavigationItems(featureFlags: RemoteConfigValues): NavigationItem[] {
+export function buildNavigationItems(
+  featureFlags: RemoteConfigValues,
+): NavigationItem[] {
   const navigationItems: NavigationItem[] = [
-    { title: 'About', target: 'about', color: 'inherit', variant: NavigationItemVariant.Text },
+    {
+      title: 'About',
+      target: 'about',
+      color: 'inherit',
+      variant: NavigationItemVariant.Text,
+    },
   ];
 
   if (featureFlags.enableFeedsPage) {
-    navigationItems.push({ title: 'Feeds', target: 'feeds', color: 'inherit', variant: NavigationItemVariant.Text })
+    navigationItems.push({
+      title: 'Feeds',
+      target: 'feeds',
+      color: 'inherit',
+      variant: NavigationItemVariant.Text,
+    });
   }
 
-  navigationItems.push(...[
-    { title: 'FAQ', target: 'faq', color: 'inherit', variant: NavigationItemVariant.Text },
-    {
-      title: 'Add a Feed',
-      target: 'contribute',
-      color: 'inherit',
-      variant: NavigationItemVariant.Text,
-    },
-    {
-      title: 'API Docs',
-      target:
-        'https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html',
-      color: 'inherit',
-      variant: NavigationItemVariant.Text,
-      external: true,
-    },
-    {
-      title: 'Contact Us',
-      target: 'mailto:api@mobilitydata.org',
-      color: 'inherit',
-      variant: NavigationItemVariant.Text,
-      external: true,
-    }]);
+  navigationItems.push(
+    ...[
+      {
+        title: 'FAQ',
+        target: 'faq',
+        color: 'inherit',
+        variant: NavigationItemVariant.Text,
+      },
+      {
+        title: 'Add a Feed',
+        target: 'contribute',
+        color: 'inherit',
+        variant: NavigationItemVariant.Text,
+      },
+      {
+        title: 'API Docs',
+        target:
+          'https://mobilitydata.github.io/mobility-feed-api/SwaggerUI/index.html',
+        color: 'inherit',
+        variant: NavigationItemVariant.Text,
+        external: true,
+      },
+      {
+        title: 'Contact Us',
+        target: 'mailto:api@mobilitydata.org',
+        color: 'inherit',
+        variant: NavigationItemVariant.Text,
+        external: true,
+      },
+    ],
+  );
   return navigationItems;
 }
 

--- a/web-app/src/app/interface/Navigation.ts
+++ b/web-app/src/app/interface/Navigation.ts
@@ -2,12 +2,5 @@ export default interface NavigationItem {
   title: string;
   color: string;
   target: string;
-  variant: NavigationItemVariant;
   external?: boolean;
-}
-
-export enum NavigationItemVariant {
-  Text = 'text',
-  Outlined = 'outlined',
-  Contained = 'contained',
 }

--- a/web-app/src/app/interface/Navigation.ts
+++ b/web-app/src/app/interface/Navigation.ts
@@ -2,6 +2,12 @@ export default interface NavigationItem {
   title: string;
   color: string;
   target: string;
-  variant: 'text' | 'outlined' | 'contained' | undefined;
+  variant: NavigationItemVariant;
   external?: boolean;
+}
+
+export enum NavigationItemVariant {
+  Text = 'text',
+  Outlined = 'outlined',
+  Contained = 'contained',
 }

--- a/web-app/src/app/interface/RemoteConfig.ts
+++ b/web-app/src/app/interface/RemoteConfig.ts
@@ -1,5 +1,12 @@
 import { remoteConfig } from '../../firebase';
-export type RemoteConfigValues = Record<string, string | number | boolean>;
+
+type FirebaseDefaultConfig = typeof remoteConfig.defaultConfig;
+
+export interface RemoteConfigValues extends FirebaseDefaultConfig {
+  enableAppleSSO: boolean;
+  enableMVPSearch: boolean;
+  enableFeedsPage: boolean;
+}
 
 // Add default values for remote config here
 export const defaultRemoteConfigValues: RemoteConfigValues = {

--- a/web-app/src/app/interface/RemoteConfig.ts
+++ b/web-app/src/app/interface/RemoteConfig.ts
@@ -5,6 +5,7 @@ export type RemoteConfigValues = Record<string, string | number | boolean>;
 export const defaultRemoteConfigValues: RemoteConfigValues = {
   enableAppleSSO: false,
   enableMVPSearch: false,
+  enableFeedsPage: false,
 };
 
 remoteConfig.defaultConfig = defaultRemoteConfigValues;


### PR DESCRIPTION
closes #477 

**Summary:**

Adds feature flag to 'feeds' page to hide it in PROD until it's ready

**Expected behavior:** 

If the feature flag is disabled, 'feeds' should not appear in the nav bar, nor should it exist as a route.
![Screenshot 2024-06-17 at 14 28 05](https://github.com/MobilityData/mobility-feed-api/assets/18631060/faca929f-aaa6-41ba-9e6c-a196ff8df936)


**Testing tips:**

Go into [firebase](https://console.firebase.google.com/project/mobility-feeds-dev/config/env/firebase) and modify the feature flag values

Go into `web-app/src/app/constants/Navigation.ts` and manually modify the feature flag values

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
