### PR TITLE
fix: returned 404 if feed does not exist

### DIFF
--- a/api/tests/integration/test_datasets_api.py
+++ b/api/tests/integration/test_datasets_api.py
@@ -37,3 +37,28 @@ def test_feeds_gtfs_id_datasets_get(client: TestClient):
     )
 
     assert response.status_code == 200
+
+
+def test_feeds_wrong_gtfs_id_datasets_get(client: TestClient):
+    """Test case for feeds_gtfs_id_datasets_get where the gtfs feed id does not exist"""
+
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets".format(id="nonexistent"),
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 404
+
+
+def test_feeds_gtfs_id_no_datasets_get(client: TestClient):
+    """Test case for feeds_gtfs_id_datasets_get where the gtfs feed does not have any dataset"""
+
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds/{id}/datasets".format(id="mdb-20"),
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 0, "Expected no datasets, but got some"


### PR DESCRIPTION
**Summary:**
Closes #600 

Applies to `/v1/gtfs_feeds/{id}/datasets` endpoint
Checked for the existence of a feed before trying to extract its datasets.

**Expected behavior:** 

If the feed does not exist it should return 404
If the feed does exist but has no datasets, it should return 200 with an empty list.

**Testing tips:**


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
