### PR TITLE
poc: recognizing when a dataset was unfetchable

### DIFF
--- a/api/.openapi-generator/FILES
+++ b/api/.openapi-generator/FILES
@@ -14,9 +14,11 @@ src/feeds_gen/models/basic_feed.py
 src/feeds_gen/models/bounding_box.py
 src/feeds_gen/models/external_id.py
 src/feeds_gen/models/extra_models.py
+src/feeds_gen/models/fetch_status.py
 src/feeds_gen/models/gtfs_dataset.py
 src/feeds_gen/models/gtfs_feed.py
 src/feeds_gen/models/gtfs_rt_feed.py
+src/feeds_gen/models/last_fetch_attempt.py
 src/feeds_gen/models/latest_dataset.py
 src/feeds_gen/models/latest_dataset_validation_report.py
 src/feeds_gen/models/location.py

--- a/api/.openapi-generator/FILES
+++ b/api/.openapi-generator/FILES
@@ -14,7 +14,6 @@ src/feeds_gen/models/basic_feed.py
 src/feeds_gen/models/bounding_box.py
 src/feeds_gen/models/external_id.py
 src/feeds_gen/models/extra_models.py
-src/feeds_gen/models/fetch_status.py
 src/feeds_gen/models/gtfs_dataset.py
 src/feeds_gen/models/gtfs_feed.py
 src/feeds_gen/models/gtfs_rt_feed.py

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -48,3 +48,4 @@ fastapi-filter[sqlalchemy]==0.6.1
 PyJWT
 shapely
 google-cloud-pubsub
+google-cloud-datastore

--- a/api/src/feeds/impl/datasets_api_impl.py
+++ b/api/src/feeds/impl/datasets_api_impl.py
@@ -101,6 +101,8 @@ class DatasetsApiImpl(BaseDatasetsApi):
             offset=offset,
             group_by=lambda x: x[0].stable_id,
         )
+        if not dataset_groups:
+            return []
 
         gtfs_datasets = []
         for dataset_group in dataset_groups:

--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -43,6 +43,7 @@ from feeds_gen.models.gtfs_rt_feed import GtfsRTFeed
 from feeds_gen.models.location import Location as ApiLocation
 from feeds_gen.models.source_info import SourceInfo
 from feeds_gen.models.redirect import Redirect
+from utils.datastore_utils import get_by_stable_ids
 from utils.date_utils import valid_iso_date
 
 
@@ -169,6 +170,8 @@ class FeedsApiImpl(BaseFeedsApi):
         )
         gtfs_feeds = []
         for feed_group in feed_groups:
+            stable_id = feed_group[0][0].stable_id
+            get_by_stable_ids(stable_id)
             feed_objects, redirect_ids, external_ids, redirect_comments, datasets, bounding_boxes, locations = zip(
                 *feed_group
             )

--- a/api/src/utils/datastore_utils.py
+++ b/api/src/utils/datastore_utils.py
@@ -1,0 +1,16 @@
+from google.cloud import datastore
+from google.cloud.datastore.query import PropertyFilter
+
+
+def get_by_stable_ids(stable_id: str):
+    try:
+        client = datastore.Client()
+        query = client.query(kind="dataset_trace")
+        query.add_filter(filter=PropertyFilter("stable_id", "=", stable_id))
+        # query.order = ["-timestamp"]
+
+        results = list(query.fetch(limit=1))
+        # TODO: complete this function
+        print(results)
+    except Exception as e:
+        print(e)

--- a/api/src/utils/datastore_utils.py
+++ b/api/src/utils/datastore_utils.py
@@ -1,16 +1,59 @@
+from datetime import datetime
+from typing import Optional, List, Dict
+
 from google.cloud import datastore
-from google.cloud.datastore.query import PropertyFilter
+
+from feeds_gen.models.last_fetch_attempt import LastFetchAttempt
 
 
-def get_by_stable_ids(stable_id: str):
+def get_lts_traces(stable_ids: List[str]) -> Dict[str, Optional[LastFetchAttempt]]:
+    if not stable_ids:
+        return {}
+
+    results: Dict[str, Optional[LastFetchAttempt]] = {stable_id: None for stable_id in stable_ids}
+    client = datastore.Client()
+
     try:
-        client = datastore.Client()
-        query = client.query(kind="dataset_trace")
-        query.add_filter(filter=PropertyFilter("stable_id", "=", stable_id))
-        # query.order = ["-timestamp"]
+        # Step 1: Get the latest timestamp for the first stable_id
+        first_result = None
+        n = 0
+        while not first_result and n < len(stable_ids):  # Retry until we get a result or reach the end
+            query = client.query(kind="dataset_trace")
+            query.add_filter("stable_id", "=", stable_ids[n])
+            query.order = ["-timestamp"]
+            first_result = list(query.fetch(limit=1))
+            n += 1
 
