### PR TITLE
fix: refresh materialized view in batch functions

### DIFF
--- a/functions-python/helpers/database.py
+++ b/functions-python/helpers/database.py
@@ -18,7 +18,7 @@ import os
 import threading
 from typing import Final
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 import logging
 
@@ -103,6 +103,6 @@ def refresh_materialized_view(session, view_name: str):
     Refresh Materialized view by name.
     """
     try:
-        session.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view_name}")
+        session.execute(text(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view_name}"))
     except Exception as error:
         logging.error(f"Error raised while refreshing view: {error}")

--- a/functions-python/helpers/database.py
+++ b/functions-python/helpers/database.py
@@ -98,11 +98,14 @@ def close_db_session(session, raise_exception: bool = False):
             raise error
 
 
-def refresh_materialized_view(session, view_name: str):
+def refresh_materialized_view(session, view_name: str) -> bool:
     """
     Refresh Materialized view by name.
+    @return: True if the view was refreshed successfully, False otherwise
     """
     try:
         session.execute(text(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view_name}"))
+        return True
     except Exception as error:
         logging.error(f"Error raised while refreshing view: {error}")
+    return False

--- a/functions-python/helpers/tests/test_database.py
+++ b/functions-python/helpers/tests/test_database.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from typing import Final
+from unittest import mock
+
+from helpers.database import refresh_materialized_view, start_db_session
+
+default_db_url: Final[
+    str
+] = "postgresql://postgres:postgres@localhost:54320/MobilityDatabaseTest"
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "FEEDS_DATABASE_URL": default_db_url,
+        "FEEDS_PUBSUB_TOPIC_NAME": "test_topic",
+        "ENVIRONMENT": "test",
+        "FEEDS_LIMIT": "5",
+    },
+)
+class TestDatabase(unittest.TestCase):
+    def test_refresh_materialized_view_existing_view(self):
+        view_name = "feedsearch"
+
+        session = start_db_session(os.getenv("FEEDS_DATABASE_URL"))
+        result = refresh_materialized_view(session, view_name)
+
+        self.assertTrue(result)
+
+    def test_refresh_materialized_view_invalid_view(self):
+        view_name = "invalid_view_name"
+
+        session = start_db_session(os.getenv("FEEDS_DATABASE_URL"))
+        result = refresh_materialized_view(session, view_name)
+
+        self.assertFalse(result)


### PR DESCRIPTION
**Summary:**

After upgrading to the Alchemy 2.0 plain text SQL queries need to be wrapped with `text` function. This is for security and validation purposes.

**Expected behavior:** 

The refresh materialized view function works as expected.

**Testing tips:**

Unit tests should cover the right behavior. For manual testing you need to deploy the bash processing code to DEV and run it. Expect no error in the logs with message: _"Error raised while refreshing view: feedsearch"_

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
