### PR TITLE
feat: Programmatic download of valid ZIP files returns HTML responses for certain producer URLs

### DIFF
--- a/functions-python/helpers/tests/test_helpers.py
+++ b/functions-python/helpers/tests/test_helpers.py
@@ -11,6 +11,10 @@ from helpers.logger import Logger
 from helpers.utils import create_bucket, download_and_get_hash, download_url_content
 
 responses = urllib3_mock.Responses("requests.packages.urllib3")
+expected_user_agent = (
+    "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/126.0.0.0 Mobile Safari/537.36"
+)
 
 
 class TestHelpers(unittest.TestCase):
@@ -91,7 +95,10 @@ class TestHelpers(unittest.TestCase):
                 "GET",
                 url,
                 preload_content=False,
-                headers={api_key_parameter_name: credentials},
+                headers={
+                    "User-Agent": expected_user_agent,
+                    api_key_parameter_name: credentials,
+                },
             )
 
             if os.path.exists(file_path):
@@ -132,7 +139,10 @@ class TestHelpers(unittest.TestCase):
             )
 
             mock_request.assert_called_with(
-                "GET", modified_url, preload_content=False, headers={}
+                "GET",
+                modified_url,
+                preload_content=False,
+                headers={"User-Agent": expected_user_agent},
             )
 
         if os.path.exists(file_path):

--- a/functions-python/helpers/utils.py
+++ b/functions-python/helpers/utils.py
@@ -101,10 +101,9 @@ def download_and_get_hash(
 
         # authentication_type == 1 -> the credentials are passed in the header
         headers = {
-            'User-Agent':
-                'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/126.0.0.0 Mobile Safari/537.36'
+            "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/126.0.0.0 Mobile Safari/537.36"
         }
         if authentication_type == 1 and api_key_parameter_name and credentials:
             headers[api_key_parameter_name] = credentials

--- a/functions-python/helpers/utils.py
+++ b/functions-python/helpers/utils.py
@@ -100,7 +100,12 @@ def download_and_get_hash(
         ctx.options |= 0x4  # ssl.OP_LEGACY_SERVER_CONNECT
 
         # authentication_type == 1 -> the credentials are passed in the header
-        headers = {}
+        headers = {
+            'User-Agent':
+                'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/126.0.0.0 Mobile Safari/537.36'
+        }
         if authentication_type == 1 and api_key_parameter_name and credentials:
             headers[api_key_parameter_name] = credentials
 


### PR DESCRIPTION
**Summary:**
Added `User-Agent` to the header of the requests, resolving the issue for all feeds specified in #502. To achieve this, I mimicked the equivalent curl request from the browser network tab and systematically filtered out each header to identify that only the `User-Agent` was necessary.

**Testing Tips:**
- Run `datasets-batch-deployer-dev` from the branch `feat/502` to deploy the current behavior.
- Adjust the `FEEDS_LIMIT` variable in the `batch-datasets-dev` cloud function to cover more feeds.
- Filter logs to validate that feeds `mdb-232`, `mdb-919`, and `mdb-683` have been properly processed. If these feeds are not included in the processing, you may need to further increase the `FEEDS_LIMIT` variable.

**Example for `mdb-683`**:
![image-fotor-20240703131338](https://github.com/MobilityData/mobility-feed-api/assets/60586858/78d5ce85-6b01-4718-b115-2289477a58eb)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
