### PR TITLE
fix: Test latest_dataset is not none when bounding_box is None

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This command is very useful when switching branches that potentially have differ
 ```
 Datasets are not part of the catalog. If you need to test or debug a feature that requires dataset entities use the following command:
 ```bash
-./scripts/docker-localdb-rebuild-data.sh --populate-db --populate-test-db
+./scripts/docker-localdb-rebuild-data.sh --populate-db --populate-test-data
 ```
 
 

--- a/api/tests/unittest/test_feeds.py
+++ b/api/tests/unittest/test_feeds.py
@@ -125,20 +125,7 @@ def test_gtfs_feeds_get(client: TestClient, mocker):
         subdivision_name="test_subdivision_name",
         municipality="test_municipality",
     )
-    mock_bounding_box = json.dumps(
-        {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [-70.248666, 43.655373],
-                    [-70.248666, 43.71619],
-                    [-70.11018, 43.71619],
-                    [-70.11018, 43.655373],
-                    [-70.248666, 43.655373],
-                ]
-            ],
-        }
-    )
+
     mock_select.return_value = [
         [
             (
@@ -147,7 +134,8 @@ def test_gtfs_feeds_get(client: TestClient, mocker):
                 mock_external_id,
                 redirect_comment,
                 mock_latest_datasets,
-                mock_bounding_box,
+                # See issue #431 where latest_dataset would be None if bounding_box was None.
+                None,
                 mock_locations,
             )
         ]
@@ -185,6 +173,8 @@ def test_gtfs_feeds_get(client: TestClient, mocker):
         response_gtfs_feed["locations"][0]["municipality"] == "test_municipality"
     ), f'Response feed municipality was {response_gtfs_feed["locations"][0]["municipality"]} \
         instead of test_municipality'
+    # See issue #431 where latest_dataset would be None if bounding_box was None.
+    assert response_gtfs_feed["latest_dataset"] is not None, "Response feed latest dataset was None"
     assert (
         response_gtfs_feed["latest_dataset"]["id"] == "test_latest_dataset_id"
     ), f'Response feed latest dataset id was {response_gtfs_feed["latest_dataset"]["id"]} \

--- a/api/tests/unittest/test_feeds.py
+++ b/api/tests/unittest/test_feeds.py
@@ -10,6 +10,8 @@ from feeds.filters.feed_filter import FeedFilter
 from feeds.impl.models.basic_feed_impl import BaseFeedImpl
 from tests.test_utils.token import authHeaders
 
+from geoalchemy2 import WKTElement
+
 redirect_target_id = "test_target_id"
 redirect_comment = "Some comment"
 expected_redirect_response = {"target_id": redirect_target_id, "comment": redirect_comment}
@@ -118,27 +120,18 @@ def test_gtfs_feeds_get(client: TestClient, mocker):
     mock_select = mocker.patch.object(Database(), "select")
     mock_feed = Feed(stable_id="test_gtfs_id")
     mock_external_id = Externalid(associated_id="test_associated_id", source="test_source")
-    mock_latest_datasets = Gtfsdataset(stable_id="test_latest_dataset_id", hosted_url="test_hosted_url", latest=True)
     mock_locations = Location(
         id="test_location_id",
         country_code="test_country_code",
         subdivision_name="test_subdivision_name",
         municipality="test_municipality",
     )
-    mock_bounding_box = json.dumps(
-        {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [-70.248666, 43.655373],
-                    [-70.248666, 43.71619],
-                    [-70.11018, 43.71619],
-                    [-70.11018, 43.655373],
-                    [-70.248666, 43.655373],
-                ]
-            ],
-        }
+    mock_bounding_box = WKTElement("POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))")
+
+    mock_latest_datasets = Gtfsdataset(
+        stable_id="test_latest_dataset_id", hosted_url="test_hosted_url", latest=True, bounding_box=mock_bounding_box
     )
+
     mock_select.return_value = [
         [
             (
@@ -194,6 +187,7 @@ def test_gtfs_feeds_get(client: TestClient, mocker):
         response_gtfs_feed["latest_dataset"]["hosted_url"] == "test_hosted_url"
     ), f'Response feed hosted url was {response_gtfs_feed["latest_dataset"]["hosted_url"]} \
         instead of test_hosted_url'
+    assert response_gtfs_feed["latest_dataset"]["bounding_box"] is not None, "Response feed bounding_box was None"
 
 
 def test_gtfs_feeds_get_no_bounding_box(client: TestClient, mocker):

--- a/scripts/docker-localdb-rebuild-data.sh
+++ b/scripts/docker-localdb-rebuild-data.sh
@@ -72,6 +72,9 @@ docker rm $container_name
 # delete the data
 rm -rf $SCRIPT_PATH/../data
 
+# Add a slight delay because sometimes Docker does not seem ready after the rm.
+sleep 5
+
 # Start the container and run the liquibase
 docker-compose -f $SCRIPT_PATH/../docker-compose.yaml up -d liquibase
 # wait for the liquibase to finish


### PR DESCRIPTION
**Summary:**

Closes #440 
Tested the conditions that lead to #431 

**Expected behavior:** 

These tests pass: 

- https://github.com/MobilityData/mobility-feed-api/blob/8eee5c90fad8c275bc0e7a947d565c847b189d0c/api/tests/unittest/test_feeds.py#L114
- https://github.com/MobilityData/mobility-feed-api/blob/8ebbffeebcccc994deb347de40dff83968c3506b/api/tests/unittest/test_feeds.py#L199

**Testing tips:**

To test I put back the code from [PR #433](https://github.com/MobilityData/mobility-feed-api/pull/433/files) in api/src/feeds/impl/feeds_api_impl.py and verified that it failed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
