### PR TITLE
feat: verify if the version and commit hash are accurate

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Extract commit hash and version from git
       run: ./scripts/extract-hash-and-version.sh
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python_version }}
@@ -46,6 +46,9 @@ jobs:
 
     - name: Health Check
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
+      env:
+        FILE_PATH: ${{ env.FILE_PATH }}
+        REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
 
     - name: Run Integration Tests
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Health Check
+      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
+
     - name: Run Integration Tests
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
       env:

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# API version automatically generated
+/src/version_info

--- a/api/src/feeds/impl/metadata_api_impl.py
+++ b/api/src/feeds/impl/metadata_api_impl.py
@@ -8,7 +8,7 @@ from feeds_gen.models.metadata import Metadata
 
 class MetadataApiImpl(BaseMetadataApi):
     """
-    This class represents the implementation of the `/datasets` endpoints.
+    This class represents the implementation of the `/metadata` endpoint.
     All methods from the parent class `feeds_gen.apis.metadata_api_base.BaseMetadataApi` should be implemented.
     If a method is left blank the associated endpoint will return a 500 HTTP response.
     """

--- a/api/tests/test_metadata_api.py
+++ b/api/tests/test_metadata_api.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import os
 
 from fastapi.testclient import TestClient
 
@@ -7,11 +8,23 @@ from .test_utils.token import authHeaders
 
 def test_metadata_get(client: TestClient):
     """Test case for metadata_get"""
+    test_hash = "1234567890123456789012345678901234567890"
+    test_version = "v1.2.3"
+    version_info_path = os.path.join(os.path.dirname(__file__), "../src/version_info")
+    with open(version_info_path, "w") as file:
+        file.write("[DEFAULT]\n")
+        file.write(f"LONG_COMMIT_HASH={test_hash}\n")
+        file.write(f"SHORT_COMMIT_HASH={test_hash[:7]}\n")
+        file.write(f"EXTRACTED_VERSION={test_version}")
 
     response = client.request(
         "GET",
         "/v1/metadata",
         headers=authHeaders,
     )
+
+    # Validate that the response reads from version_info
+    assert response.json()["commit_hash"] == test_hash
+    assert response.json()["version"] == test_version
 
     assert response.status_code == 200

--- a/integration-tests/src/endpoints/metadata.py
+++ b/integration-tests/src/endpoints/metadata.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 from endpoints.integration_tests import IntegrationTests
 
@@ -6,13 +7,24 @@ from endpoints.integration_tests import IntegrationTests
 class MetadataEndpointTests(IntegrationTests):
     def __init__(self, file_path, access_token, url, progress):
         super().__init__(file_path, access_token, url, progress=progress)
+        self.version_info_path = os.path.join(
+            os.path.dirname(__file__), "../../../api/src/version_info"
+        )
+
+    def read_version_info(self):
+        """Read the version_info file and extract the long commit hash and extracted version"""
+        with open(self.version_info_path, "r") as file:
+            content = file.read()
+            long_commit_hash = re.search(r"LONG_COMMIT_HASH=(\w+)", content).group(1)
+            extracted_version = re.search(r"EXTRACTED_VERSION=(\S+)", content).group(1)
+        return long_commit_hash, extracted_version
 
     def test_metadata(self):
         """Test retrieval of GTFS feeds"""
         response = self.get_response("v1/metadata")
         assert (
             response.status_code == 200
-        ), "Expected 200 status code for metadata, got {response.status_code}."
+        ), f"Expected 200 status code for metadata, got {response.status_code}."
         metadata = response.json()
 
         version = metadata["version"]
@@ -21,7 +33,7 @@ class MetadataEndpointTests(IntegrationTests):
         ), f"Could not extract version from metadata = {metadata}"
 
         assert re.match(
-            r"^v\d+\.\d+\.\d+", version
+            r"^v\d+\.\d+\.\d+(_SNAPSHOT)?$", version
         ), f"Found version but not the right format. metadata = {metadata}"
 
         commit_hash = metadata["commit_hash"]
@@ -33,3 +45,17 @@ class MetadataEndpointTests(IntegrationTests):
         assert (
             len(commit_hash) > 20
         ), f"Commit hash seems too short in metadata = {metadata}"
+
+        # Read the expected values from the version_info file
+        expected_long_commit_hash, expected_extracted_version = self.read_version_info()
+
+        # Verify that the commit hash matches the long commit hash from the version_info file
+        assert commit_hash == expected_long_commit_hash, (
+            f"Commit hash from metadata ({commit_hash}) does not match expected long commit hash "
+            f"({expected_long_commit_hash})"
+        )
+
+        # Verify that the version matches the extracted version from the version_info file
+        assert (
+            version == expected_extracted_version
+        ), f"Version from metadata ({version}) does not match expected extracted version ({expected_extracted_version})"


### PR DESCRIPTION
**Summary:**
This update introduces automated tests to verify the expected behavior of the commit hash and version returned from the `metadata` endpoint.

**Expected Behavior:**
- The unit test `test_metadata_get` ensures that the version is correctly read from the `api/src/version_info` file.
- The integration test `test_metadata` confirms that the version and commit hash returned by the endpoint match those generated by the `./scripts/extract-hash-and-version.sh` script, as part of the `integration-tests.yml` action.

**Testing Instructions:**
1. **Prepare the Environment:**
   - Copy the content of the QA `version_info` file to `api/src/version_info`:
     ```
     # This file is automatically created at build time. Do not delete.
     [DEFAULT]
     LONG_COMMIT_HASH=2c67dc67ea3a029f498349e8fb8571a9a53bcaee
     SHORT_COMMIT_HASH=2c67dc67e
     EXTRACTED_VERSION=v1.2.1_SNAPSHOT
     ```

2. **Run Integration Tests:**
   - Point to the QA environment and run the integration tests:
     ```bash
     export REFRESH_TOKEN="your refresh token"
     ./scripts/integration-tests.sh -u https://api-qa.mobilitydatabase.org/ -f "path to sources.csv" -c MetadataEndpointTests
     ```

3. **Run Unit Tests:**
   - Execute the unit tests:
     ```bash
     ./scripts/api-tests.sh
     ```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