-        results = list(query.fetch(limit=1))
-        # TODO: complete this function
-        print(results)
+        if not first_result:
+            return results
+
+        first_stable_id = stable_ids[n - 1]
+        latest_timestamp = first_result[0]["timestamp"]
+
+        # Record the result for the first stable_id
+        results[first_stable_id] = LastFetchAttempt(
+            status=first_result[0]["status"], timestamp=datetime.fromtimestamp(first_result[0]["timestamp"].timestamp())
+        )
+
+        # Step 2: Fetch and filter other stable_ids using the latest timestamp
+        for i in range(n, len(stable_ids), 30):
+            # Fetch 30 stable_ids at a time to avoid exceeding the datastore limit
+            batch_stable_ids = stable_ids[i : i + 30]
+            query = client.query(kind="dataset_trace")
+            query.add_filter("stable_id", "IN", batch_stable_ids)
+            query.add_filter("timestamp", ">=", latest_timestamp)
+            query.order = ["-timestamp"]
+
+            query_results = list(query.fetch())
+            for result in query_results:
+                # The first result is the latest timestamp for the stable_id
+                if result["stable_id"] in results and results[result["stable_id"]] is None:
+                    print(f"Found result for {result['stable_id']}")
+                    results[result["stable_id"]] = LastFetchAttempt(
+                        status=result["status"], timestamp=datetime.fromtimestamp(result["timestamp"].timestamp())
+                    )
     except Exception as e:
-        print(e)
+        print(f"An error occurred: {e}")
+        return {stable_id: None for stable_id in stable_ids}
+
+    return results

