### PR TITLE
feat: gtfs rt entity icons in search page

### DIFF
--- a/web-app/public/locales/en/common.json
+++ b/web-app/public/locales/en/common.json
@@ -10,6 +10,11 @@
     "feeds": "Feeds",
     "gtfsSchedule": "GTFS Schedule",
     "gtfsRealtime": "GTFS Realtime",
+    "gtfsRealtimeEntities": {
+        "tripUpdates": "Trip Updates",
+        "vehiclePositions": "Vehicle Positions",
+        "serviceAlerts": "Service Alerts"
+    },
     "loading": "Loading...",
     "errors": {
         "generic": "We are unable to complete your request at the moment."

--- a/web-app/src/app/screens/Feeds/GtfsRtEntities.tsx
+++ b/web-app/src/app/screens/Feeds/GtfsRtEntities.tsx
@@ -1,0 +1,66 @@
+import { Box, type SxProps, Tooltip, colors } from '@mui/material';
+import * as React from 'react';
+
+import UpdateIcon from '@mui/icons-material/Update';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { useTranslation } from 'react-i18next';
+
+type GtfsRtEntitySelection = 'vp' | 'tu' | 'sa';
+
+interface GtfsRtEntitiesProps {
+  entities: GtfsRtEntitySelection[] | undefined;
+}
+
+const iconStyle: SxProps = {
+  color: 'white',
+  borderRadius: '50%',
+  padding: '3px',
+};
+
+export default function GtfsRtEntities({
+  entities,
+}: GtfsRtEntitiesProps): React.ReactElement {
+  const { t } = useTranslation('common');
+  const entityData = {
+    vp: {
+      icon: (
+        <LocationOnIcon sx={{ ...iconStyle, background: colors.blue[600] }} />
+      ),
+      title: t('gtfsRealtimeEntities.vehiclePositions'),
+    },
+    tu: {
+      icon: <UpdateIcon sx={{ ...iconStyle, background: colors.blue[300] }} />,
+      title: t('gtfsRealtimeEntities.tripUpdates'),
+    },
+    sa: {
+      icon: (
+        <WarningAmberIcon sx={{ ...iconStyle, background: colors.blue[900] }} />
+      ),
+      title: t('gtfsRealtimeEntities.serviceAlerts'),
+    },
+  };
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        ml: 1,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        gap: '2px',
+      }}
+    >
+      {entities?.map((entity) => {
+        return (
+          <Tooltip
+            title={entityData[entity].title}
+            placement='top'
+            key={entity}
+          >
+            {entityData[entity].icon}
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+}

--- a/web-app/src/app/screens/Feeds/SearchTable.tsx
+++ b/web-app/src/app/screens/Feeds/SearchTable.tsx
@@ -16,6 +16,7 @@ import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import GtfsRtEntities from './GtfsRtEntities';
 
 export interface SearchTableProps {
   feedsData: AllFeedsType | undefined;
@@ -39,8 +40,7 @@ const getDataTypeElement = (dataType: 'gtfs' | 'gtfs_rt'): JSX.Element => {
         sx={{
           display: 'flex',
           alignItems: 'center',
-          p: 1,
-          justifyContent: 'flex-end',
+          justifyContent: 'flex-start',
         }}
       >
         {children}
@@ -50,14 +50,14 @@ const getDataTypeElement = (dataType: 'gtfs' | 'gtfs_rt'): JSX.Element => {
   if (dataType === 'gtfs') {
     return (
       <DataTypeHolder>
-        <DirectionsBusIcon sx={{ m: 1 }}></DirectionsBusIcon>
+        <DirectionsBusIcon sx={{ m: 1, ml: 0 }}></DirectionsBusIcon>
         {t('common:gtfsSchedule')}
       </DataTypeHolder>
     );
   } else {
     return (
       <DataTypeHolder>
-        <BusAlertIcon sx={{ m: 1 }}></BusAlertIcon>
+        <BusAlertIcon sx={{ m: 1, ml: 0 }}></BusAlertIcon>
         {t('common:gtfsRealtime')}
       </DataTypeHolder>
     );
@@ -111,7 +111,7 @@ export default function SearchTable({
           <HeaderTableCell>{t('transitProvider')}</HeaderTableCell>
           <HeaderTableCell>{t('location')}</HeaderTableCell>
           <HeaderTableCell>{t('feedDescription')}</HeaderTableCell>
-          <HeaderTableCell align='right'>{t('dataType')}</HeaderTableCell>
+          <HeaderTableCell>{t('dataType')}</HeaderTableCell>
         </TableRow>
       </TableHead>
 
@@ -140,7 +140,7 @@ export default function SearchTable({
           },
           'tr td:last-child': {
             borderRight: '1px solid black',
-            minWidth: '205px',
+            minWidth: '210px',
           },
         }}
       >
@@ -178,8 +178,13 @@ export default function SearchTable({
             </TableCell>
             <TableCell>{getLocationName(feed.locations)}</TableCell>
             <TableCell>{feed.feed_name}</TableCell>
-            <TableCell align='left'>
-              {getDataTypeElement(feed.data_type)}
+            <TableCell>
+              <Box sx={{ display: 'flex' }}>
+                {getDataTypeElement(feed.data_type)}
+                {feed.data_type === 'gtfs_rt' && (
+                  <GtfsRtEntities entities={feed.entity_types}></GtfsRtEntities>
+                )}
+              </Box>
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
closes #541 
**Summary:**

Add indicators in the search page for GTFS RT to display which entities are available

**Expected behavior:** 

Display the available gtfs rt entitites with a tool tip

**Testing tips:**

Search feeds and see if the correct icons show up

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2024-07-10 at 10 48 20](https://github.com/MobilityData/mobility-feed-api/assets/18631060/d7e63770-0a57-43e6-9e54-a9d6273bbc90)

![Screenshot 2024-07-10 at 10 59 55](https://github.com/MobilityData/mobility-feed-api/assets/18631060/1ca60a02-f06f-4bb5-a384-93e316bf06b7)


