### PR TITLE
Feat: Feed page remove duplicate warnings (no dataset and redirect link)

### DIFF
--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -63,6 +63,8 @@ export default function Feed(): React.ReactElement {
   const isAuthenticatedOrAnonymous =
     useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);
   const hasDatasets = datasets !== undefined && datasets.length > 0;
+  const hasFeedRedirect =
+    feed?.redirects !== undefined && feed?.redirects.length > 0;
   const downloadLatestUrl =
     feed?.data_type === 'gtfs'
       ? feed?.latest_dataset?.hosted_url
@@ -219,7 +221,7 @@ export default function Feed(): React.ReactElement {
                     </Typography>
                   </Grid>
                 )}
-              {!hasDatasets && (
+              {!hasDatasets && !hasFeedRedirect && (
                 <Grid item xs={12}>
                   <WarningContentBox>
                     Unable to download this feed. If there is a more recent URL
@@ -228,11 +230,11 @@ export default function Feed(): React.ReactElement {
                   </WarningContentBox>
                 </Grid>
               )}
-              {feed?.redirects !== undefined && feed?.redirects.length > 0 && (
+              {hasFeedRedirect && (
                 <Grid item xs={12}>
                   <WarningContentBox>
                     This feed has been replaced with a different producer URL.{' '}
-                    <a href={`/feeds/${feed.redirects[0].target_id}`}>
+                    <a href={`/feeds/${feed?.redirects?.[0]?.target_id}`}>
                       Go to the new feed here
                     </a>
                     .


### PR DESCRIPTION
closes #547 
**Summary:**

When a feed doesn't have a dataset but has a redirect link, it should only show the redirect link warning and not both

**Expected behavior:** 

Above^

**Testing tips:**

Go on feeds with redirect links and no datasets and make sure only 1 warning appears
ex: mdb-1030

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2024-07-10 at 13 46 12](https://github.com/MobilityData/mobility-feed-api/assets/18631060/7448dfd4-000c-47e8-b00e-46ab07744ea0)