--- a/api/src/utils/datastore_utils.py
+++ b/api/src/utils/datastore_utils.py
@@ -11,9 +11,10 @@ def get_lts_traces(stable_ids: List[str]) -> Dict[str, Optional[LastFetchAttempt
         return {}
 
     results: Dict[str, Optional[LastFetchAttempt]] = {stable_id: None for stable_id in stable_ids}
-    client = datastore.Client()
 
     try:
+        client = datastore.Client()
+
         # Step 1: Get the latest timestamp for the first stable_id
         first_result = None
         n = 0

--- a/config/.env.local
+++ b/config/.env.local
@@ -8,4 +8,4 @@ ENV=local
 SCHEMA_SPY_DOC=schemaspy-dev
 FEEDS_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/MobilityDatabase
 FEEDS_AUTHORIZATION=Bearer
-PROJECT_ID=movility-feeds-dev
+PROJECT_ID=mobility-feeds-dev

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -23,7 +23,7 @@ servers:
     description: Pre-prod environment
   - url: https://api-dev.mobilitydatabase.org/
     description: Development environment
-  - url: http://localhost:8080/
+  - url: http://localhost:8000/
     description: Local development environment
 
 tags:
@@ -371,6 +371,10 @@ components:
           properties:
             latest_dataset:
               $ref: "#/components/schemas/LatestDataset"
+        - type: object
+          properties:
+            last_fetch_attempt:
+              $ref: "#/components/schemas/LastFetchAttempt"
 
     GtfsRTFeed:
       allOf:
@@ -549,6 +553,35 @@ components:
           type: string
           format: url
           example: https://www.ladottransit.com/dla.html
+
+    FetchStatus:
+      type: string
+      description: >
+        Describes the status of the fetch operation. Should be one of
+          * `FAILED` - The fetch operation failed.
+          * `PUBLISHED` - The fetch operation was successful and the updated dataset was published.
+          * `NOT_PUBLISHED` - The fetch operation was successful but the updated dataset was not published because no 
+            changes were detected.
+          * `INVALID_ZIP_FILE` - The fetch operation failed because the response from the producer was not a valid ZIP file.
+      enum:
+        - FAILED
+        - PUBLISHED
+        - NOT_PUBLISHED
+        - INVALID_ZIP_FILE
+      example: FAILED
+
+    LastFetchAttempt:
+      type: object
+      description: >
+        Describes the last fetch attempt of the feed using the producer URL.
+      properties:
+        status:
+          $ref: "#/components/schemas/FetchStatus"
+        timestamp:
+          type: string
+          format: date-time
+          description: Timestamp of the last fetch attempt.
+          example: 2023-06-26T12:00:00Z
 
     Locations:
       type: array

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -554,29 +554,26 @@ components:
           format: url
           example: https://www.ladottransit.com/dla.html
 
-    FetchStatus:
-      type: string
-      description: >
-        Describes the status of the fetch operation. Should be one of
-          * `FAILED` - The fetch operation failed.
-          * `PUBLISHED` - The fetch operation was successful and the updated dataset was published.
-          * `NOT_PUBLISHED` - The fetch operation was successful but the updated dataset was not published because no 
-            changes were detected.
-          * `INVALID_ZIP_FILE` - The fetch operation failed because the response from the producer was not a valid ZIP file.
-      enum:
-        - FAILED
-        - PUBLISHED
-        - NOT_PUBLISHED
-        - INVALID_ZIP_FILE
-      example: FAILED
-
     LastFetchAttempt:
       type: object
       description: >
         Describes the last fetch attempt of the feed using the producer URL.
       properties:
         status:
-          $ref: "#/components/schemas/FetchStatus"
+          type: string
+          description: >
+            Describes the status of the fetch operation. Should be one of
+              * `FAILED` - The fetch operation failed.
+              * `PUBLISHED` - The fetch operation was successful and the updated dataset was published.
+              * `NOT_PUBLISHED` - The fetch operation was successful but the updated dataset was not published because no 
+                changes were detected.
+              * `INVALID_ZIP_FILE` - The fetch operation failed because the response from the producer was not a valid ZIP file.
+          enum:
+            - FAILED
+            - PUBLISHED
+            - NOT_PUBLISHED
+            - INVALID_ZIP_FILE
+          example: FAILED
         timestamp:
           type: string
           format: date-time

--- a/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
+++ b/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
@@ -12,6 +12,7 @@ from batch_process_dataset.src.main import (
     process_dataset,
 )
 from database_gen.sqlacodegen_models import Gtfsfeed
+from dataset_service.main import InvalidZipFileException
 from test_utils.database_utils import get_testing_session, default_db_url
 from cloudevents.http import CloudEvent
 
@@ -136,10 +137,11 @@ class TestDatasetProcessor(unittest.TestCase):
             None,
             test_hosted_public_url,
         )
+        try:
+            processor.upload_dataset()
+        except InvalidZipFileException:
+            pass
 
-        result = processor.upload_dataset()
-
-        self.assertIsNone(result)
         upload_file_to_storage.blob.assert_not_called()
         mock_blob.make_public.assert_not_called()
         mock_download_url_content.assert_called_once()

--- a/functions-python/dataset_service/main.py
+++ b/functions-python/dataset_service/main.py
@@ -22,6 +22,7 @@ from typing import Optional, Final
 from google.cloud import datastore
 from google.cloud.datastore import Client
 
+
 # This files contains the dataset trace and batch execution models and services.
 # The dataset trace is used to store the trace of a dataset and the batch execution
 # One batch execution can have multiple dataset traces.
@@ -34,6 +35,7 @@ class Status(Enum):
     FAILED = "FAILED"
     PUBLISHED = "PUBLISHED"
     NOT_PUBLISHED = "NOT_PUBLISHED"
+    INVALID_ZIP_FILE = "INVALID_ZIP_FILE"
 
 
 # Dataset trace class to store the trace of a dataset
@@ -153,3 +155,23 @@ class BatchExecutionService:
         entity.update(asdict(execution))
 
         return entity
+
+
+class InvalidZipFileException(Exception):
+    """Exception raised for errors in the dataset being not a valid ZIP file."""
+
+    def __init__(
+        self,
+        stable_id,
+        producer_url,
+        message="Producer URL response is not a valid ZIP file",
+    ):
+        self.stable_id = stable_id
+        self.producer_url = producer_url
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return (
+            f"[{self.stable_id}] {self.message} with producer URL: {self.producer_url}"
+        )

--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -200,7 +200,7 @@ resource "google_cloud_run_service_iam_member" "batch_datasets_cloud_run_invoker
 }
 
 
