### PR TITLE
chore: add cypress intercepts for feed api calls

### DIFF
--- a/web-app/cypress/e2e/feeds.cy.ts
+++ b/web-app/cypress/e2e/feeds.cy.ts
@@ -2,6 +2,7 @@ describe('Feed page', () => {
   beforeEach(() => {
     // (API mocking code remains the same)
     cy.visit('/feeds/mdb-516');
+    cy.wait(100);
   });
 
   it('should render feed title and provider', () => {

--- a/web-app/cypress/e2e/feeds.cy.ts
+++ b/web-app/cypress/e2e/feeds.cy.ts
@@ -1,14 +1,25 @@
+import feedJson from '../fixtures/feed_test-516.json';
+import gtfsFeedJson from '../fixtures/gtfs_feed_test-516.json';
+import datasetsFeedJson from '../fixtures/feed_datasets_test-516.json';
+
+const apiBaseUrl = '**';
+
 describe('Feed page', () => {
   beforeEach(() => {
-    // (API mocking code remains the same)
-    cy.visit('/feeds/mdb-516');
-    cy.wait(100);
+    cy.intercept('GET', `${apiBaseUrl}/v1/feeds/test-516`, feedJson);
+    cy.intercept('GET', `${apiBaseUrl}/v1/gtfs_feeds/test-516`, gtfsFeedJson);
+    cy.intercept(
+      'GET',
+      `${apiBaseUrl}/v1/gtfs_feeds/test-516/datasets`,
+      datasetsFeedJson,
+    );
+    cy.visit('feeds/test-516');
   });
 
   it('should render feed title and provider', () => {
     cy.get('[data-testid="feed-provider"]').should(
       'contain',
-      'MTA New York City Transit (MTA)',
+      'Metropolitan Transit Authority (MTA)',
     );
     cy.get('[data-testid="feed-name"]').should('contain', 'NYC Subway');
   });

--- a/web-app/cypress/fixtures/feed_datasets_test-516.json
+++ b/web-app/cypress/fixtures/feed_datasets_test-516.json
@@ -1,0 +1,63 @@
+[
+    {
+        "id": "mdb-516-202402071830",
+        "feed_id": "mdb-516",
+        "hosted_url": "https://storage.googleapis.com/mobilitydata-datasets-qa/mdb-516/mdb-516-202402071830/mdb-516-202402071830.zip",
+        "note": null,
+        "downloaded_at": "2024-02-07T18:16:50.247142Z",
+        "hash": "d140d863d94cfc14228480babc3a004616fde281c64a0813207ee2bc235e5aba",
+        "bounding_box": null,
+        "validation_report": {
+            "validated_at": "2024-06-27T11:10:52Z",
+            "features": [
+                "Transfers",
+                "Shapes",
+                "Route Colors",
+                "Headsigns",
+                "Location Types"
+            ],
+            "validator_version": "5.0.2-SNAPSHOT",
+            "total_error": 0,
+            "total_warning": 119,
+            "total_info": 0,
+            "unique_error_count": 0,
+            "unique_warning_count": 7,
+            "unique_info_count": 0,
+            "url_json": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202402071830/report_5.0.2-SNAPSHOT.json",
+            "url_html": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202402071830/report_5.0.2-SNAPSHOT.html"
+        }
+    },
+    {
+        "id": "mdb-516-202407101414",
+        "feed_id": "mdb-516",
+        "hosted_url": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202407101414/mdb-516-202407101414.zip",
+        "note": null,
+        "downloaded_at": "2024-07-10T14:00:15.488196Z",
+        "hash": "5d778850ac280d4ef8e5f49cc490f7592750b6673496096a132b8bed2381460e",
+        "bounding_box": {
+            "minimum_latitude": 40.512764,
+            "maximum_latitude": 40.903125,
+            "minimum_longitude": -74.251961,
+            "maximum_longitude": -73.755405
+        },
+        "validation_report": {
+            "validated_at": "2024-07-10T14:00:25Z",
+            "features": [
+                "Transfers",
+                "Shapes",
+                "Route Colors",
+                "Headsigns",
+                "Location Types"
+            ],
+            "validator_version": "5.0.2-SNAPSHOT",
+            "total_error": 0,
+            "total_warning": 124,
+            "total_info": 0,
+            "unique_error_count": 0,
+            "unique_warning_count": 6,
+            "unique_info_count": 0,
+            "url_json": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202407101414/report_5.0.2-SNAPSHOT.json",
+            "url_html": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202407101414/report_5.0.2-SNAPSHOT.html"
+        }
+    }
+]

--- a/web-app/cypress/fixtures/feed_test-516.json
+++ b/web-app/cypress/fixtures/feed_test-516.json
@@ -1,0 +1,24 @@
+{
+    "id": "mdb-516",
+    "data_type": "gtfs",
+    "status": "active",
+    "created_at": "2024-02-08T00:00:00Z",
+    "external_ids": [
+        {
+            "external_id": "516",
+            "source": "mdb"
+        }
+    ],
+    "provider": "Metropolitan Transit Authority (MTA)",
+    "feed_name": "NYC Subway",
+    "note": "",
+    "feed_contact_email": "",
+    "source_info": {
+        "producer_url": "http://web.mta.info/developers/data/nyct/subway/google_transit.zip",
+        "authentication_type": 0,
+        "authentication_info_url": "",
+        "api_key_parameter_name": "",
+        "license_url": ""
+    },
+    "redirects": []
+}

--- a/web-app/cypress/fixtures/gtfs_feed_test-516.json
+++ b/web-app/cypress/fixtures/gtfs_feed_test-516.json
@@ -1,0 +1,51 @@
+{
+    "id": "mdb-516",
+    "data_type": "gtfs",
+    "status": "active",
+    "created_at": "2024-02-08T00:00:00Z",
+    "external_ids": [
+        {
+            "external_id": "516",
+            "source": "mdb"
+        }
+    ],
+    "provider": "Metropolitan Transit Authority (MTA)",
+    "feed_name": "NYC Subway",
+    "note": "",
+    "feed_contact_email": "",
+    "source_info": {
+        "producer_url": "http://web.mta.info/developers/data/nyct/subway/google_transit.zip",
+        "authentication_type": 0,
+        "authentication_info_url": "",
+        "api_key_parameter_name": "",
+        "license_url": ""
+    },
+    "redirects": [],
+    "locations": [
+        {
+            "country_code": "US",
+            "subdivision_name": "New York",
+            "municipality": "New York City"
+        }
+    ],
+    "latest_dataset": {
+        "id": "mdb-516-202407101414",
+        "hosted_url": "https://qa-files.mobilitydatabase.org/mdb-516/mdb-516-202407101414/mdb-516-202407101414.zip",
+        "bounding_box": {
+            "minimum_latitude": 40.512764,
+            "maximum_latitude": 40.903125,
+            "minimum_longitude": -74.251961,
+            "maximum_longitude": -73.755405
+        },
+        "downloaded_at": "2024-07-10T14:00:15.488196Z",
+        "hash": "5d778850ac280d4ef8e5f49cc490f7592750b6673496096a132b8bed2381460e",
+        "validation_report": {
+            "total_error": 0,
+            "total_warning": 124,
+            "total_info": 0,
+            "unique_error_count": 0,
+            "unique_warning_count": 6,
+            "unique_info_count": 0
+        }
+    }
+}


### PR DESCRIPTION
**Summary:**
Add cypress intercepts for feed API calls.
I tried to use the _cy. fixtures_ command from Cypress, but its asynchronous nature makes the code less readable. This is why I used a regular JSON import for the fixtures. 

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
