### PR TITLE
feat: null states for feed page

### DIFF
--- a/web-app/src/app/components/ContentBox.tsx
+++ b/web-app/src/app/components/ContentBox.tsx
@@ -6,6 +6,7 @@ export interface ContentBoxProps {
   width: Record<string, string>;
   outlineColor: string;
   padding?: string | number;
+  margin?: string | number;
 }
 
 export const ContentBox = (
@@ -19,6 +20,7 @@ export const ContentBox = (
         borderRadius: '6px',
         border: `2px solid ${props.outlineColor}`,
         p: props.padding ?? 5,
+        m: props.margin ?? 0,
         fontSize: '18px',
         fontWeight: 700,
         mr: 0,

--- a/web-app/src/app/components/WarningContentBox.tsx
+++ b/web-app/src/app/components/WarningContentBox.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Box, Typography, colors } from '@mui/material';
+import { ContentBox } from './ContentBox';
+import { WarningAmberOutlined } from '@mui/icons-material';
+
+export const WarningContentBox = (
+  props: React.PropsWithChildren,
+): JSX.Element => {
+  return (
+    <ContentBox
+      title={''}
+      width={{ xs: '100%' }}
+      outlineColor={colors.yellow[900]}
+      padding={2}
+      margin={'10px 0'}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <WarningAmberOutlined sx={{ mr: 1 }} />
+        <Typography sx={{ fontWeight: 'bold' }}>{props.children}</Typography>
+      </Box>
+    </ContentBox>
+  );
+};

--- a/web-app/src/app/screens/Feed/DataQualitySummary.tsx
+++ b/web-app/src/app/screens/Feed/DataQualitySummary.tsx
@@ -4,6 +4,7 @@ import { Button, Chip, Grid, Typography } from '@mui/material';
 import { CheckCircle, ReportOutlined } from '@mui/icons-material';
 import { type components } from '../../services/feeds/types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { WarningContentBox } from '../../components/WarningContentBox';
 
 export interface DataQualitySummaryProps {
   latestDataset: components['schemas']['GtfsDataset'] | undefined;
@@ -12,117 +13,122 @@ export interface DataQualitySummaryProps {
 export default function DataQualitySummary({
   latestDataset,
 }: DataQualitySummaryProps): React.ReactElement {
-  if (
-    latestDataset?.validation_report === undefined ||
-    latestDataset.validation_report === null
-  )
-    return <></>;
   return (
     <>
       <Typography variant='h6' gutterBottom>
         Data Quality Summary
       </Typography>
-      <Grid container direction={'column'} spacing={2}>
-        <Grid item container direction={'row'} spacing={2}>
-          <Grid
-            item
-            sx={{
-              alignContent: 'center',
-            }}
-          >
-            <Chip
-              icon={
-                latestDataset?.validation_report?.unique_error_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_error_count > 0 ? (
-                  <ReportOutlined />
-                ) : (
-                  <CheckCircle />
-                )
-              }
-              label={
-                latestDataset?.validation_report?.unique_error_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_error_count > 0
-                  ? `${latestDataset?.validation_report?.unique_error_count} errors`
-                  : `No errors`
-              }
-              color={
-                latestDataset?.validation_report?.unique_error_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_error_count > 0
-                  ? 'error'
-                  : 'success'
-              }
-              variant='outlined'
-            />
+      {(latestDataset?.validation_report === undefined ||
+        latestDataset.validation_report === null) && (
+        <WarningContentBox>
+          Unable to generate data quality report.
+        </WarningContentBox>
+      )}
+      {latestDataset?.validation_report !== undefined &&
+        latestDataset.validation_report !== null && (
+          <Grid container direction={'column'} spacing={2}>
+            <Grid item container direction={'row'} spacing={2}>
+              <Grid
+                item
+                sx={{
+                  alignContent: 'center',
+                }}
+              >
+                <Chip
+                  icon={
+                    latestDataset?.validation_report?.unique_error_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_error_count > 0 ? (
+                      <ReportOutlined />
+                    ) : (
+                      <CheckCircle />
+                    )
+                  }
+                  label={
+                    latestDataset?.validation_report?.unique_error_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_error_count > 0
+                      ? `${latestDataset?.validation_report?.unique_error_count} errors`
+                      : `No errors`
+                  }
+                  color={
+                    latestDataset?.validation_report?.unique_error_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_error_count > 0
+                      ? 'error'
+                      : 'success'
+                  }
+                  variant='outlined'
+                />
+              </Grid>
+              <Grid
+                item
+                sx={{
+                  alignContent: 'center',
+                }}
+              >
+                <Chip
+                  icon={
+                    latestDataset?.validation_report?.unique_warning_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_warning_count >
+                      0 ? (
+                      <ReportOutlined />
+                    ) : (
+                      <CheckCircle />
+                    )
+                  }
+                  label={
+                    latestDataset?.validation_report?.unique_warning_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_warning_count > 0
+                      ? `${latestDataset?.validation_report?.unique_warning_count} warnings`
+                      : `No warnings`
+                  }
+                  color={
+                    latestDataset?.validation_report?.unique_warning_count !==
+                      undefined &&
+                    latestDataset?.validation_report?.unique_warning_count > 0
+                      ? 'warning'
+                      : 'success'
+                  }
+                  variant='outlined'
+                />
+              </Grid>
+              <Grid
+                item
+                sx={{
+                  alignContent: 'center',
+                }}
+              >
+                <Chip
+                  icon={<InfoOutlinedIcon />}
+                  label={`${
+                    latestDataset?.validation_report?.unique_info_count ?? '0'
+                  } info notices`}
+                  color='primary'
+                  variant='outlined'
+                />
+              </Grid>
+            </Grid>
+            <Grid item container direction={'row'} spacing={2}>
+              <Grid item>
+                {latestDataset?.validation_report?.url_html !== undefined && (
+                  <Button variant='contained' disableElevation>
+                    <a
+                      href={`${latestDataset?.validation_report?.url_html}`}
+                      target='_blank'
+                      className='btn-link'
+                      rel='noreferrer'
+                    >
+                      Open Full Report
+                    </a>
+                  </Button>
+                )}
+              </Grid>
+            </Grid>
           </Grid>
-          <Grid
-            item
-            sx={{
-              alignContent: 'center',
-            }}
-          >
-            <Chip
-              icon={
-                latestDataset?.validation_report?.unique_warning_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_warning_count > 0 ? (
-                  <ReportOutlined />
-                ) : (
-                  <CheckCircle />
-                )
-              }
-              label={
-                latestDataset?.validation_report?.unique_warning_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_warning_count > 0
-                  ? `${latestDataset?.validation_report?.unique_warning_count} warnings`
-                  : `No warnings`
-              }
-              color={
-                latestDataset?.validation_report?.unique_warning_count !==
-                  undefined &&
-                latestDataset?.validation_report?.unique_warning_count > 0
-                  ? 'warning'
-                  : 'success'
-              }
-              variant='outlined'
-            />
-          </Grid>
-          <Grid
-            item
-            sx={{
-              alignContent: 'center',
-            }}
-          >
-            <Chip
-              icon={<InfoOutlinedIcon />}
-              label={`${
-                latestDataset?.validation_report?.unique_info_count ?? '0'
-              } info notices`}
-              color='primary'
-              variant='outlined'
-            />
-          </Grid>
-        </Grid>
-        <Grid item container direction={'row'} spacing={2}>
-          <Grid item>
-            {latestDataset?.validation_report?.url_html !== undefined && (
-              <Button variant='contained' disableElevation>
-                <a
-                  href={`${latestDataset?.validation_report?.url_html}`}
-                  target='_blank'
-                  className='btn-link'
-                  rel='noreferrer'
-                >
-                  Open Full Report
-                </a>
-              </Button>
-            )}
-          </Grid>
-        </Grid>
-      </Grid>
+        )}
     </>
   );
 }

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -79,7 +79,7 @@ export default function PreviousDatasets({
                 <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
                   {(dataset.validation_report === null ||
                     dataset.validation_report === undefined) && (
-                    <Typography>
+                    <Typography sx={{ ml: '4px' }}>
                       Unable to generate data quality report
                     </Typography>
                   )}
@@ -154,7 +154,7 @@ export default function PreviousDatasets({
                       </>
                     )}
                 </TableCell>
-                <TableCell sx={{ textAlign: 'center' }}>
+                <TableCell>
                   {(dataset.validation_report === null ||
                     dataset.validation_report === undefined) && (
                     <Button

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -77,6 +77,12 @@ export default function PreviousDatasets({
                   </Button>
                 </TableCell>
                 <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
+                  {(dataset.validation_report === null ||
+                    dataset.validation_report === undefined) && (
+                    <Typography>
+                      Unable to generate data quality report
+                    </Typography>
+                  )}
                   {dataset.validation_report !== null &&
                     dataset.validation_report !== undefined && (
                       <>
@@ -149,41 +155,58 @@ export default function PreviousDatasets({
                     )}
                 </TableCell>
                 <TableCell sx={{ textAlign: 'center' }}>
+                  {(dataset.validation_report === null ||
+                    dataset.validation_report === undefined) && (
+                    <Button
+                      variant='contained'
+                      sx={{ mx: 2 }}
+                      disableElevation
+                      endIcon={<LaunchOutlined />}
+                    >
+                      <a
+                        href={'https://gtfs-validator.mobilitydata.org/'}
+                        target='_blank'
+                        className='btn-link'
+                        rel='noreferrer'
+                      >
+                        Run Validator Yourself
+                      </a>
+                    </Button>
+                  )}
                   {dataset.validation_report != null &&
                     dataset.validation_report !== undefined && (
-                      <Button
-                        variant='contained'
-                        sx={{ mx: 2 }}
-                        disableElevation
-                        endIcon={<LaunchOutlined />}
-                      >
-                        <a
-                          href={`${dataset?.validation_report?.url_html}`}
-                          target='_blank'
-                          className='btn-link'
-                          rel='noreferrer'
+                      <>
+                        <Button
+                          variant='contained'
+                          sx={{ mx: 2 }}
+                          disableElevation
+                          endIcon={<LaunchOutlined />}
                         >
-                          View Report
-                        </a>
-                      </Button>
-                    )}
-                  {dataset.validation_report != null &&
-                    dataset.validation_report !== undefined && (
-                      <Button
-                        variant='contained'
-                        sx={{ mx: 2, my: { xs: 1, xl: 0 } }}
-                        endIcon={<LaunchOutlined />}
-                        disableElevation
-                      >
-                        <a
-                          href={`${dataset?.validation_report?.url_json}`}
-                          target='_blank'
-                          className='btn-link'
-                          rel='noreferrer'
+                          <a
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            className='btn-link'
+                            rel='noreferrer'
+                          >
+                            View Report
+                          </a>
+                        </Button>
+                        <Button
+                          variant='contained'
+                          sx={{ mx: 2, my: { xs: 1, xl: 0 } }}
+                          endIcon={<LaunchOutlined />}
+                          disableElevation
                         >
-                          JSON Version
-                        </a>
-                      </Button>
+                          <a
+                            href={`${dataset?.validation_report?.url_json}`}
+                            target='_blank'
+                            className='btn-link'
+                            rel='noreferrer'
+                          >
+                            JSON Version
+                          </a>
+                        </Button>
+                      </>
                     )}
                 </TableCell>
               </TableRow>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -11,7 +11,7 @@ import {
   Grid,
   colors,
 } from '@mui/material';
-import { ChevronLeft, WarningAmberOutlined } from '@mui/icons-material';
+import { ChevronLeft } from '@mui/icons-material';
 import '../../styles/SignUp.css';
 import '../../styles/FAQ.css';
 import { ContentBox } from '../../components/ContentBox';
@@ -44,6 +44,7 @@ import PreviousDatasets from './PreviousDatasets';
 import FeedSummary from './FeedSummary';
 import DataQualitySummary from './DataQualitySummary';
 import AssociatedFeeds from './AssociatedFeeds';
+import { WarningContentBox } from '../../components/WarningContentBox';
 
 export default function Feed(): React.ReactElement {
   const { feedId } = useParams();
@@ -61,6 +62,7 @@ export default function Feed(): React.ReactElement {
   const dispatch = useAppDispatch();
   const isAuthenticatedOrAnonymous =
     useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);
+  const hasDatasets = datasets !== undefined && datasets.length > 0;
 
   useEffect(() => {
     if (user !== undefined && feedId !== undefined) {
@@ -213,20 +215,24 @@ export default function Feed(): React.ReactElement {
                     </Typography>
                   </Grid>
                 )}
+              {!hasDatasets && (
+                <Grid item xs={12}>
+                  <WarningContentBox>
+                    Unable to download this feed. If there is a more recent URL
+                    for this feed,{' '}
+                    <a href='/contribute'>please submit it here</a>
+                  </WarningContentBox>
+                </Grid>
+              )}
               {feed?.redirects !== undefined && feed?.redirects.length > 0 && (
                 <Grid item xs={12}>
-                  <ContentBox
-                    title={''}
-                    width={{ xs: '100%' }}
-                    outlineColor={colors.yellow[900]}
-                  >
-                    <WarningAmberOutlined />
-                    This feed has been replaced with a different producer URL.
+                  <WarningContentBox>
+                    This feed has been replaced with a different producer URL.{' '}
                     <a href={`/feeds/${feed.redirects[0].target_id}`}>
                       Go to the new feed here
                     </a>
                     .
-                  </ContentBox>
+                  </WarningContentBox>
                 </Grid>
               )}
               <Grid item xs={12} marginBottom={2}>
@@ -301,6 +307,11 @@ export default function Feed(): React.ReactElement {
                         outlineColor={colors.blue[900]}
                         padding={2}
                       >
+                        {boundingBox === undefined && (
+                          <WarningContentBox>
+                            Unable to generate bounding box.
+                          </WarningContentBox>
+                        )}
                         {boundingBox !== undefined && (
                           <Box width={{ xs: '100%' }} sx={{ mt: 2, mb: 2 }}>
                             <Map polygon={boundingBox} />
@@ -321,7 +332,7 @@ export default function Feed(): React.ReactElement {
                   </Grid>
                 </Grid>
               </Grid>
-              {feed?.data_type === 'gtfs' && (
+              {feed?.data_type === 'gtfs' && hasDatasets && (
                 <Grid item xs={12}>
                   <PreviousDatasets datasets={datasets} />
                 </Grid>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -63,6 +63,10 @@ export default function Feed(): React.ReactElement {
   const isAuthenticatedOrAnonymous =
     useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);
   const hasDatasets = datasets !== undefined && datasets.length > 0;
+  const downloadLatestUrl =
+    feed?.data_type === 'gtfs'
+      ? feed?.latest_dataset?.hosted_url
+      : feed?.source_info?.producer_url;
 
   useEffect(() => {
     if (user !== undefined && feedId !== undefined) {
@@ -236,18 +240,14 @@ export default function Feed(): React.ReactElement {
                 </Grid>
               )}
               <Grid item xs={12} marginBottom={2}>
-                {feedType === 'gtfs' && (
+                {feedType === 'gtfs' && downloadLatestUrl !== undefined && (
                   <Button
                     disableElevation
                     variant='contained'
                     sx={{ marginRight: 2 }}
                   >
                     <a
-                      href={
-                        feed?.data_type === 'gtfs'
-                          ? feed?.latest_dataset?.hosted_url
-                          : feed?.source_info?.producer_url
-                      }
+                      href={downloadLatestUrl}
                       target='_blank'
                       className='btn-link'
                       rel='noreferrer'


### PR DESCRIPTION
closes: #535 
**Summary:**

Handle the `undefined` or `null` states in the Feed page as well as styling the warning component

**Expected behavior:** 

1. If a feed doesn't have bounding box data, show warning
2. If a feed doesn't have data quality report, show warning
3. If a feed doesn't have datasets, show warning + hide previous
4. If a feed dataset doesn't have data quality report, show action 

**Testing tips:**

Go to the specified feed ids and view warnings

Feed ids to test
[No bounding box + no data quality report + no datasets]: mdb-1838 (SEMO)
[Deprecated Feed]: mdb-273 (Ben Franklin Transit) deprecated 
[Dataset missing data quality]: mdb-2024 (Ben Franklin Transit)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

<img width="1581" alt="Screenshot 2024-07-09 at 10 07 28" src="https://github.com/MobilityData/mobility-feed-api/assets/18631060/41ea7dfe-dd2d-452f-be77-da80c0d75865">

<img width="1439" alt="Screenshot 2024-07-09 at 10 07 54" src="https://github.com/MobilityData/mobility-feed-api/assets/18631060/ad420ca1-3b8c-4eda-9028-e8c79bf1fd91">

<img width="1082" alt="Screenshot 2024-07-09 at 10 29 15" src="https://github.com/MobilityData/mobility-feed-api/assets/18631060/34df4288-6645-4fca-a146-1fd59fb6b1a3">

