### PR TITLE
fix: Replaced Download button on GTFS pages with a hyperlink

### DIFF
--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -73,7 +73,16 @@ export default function FeedSummary({
             sx={{ display: 'flex', overflowWrap: 'anywhere' }}
             data-testid='producer-url'
           >
-            {feed?.source_info?.producer_url}
+            {feed?.source_info?.producer_url !== undefined && (
+              <a
+                href={feed?.source_info?.producer_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: 'none' }}
+              >
+                {feed?.source_info?.producer_url}
+              </a>
+            )}
             <ContentCopy
               titleAccess='Copy download URL'
               sx={{ cursor: 'pointer', ml: 1 }}
@@ -87,17 +96,6 @@ export default function FeedSummary({
               }}
             />
           </Typography>
-          {feed?.source_info?.producer_url !== undefined && (
-            <a
-              href={feed?.source_info?.producer_url}
-              download
-              style={{ textDecoration: 'none' }}
-            >
-              <Button sx={{ mt: 1 }} variant='contained' disableElevation>
-                Download
-              </Button>
-            </a>
-          )}
           <Snackbar
             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
             open={snackbarOpen}

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -76,8 +76,8 @@ export default function FeedSummary({
             {feed?.source_info?.producer_url !== undefined && (
               <a
                 href={feed?.source_info?.producer_url}
-                target="_blank"
-                rel="noopener noreferrer"
+                target='_blank'
+                rel='noopener noreferrer'
                 style={{ textDecoration: 'none' }}
               >
                 {feed?.source_info?.producer_url}


### PR DESCRIPTION
**Summary:**
Closes #601 
![image](https://github.com/user-attachments/assets/a76036da-ee3c-4d1a-849d-af4a90911fcb)

**Expected behavior:** 
Replace Download button on GTFS pages with a hyperlink
Click on the producer url hyperlink opens a new tab

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