-ressource "google_datastore_index" "dataset_trace_index_execution_id_timestamp" {
+resource "google_datastore_index" "dataset_trace_index_execution_id_timestamp" {
   project = var.project_id
   kind    = "dataset_trace"
   properties {

--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -200,29 +200,16 @@ resource "google_cloud_run_service_iam_member" "batch_datasets_cloud_run_invoker
 }
 
 
-resource "google_datastore_index" "dataset_processing_index_execution_id_stable_id_status" {
+ressource "google_datastore_index" "dataset_trace_index_execution_id_timestamp" {
   project = var.project_id
-  kind    = "historical_dataset_batch"
-  properties {
-    name      = "execution_id"
-    direction = "ASCENDING"
-  }
+  kind    = "dataset_trace"
   properties {
     name      = "stable_id"
     direction = "ASCENDING"
   }
-}
-
-resource "google_datastore_index" "dataset_processing_index_execution_id_timestamp" {
-  project = var.project_id
-  kind    = "historical_dataset_batch"
-  properties {
-    name      = "execution_id"
-    direction = "ASCENDING"
-  }
   properties {
     name      = "timestamp"
-    direction = "ASCENDING"
+    direction = "DESCENDING"
   }
 }
 

--- a/web-app/src/app/services/feeds/index.ts
+++ b/web-app/src/app/services/feeds/index.ts
@@ -109,8 +109,7 @@ export const getGtfsFeed = async (
   return await client
     .GET('/v1/gtfs_feeds/{id}', { params: { path: { id } } })
     .then((response) => {
-      const data = response.data;
-      return data;
+      return response.data;
     })
     .catch(function (error) {
       throw error;

--- a/web-app/src/app/services/feeds/types.ts
+++ b/web-app/src/app/services/feeds/types.ts
@@ -101,6 +101,19 @@ export interface components {
        */
       comment?: string;
     };
+    LastFetchAttempt: {
+      /**
+       * @description The status of the last fetch attempt.
+       * @example PUBLISHED
+       */
+      status?: 'NOT_PUBLISHED' | 'PUBLISHED' | 'FAILED' | 'INVALID_ZIP_FILE';
+      /**
+       * Format: date-time
+       * @description The date and time of the last fetch attempt, in ISO 8601 date-time format.
+       * @example "2024-06-19T13:52:13.796248"
+       */
+      timestamp?: string;
+    };
     BasicFeed: {
       /**
        * @description Unique identifier used as a key for the feeds table.
@@ -153,6 +166,7 @@ export interface components {
       } & {
         data_type: 'gtfs';
         latest_dataset?: components['schemas']['LatestDataset'];
+        last_fetch_attempt?: components['schemas']['LastFetchAttempt'];
       };
     GtfsRTFeed: {
       data_type: 'gtfs_rt';


### PR DESCRIPTION
**Summary:**
This PR is a proof of concept (POC) to identify when a dataset was not fetched, providing clearer information to the user about when and why a dataset was never fetched.

**Expected Behavior:**
Currently, the batch processing job attempts to fetch all non-deprecated feeds. Known reasons for a non-deprecated feed not being successfully fetched include:

1. Internal server errors (e.g., HTTP connection timeout because the URL is inaccessible).
2. Invalid ZIP file: If the dataset available at the producer's URL is not a valid ZIP file (e.g., the URL redirects to an HTML page), processing is skipped.

The goal of this POC is to enhance the UI by providing more information when a feed has no datasets. To achieve this, the existing `dataset_trace` GCP Datastore entity has been updated with an `INVALID_ZIP` status type. The status types are now as follows:
- `FETCHED`: The dataset was successfully updated, stored in GCP, and added to the database.
- `NOT_FETCHED`: There was no update; the latest stored dataset is still up to date.
- `FAILURE`: An error occurred during processing (e.g., HTTP connection timeout due to an inaccessible producer URL).
- `INVALID_ZIP_FILE`: The URL is accessible, but the response is not a valid ZIP file.

By having this status in Datastore, along with a `timestamp` and a `stable_id` corresponding to the feed's `stable_id`, it is possible to retrieve the latest status of retrieval for a given feed. Consequently, an element has been added to the API's GTFSFeed response to include information about the last fetch attempt. Here is an example of the object:
```json
"last_fetch_attempt": {
        "status": "PUBLISHED",
        "timestamp": "2024-06-19T17:40:50.188550"
}
```

This information is now displayed on the UI's feed pages to show the latest status. Here are a few examples for different types of statuses (note that the results may vary if the API development is rebuilt or the batch processing jobs are run using the preview link):
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/f66d6588-4b90-4a9d-9b28-2b4c49c0a306)
<img width="1251" alt="Screenshot 2024-06-28 at 2 10 49 PM" src="https://github.com/MobilityData/mobility-feed-api/assets/60586858/3fa9c40b-d5f7-4c31-a1b0-6e5e3e6a812a">
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/e5a7e58b-c87d-4528-9c95-07ad79b1d247)
![image](https://github.com/MobilityData/mobility-feed-api/assets/60586858/134ce288-a853-4c77-b7a5-de2689ca5b71)

**Not covered by this POC**:
- In the final screenshot, you can see that the status is displayed as "in about 4 hours." This discrepancy is due to a timezone difference between the UI and the backend. The processing was completed recently on the backend, but the UI is operating in a different timezone, causing the time mismatch.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
