### PR TITLE
feat: add created_at timestamp to feed response

### DIFF
--- a/api/src/feeds/impl/models/basic_feed_impl.py
+++ b/api/src/feeds/impl/models/basic_feed_impl.py
@@ -27,6 +27,7 @@ class BaseFeedImpl(BasicFeed):
             id=feed.stable_id,
             data_type=feed.data_type,
             status=feed.status,
+            created_at=feed.created_at,
             external_ids=sorted(
                 [ExternalIdImpl.from_orm(item) for item in feed.externalids], key=lambda x: x.external_id
             ),

--- a/api/src/scripts/populate_db.py
+++ b/api/src/scripts/populate_db.py
@@ -21,6 +21,8 @@ from database_gen.sqlacodegen_models import (
 from scripts.load_dataset_on_create import publish_all
 from utils.data_utils import set_up_defaults
 from utils.logger import Logger
+from datetime import datetime
+import pytz
 
 import logging
 
@@ -219,7 +221,12 @@ class DatabasePopulateHelper:
             if feed:
                 self.logger.debug(f"Updating {feed.__class__.__name__}: {stable_id}")
             else:
-                feed = self.get_model(data_type)(id=generate_unique_id(), data_type=data_type, stable_id=stable_id)
+                feed = self.get_model(data_type)(
+                    id=generate_unique_id(),
+                    data_type=data_type,
+                    stable_id=stable_id,
+                    created_at=datetime.now(pytz.utc),  # Current timestamp with UTC timezone
+                )
                 self.logger.info(f"Creating {feed.__class__.__name__}: {stable_id}")
                 self.db.session.add(feed)
                 if data_type == "gtfs":

--- a/api/src/scripts/populate_db_test_data.py
+++ b/api/src/scripts/populate_db_test_data.py
@@ -113,7 +113,6 @@ class DatabasePopulateTestDataHelper:
         Populate the database with the test data
         """
         self.logger.info("Populating the database with test data")
-        # set_up_defaults(self.db)
         self.populate_test_datasets()
         self.logger.info("Database populated with test data")
 

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -345,6 +345,11 @@ components:
           example: deprecated
 #           Have to put the enum inline because of a bug in openapi-generator
 #          $ref: "#/components/schemas/FeedStatus"
+        created_at:
+          description: The date and time the feed was added to the database, in ISO 8601 date-time format.
+          type: string
+          example: 2023-07-10T22:06:00Z
+          format: date-time
 
         external_ids:
           $ref: "#/components/schemas/ExternalIds"

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -22,4 +22,5 @@
     <include file="changes/feat_371.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_360.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_389.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_533.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_533.sql
+++ b/liquibase/changes/feat_533.sql
@@ -1,2 +1,2 @@
--- Adding created_at column to Feed table with default value of current timestamp for new records
-ALTER TABLE Feed ADD COLUMN created_at TIMESTAMPTZ NULL;
+-- Adding created_at column to Feed table with default value and not null constraint
+ALTER TABLE Feed ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT '2024-02-08 00:00:00.000000';

--- a/liquibase/changes/feat_533.sql
+++ b/liquibase/changes/feat_533.sql
@@ -1,2 +1,2 @@
 -- Adding created_at column to Feed table with default value of current timestamp for new records
-ALTER TABLE Feed ADD COLUMN created_at TIMESTAMP NULL;
+ALTER TABLE Feed ADD COLUMN created_at TIMESTAMPTZ NULL;

--- a/liquibase/changes/feat_533.sql
+++ b/liquibase/changes/feat_533.sql
@@ -1,0 +1,2 @@
+-- Adding created_at column to Feed table with default value of current timestamp for new records
+ALTER TABLE Feed ADD COLUMN created_at TIMESTAMP NULL;


### PR DESCRIPTION
**Summary:**

Closes [#533](https://github.com/MobilityData/mobility-feed-api/issues/533) by adding the `created_at` field to the responses of the basic feed, GTFS feed, and GTFS-RT feed. 

**Expected behavior:**

The `created_at` field should appear in the API responses for the basic feed, GTFS feed, and GTFS-RT feed. The field should contain a timestamp indicating when the feed was created.

Example response:
```json
{
    "id": "mdb-195",
    "data_type": "gtfs",
    "status": "active",
    "created_at": "2024-07-11T15:24:16.631817Z",
   // other existing fields
}
```

**Testing tips:**

- Run the API locally to ensure the changes are correctly integrated.
- Verify that the `created_at` field is present in the responses for the basic feed, GTFS feed, and GTFS-RT feed.
- Check that the `created_at` field contains a valid timestamp reflecting the creation time of the feed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
