### PR TITLE
fix: feed page renders empty screen when switching between GTFS and GTFS-RT feeds

### DIFF
--- a/web-app/cypress/fixtures/feed_datasets_test-516.json
+++ b/web-app/cypress/fixtures/feed_datasets_test-516.json
@@ -1,7 +1,7 @@
 [
     {
-        "id": "mdb-516-202402071830",
-        "feed_id": "mdb-516",
+        "id": "test-516-202402071830",
+        "feed_id": "test-516",
         "hosted_url": "https://storage.googleapis.com/mobilitydata-datasets-qa/mdb-516/mdb-516-202402071830/mdb-516-202402071830.zip",
         "note": null,
         "downloaded_at": "2024-02-07T18:16:50.247142Z",

--- a/web-app/cypress/fixtures/feed_test-516.json
+++ b/web-app/cypress/fixtures/feed_test-516.json
@@ -1,12 +1,12 @@
 {
-    "id": "mdb-516",
+    "id": "test-516",
     "data_type": "gtfs",
     "status": "active",
     "created_at": "2024-02-08T00:00:00Z",
     "external_ids": [
         {
             "external_id": "516",
-            "source": "mdb"
+            "source": "test"
         }
     ],
     "provider": "Metropolitan Transit Authority (MTA)",

--- a/web-app/cypress/fixtures/gtfs_feed_test-516.json
+++ b/web-app/cypress/fixtures/gtfs_feed_test-516.json
@@ -1,12 +1,12 @@
 {
-    "id": "mdb-516",
+    "id": "test-516",
     "data_type": "gtfs",
     "status": "active",
     "created_at": "2024-02-08T00:00:00Z",
     "external_ids": [
         {
             "external_id": "516",
-            "source": "mdb"
+            "source": "test"
         }
     ],
     "provider": "Metropolitan Transit Authority (MTA)",

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -16,11 +16,7 @@ import '../../styles/SignUp.css';
 import '../../styles/FAQ.css';
 import { ContentBox } from '../../components/ContentBox';
 import { useAppDispatch } from '../../hooks';
-import {
-  loadingFeed,
-  loadingRelatedFeeds,
-  resetFeed,
-} from '../../store/feed-reducer';
+import { loadingFeed, loadingRelatedFeeds } from '../../store/feed-reducer';
 import {
   selectIsAnonymous,
   selectIsAuthenticated,
@@ -34,10 +30,11 @@ import {
   selectRelatedFeedsData,
   selectRelatedGtfsRTFeedsData,
 } from '../../store/feed-selectors';
-import { loadingDataset } from '../../store/dataset-reducer';
+import { clearDataset, loadingDataset } from '../../store/dataset-reducer';
 import {
   selectBoundingBoxFromLatestDataset,
   selectDatasetsData,
+  selectDatasetsLoadingStatus,
   selectLatestDatasetsData,
 } from '../../store/dataset-selectors';
 import { Map } from '../../components/Map';
@@ -47,67 +44,10 @@ import DataQualitySummary from './DataQualitySummary';
 import AssociatedFeeds from './AssociatedFeeds';
 import { WarningContentBox } from '../../components/WarningContentBox';
 
-export default function Feed(): React.ReactElement {
-  const { feedId } = useParams();
-  const user = useSelector(selectUserProfile);
-  const feedLoadingStatus = useSelector(selectFeedLoadingStatus);
-  const feedType = useSelector(selectFeedData)?.data_type;
-  const feed =
-    feedType === 'gtfs'
-      ? useSelector(selectGTFSFeedData)
-      : useSelector(selectGTFSRTFeedData);
-  const relatedFeeds = useSelector(selectRelatedFeedsData);
-  const relatedGtfsRtFeeds = useSelector(selectRelatedGtfsRTFeedsData);
-  const datasets = useSelector(selectDatasetsData);
-  const latestDataset = useSelector(selectLatestDatasetsData);
-  const boundingBox = useSelector(selectBoundingBoxFromLatestDataset);
-  const dispatch = useAppDispatch();
-  const isAuthenticatedOrAnonymous =
-    useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);
-  const hasDatasets = datasets !== undefined && datasets.length > 0;
-  const hasFeedRedirect =
-    feed?.redirects !== undefined && feed?.redirects.length > 0;
-  const downloadLatestUrl =
-    feed?.data_type === 'gtfs'
-      ? feed?.latest_dataset?.hosted_url
-      : feed?.source_info?.producer_url;
-
-  useEffect(() => {
-    if (user !== undefined && feedId !== undefined) {
-      dispatch(loadingFeed({ feedId }));
-      dispatch(loadingDataset({ feedId }));
-
-      return () => {
-        dispatch(resetFeed());
-      };
-    }
-  }, [isAuthenticatedOrAnonymous]);
-
-  useEffect(() => {
-    let newDocTitle = 'Mobility Database';
-    if (feed?.provider !== undefined) {
-      newDocTitle += ` | ${feed?.provider}`;
-    }
-    if (feed?.feed_name !== undefined) {
-      newDocTitle += ` | ${feed?.feed_name}`;
-    }
-    document.title = newDocTitle;
-    if (
-      feed?.data_type === 'gtfs_rt' &&
-      feedLoadingStatus === 'loaded' &&
-      feed.feed_references !== undefined
-    ) {
-      dispatch(
-        loadingRelatedFeeds({
-          feedIds: feed.feed_references,
-        }),
-      );
-    }
-    return () => {
-      document.title = 'Mobility Database';
-    };
-  }, [feed]);
-
+const wrapComponent = (
+  feedLoadingStatus: string,
+  child: React.ReactElement,
+): React.ReactElement => {
   return (
     <Container component='main' sx={{ width: '100%', m: 'auto' }} maxWidth='xl'>
       <CssBaseline />
@@ -130,235 +70,306 @@ export default function Feed(): React.ReactElement {
           {feedLoadingStatus === 'error' && (
             <>There was an error loading the feed.</>
           )}
-          {feedLoadingStatus === 'loading' && 'Loading...'}
-          {feedLoadingStatus === 'loaded' && (
-            <Grid container spacing={2}>
-              <Grid container item xs={12} spacing={3} alignItems={'center'}>
-                <Grid
-                  item
-                  sx={{
-                    cursor: 'pointer',
-                  }}
-                  onClick={() => {
-                    if (history.length === 1) {
-                      window.location.href = '/feeds';
-                    } else {
-                      history.back();
-                    }
-                  }}
-                >
-                  <Grid container alignItems={'center'}>
-                    <ChevronLeft fontSize='small' sx={{ ml: '-20px' }} />{' '}
-                    <Typography>Back</Typography>
-                  </Grid>
-                </Grid>
-                <Grid item>
-                  <Typography
-                    sx={{
-                      a: {
-                        textDecoration: 'none',
-                      },
-                    }}
-                  >
-                    <a href='/feeds'>Feeds</a> /{' '}
-                    <a href={`/feeds?${feed?.data_type}=true`}>
-                      {feed?.data_type === 'gtfs'
-                        ? 'GTFS Schedule'
-                        : 'GTFS Realtime'}
-                    </a>{' '}
-                    / {feed?.id}
-                  </Typography>
-                </Grid>
-              </Grid>
-              <Grid item xs={12}>
-                <Typography
-                  sx={{
-                    color: colors.blue.A700,
-                    fontWeight: 'bold',
-                    fontSize: { xs: 24, sm: 36 },
-                  }}
-                  data-testid='feed-provider'
-                >
-                  {feed?.provider?.substring(0, 100)}
-                  {feed?.data_type === 'gtfs_rt' && ` - ${feed?.feed_name}`}
-                </Typography>
-              </Grid>
-              {feed !== undefined &&
-                feed.feed_name !== '' &&
-                feed?.data_type === 'gtfs' && (
-                  <Grid item xs={12}>
-                    <Typography
-                      sx={{
-                        fontWeight: 'bold',
-                        fontSize: { xs: 18, sm: 24 },
-                      }}
-                      data-testid='feed-name'
-                    >
-                      {feed?.feed_name}
-                    </Typography>
-                  </Grid>
-                )}
-              {latestDataset?.downloaded_at !== undefined && (
-                <Grid item xs={12}>
-                  <Typography data-testid='last-updated'>
-                    {`Last updated on ${new Date(
-                      latestDataset.downloaded_at,
-                    ).toDateString()}`}
-                  </Typography>
-                </Grid>
-              )}
-              {feed?.data_type === 'gtfs_rt' &&
-                feed.entity_types !== undefined && (
-                  <Grid item xs={12}>
-                    <Typography variant='h5'>
-                      {' '}
-                      {feed.entity_types
-                        .map(
-                          (entityType) =>
-                            ({
-                              tu: 'Trip Updates',
-                              vp: 'Vehicle Positions',
-                              sa: 'Service Alerts',
-                            })[entityType],
-                        )
-                        .join(' and ')}
-                    </Typography>
-                  </Grid>
-                )}
-              {feedType === 'gtfs' && !hasDatasets && !hasFeedRedirect && (
-                <Grid item xs={12}>
-                  <WarningContentBox>
-                    Unable to download this feed. If there is a more recent URL
-                    for this feed,{' '}
-                    <a href='/contribute'>please submit it here</a>
-                  </WarningContentBox>
-                </Grid>
-              )}
-              {hasFeedRedirect && (
-                <Grid item xs={12}>
-                  <WarningContentBox>
-                    This feed has been replaced with a different producer URL.{' '}
-                    <a href={`/feeds/${feed?.redirects?.[0]?.target_id}`}>
-                      Go to the new feed here
-                    </a>
-                    .
-                  </WarningContentBox>
-                </Grid>
-              )}
-              <Grid item xs={12} marginBottom={2}>
-                {feedType === 'gtfs' && downloadLatestUrl !== undefined && (
-                  <Button
-                    disableElevation
-                    variant='contained'
-                    sx={{ marginRight: 2 }}
-                  >
-                    <a
-                      href={downloadLatestUrl}
-                      target='_blank'
-                      className='btn-link'
-                      rel='noreferrer'
-                      id='download-latest-button'
-                    >
-                      Download Latest
-                    </a>
-                  </Button>
-                )}
-                {feed?.source_info?.license_url !== undefined &&
-                  feed?.source_info?.license_url !== '' && (
-                    <Button
-                      disableElevation
-                      variant='contained'
-                      sx={{ marginRight: 2 }}
-                    >
-                      <a
-                        href={feed?.source_info?.license_url}
-                        target='_blank'
-                        className='btn-link'
-                        rel='noreferrer'
-                      >
-                        See License
-                      </a>
-                    </Button>
-                  )}
-
-                {feed?.source_info?.authentication_info_url !== undefined &&
-                  feed?.source_info?.authentication_info_url !== '' && (
-                    <Button
-                      disableElevation
-                      variant='contained'
-                      sx={{ marginRight: 2 }}
-                    >
-                      <a
-                        href={feed?.source_info?.authentication_info_url}
-                        target='_blank'
-                        className='btn-link'
-                        rel='noreferrer'
-                      >
-                        See Authentication info
-                      </a>
-                    </Button>
-                  )}
-              </Grid>
-              <Grid item xs={12}>
-                <Grid item xs={12} container rowSpacing={2}>
-                  <Grid
-                    container
-                    direction={{
-                      xs:
-                        feed?.data_type === 'gtfs'
-                          ? 'column-reverse'
-                          : 'column',
-                      md: 'row',
-                    }}
-                    sx={{ gap: '10px' }}
-                    justifyContent={'space-between'}
-                  >
-                    {feed?.data_type === 'gtfs' && (
-                      <ContentBox
-                        title='Bounding box from stops.txt'
-                        width={{ xs: '100%', md: '42%' }}
-                        outlineColor={colors.blue[900]}
-                        padding={2}
-                      >
-                        {boundingBox === undefined && (
-                          <WarningContentBox>
-                            Unable to generate bounding box.
-                          </WarningContentBox>
-                        )}
-                        {boundingBox !== undefined && (
-                          <Box width={{ xs: '100%' }} sx={{ mt: 2, mb: 2 }}>
-                            <Map polygon={boundingBox} />
-                          </Box>
-                        )}
-                        <DataQualitySummary latestDataset={latestDataset} />
-                      </ContentBox>
-                    )}
-                    <FeedSummary
-                      feed={feed}
-                      latestDataset={latestDataset}
-                      width={{ xs: '100%', md: '55%' }}
-                    />
-
-                    {feed?.data_type === 'gtfs_rt' && (
-                      <AssociatedFeeds
-                        feeds={relatedFeeds.filter((f) => f?.id !== feed.id)}
-                        gtfsRtFeeds={relatedGtfsRtFeeds.filter(
-                          (f) => f?.id !== feed.id,
-                        )}
-                      />
-                    )}
-                  </Grid>
-                </Grid>
-              </Grid>
-              {feed?.data_type === 'gtfs' && hasDatasets && (
-                <Grid item xs={12}>
-                  <PreviousDatasets datasets={datasets} />
-                </Grid>
-              )}
-            </Grid>
-          )}
+          {feedLoadingStatus !== 'error' ? child : null}
         </Box>
       </Box>
     </Container>
+  );
+};
+
+export default function Feed(): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const { feedId } = useParams();
+  const user = useSelector(selectUserProfile);
+  const feedLoadingStatus = useSelector(selectFeedLoadingStatus);
+  const datasetLoadingStatus = useSelector(selectDatasetsLoadingStatus);
+  const feedType = useSelector(selectFeedData)?.data_type;
+  const feed =
+    feedType === 'gtfs'
+      ? useSelector(selectGTFSFeedData)
+      : useSelector(selectGTFSRTFeedData);
+  const needsToLoadFeed = feed === undefined || feed.id !== feedId;
+  const isAuthenticatedOrAnonymous =
+    useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);
+
+  useEffect(() => {
+    if (user !== undefined && feedId !== undefined && needsToLoadFeed) {
+      dispatch(clearDataset());
+      dispatch(loadingFeed({ feedId }));
+    }
+  }, [isAuthenticatedOrAnonymous, needsToLoadFeed]);
+
+  useEffect(() => {
+    if (needsToLoadFeed) {
+      return;
+    }
+    let newDocTitle = 'Mobility Database';
+    if (feed?.provider !== undefined) {
+      newDocTitle += ` | ${feed?.provider}`;
+    }
+    if (feed?.feed_name !== undefined) {
+      newDocTitle += ` | ${feed?.feed_name}`;
+    }
+    document.title = newDocTitle;
+    if (
+      feed?.data_type === 'gtfs_rt' &&
+      feedLoadingStatus === 'loaded' &&
+      feed.feed_references !== undefined
+    ) {
+      dispatch(
+        loadingRelatedFeeds({
+          feedIds: feed.feed_references,
+        }),
+      );
+    }
+    if (
+      feedId !== undefined &&
+      feed?.data_type === 'gtfs' &&
+      feedLoadingStatus === 'loaded'
+    ) {
+      dispatch(loadingDataset({ feedId }));
+    }
+    return () => {
+      document.title = 'Mobility Database';
+    };
+  }, [feed, needsToLoadFeed]);
+
+  const relatedFeeds = useSelector(selectRelatedFeedsData);
+  const relatedGtfsRtFeeds = useSelector(selectRelatedGtfsRTFeedsData);
+  const datasets = useSelector(selectDatasetsData);
+  const latestDataset = useSelector(selectLatestDatasetsData);
+  const boundingBox = useSelector(selectBoundingBoxFromLatestDataset);
+
+  // The feedId parameter doesn't match the feedId in the store,
+  // so we need to load the new feed data
+  if (feed === undefined || feed?.id !== feedId) {
+    return wrapComponent(feedLoadingStatus, <span>Loading...</span>);
+  }
+  const hasDatasets = datasets !== undefined && datasets.length > 0;
+  const hasFeedRedirect =
+    feed?.redirects !== undefined && feed?.redirects.length > 0;
+  const downloadLatestUrl =
+    feed?.data_type === 'gtfs'
+      ? feed?.latest_dataset?.hosted_url
+      : feed?.source_info?.producer_url;
+
+  return wrapComponent(
+    feedLoadingStatus,
+    <Grid container spacing={2}>
+      <Grid container item xs={12} spacing={3} alignItems={'center'}>
+        <Grid
+          item
+          sx={{
+            cursor: 'pointer',
+          }}
+          onClick={() => {
+            if (history.length === 1) {
+              window.location.href = '/feeds';
+            } else {
+              history.back();
+            }
+          }}
+        >
+          <Grid container alignItems={'center'}>
+            <ChevronLeft fontSize='small' sx={{ ml: '-20px' }} />{' '}
+            <Typography>Back</Typography>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Typography
+            sx={{
+              a: {
+                textDecoration: 'none',
+              },
+            }}
+          >
+            <a href='/feeds'>Feeds</a> /{' '}
+            <a href={`/feeds?${feed?.data_type}=true`}>
+              {feed?.data_type === 'gtfs' ? 'GTFS Schedule' : 'GTFS Realtime'}
+            </a>{' '}
+            / {feed?.id}
+          </Typography>
+        </Grid>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography
+          sx={{
+            color: colors.blue.A700,
+            fontWeight: 'bold',
+            fontSize: { xs: 24, sm: 36 },
+          }}
+          data-testid='feed-provider'
+        >
+          {feed?.provider?.substring(0, 100)}
+          {feed?.data_type === 'gtfs_rt' && ` - ${feed?.feed_name}`}
+        </Typography>
+      </Grid>
+      {feed !== undefined &&
+        feed.feed_name !== '' &&
+        feed?.data_type === 'gtfs' && (
+          <Grid item xs={12}>
+            <Typography
+              sx={{
+                fontWeight: 'bold',
+                fontSize: { xs: 18, sm: 24 },
+              }}
+              data-testid='feed-name'
+            >
+              {feed?.feed_name}
+            </Typography>
+          </Grid>
+        )}
+      {latestDataset?.downloaded_at !== undefined && (
+        <Grid item xs={12}>
+          <Typography data-testid='last-updated'>
+            {`Last updated on ${new Date(
+              latestDataset.downloaded_at,
+            ).toDateString()}`}
+          </Typography>
+        </Grid>
+      )}
+      {feed?.data_type === 'gtfs_rt' && feed.entity_types !== undefined && (
+        <Grid item xs={12}>
+          <Typography variant='h5'>
+            {' '}
+            {feed.entity_types
+              .map(
+                (entityType) =>
+                  ({
+                    tu: 'Trip Updates',
+                    vp: 'Vehicle Positions',
+                    sa: 'Service Alerts',
+                  })[entityType],
+              )
+              .join(' and ')}
+          </Typography>
+        </Grid>
+      )}
+      {feedType === 'gtfs' &&
+        datasetLoadingStatus === 'loaded' &&
+        !hasDatasets &&
+        !hasFeedRedirect && (
+          <Grid item xs={12}>
+            <WarningContentBox>
+              Unable to download this feed. If there is a more recent URL for
+              this feed, <a href='/contribute'>please submit it here</a>
+            </WarningContentBox>
+          </Grid>
+        )}
+      {hasFeedRedirect && (
+        <Grid item xs={12}>
+          <WarningContentBox>
+            This feed has been replaced with a different producer URL.{' '}
+            <a href={`/feeds/${feed?.redirects?.[0]?.target_id}`}>
+              Go to the new feed here
+            </a>
+            .
+          </WarningContentBox>
+        </Grid>
+      )}
+      <Grid item xs={12} marginBottom={2}>
+        {feedType === 'gtfs' && downloadLatestUrl !== undefined && (
+          <Button disableElevation variant='contained' sx={{ marginRight: 2 }}>
+            <a
+              href={downloadLatestUrl}
+              target='_blank'
+              className='btn-link'
+              rel='noreferrer'
+              id='download-latest-button'
+            >
+              Download Latest
+            </a>
+          </Button>
+        )}
+        {feed?.source_info?.license_url !== undefined &&
+          feed?.source_info?.license_url !== '' && (
+            <Button
+              disableElevation
+              variant='contained'
+              sx={{ marginRight: 2 }}
+            >
+              <a
+                href={feed?.source_info?.license_url}
+                target='_blank'
+                className='btn-link'
+                rel='noreferrer'
+              >
+                See License
+              </a>
+            </Button>
+          )}
+
+        {feed?.source_info?.authentication_info_url !== undefined &&
+          feed?.source_info?.authentication_info_url !== '' && (
+            <Button
+              disableElevation
+              variant='contained'
+              sx={{ marginRight: 2 }}
+            >
+              <a
+                href={feed?.source_info?.authentication_info_url}
+                target='_blank'
+                className='btn-link'
+                rel='noreferrer'
+              >
+                See Authentication info
+              </a>
+            </Button>
+          )}
+      </Grid>
+      <Grid item xs={12}>
+        <Grid item xs={12} container rowSpacing={2}>
+          <Grid
+            container
+            direction={{
+              xs: feed?.data_type === 'gtfs' ? 'column-reverse' : 'column',
+              md: 'row',
+            }}
+            sx={{ gap: '10px' }}
+            justifyContent={'space-between'}
+          >
+            {feed?.data_type === 'gtfs' && (
+              <ContentBox
+                title='Bounding box from stops.txt'
+                width={{ xs: '100%', md: '42%' }}
+                outlineColor={colors.blue[900]}
+                padding={2}
+              >
+                {boundingBox === undefined && (
+                  <WarningContentBox>
+                    Unable to generate bounding box.
+                  </WarningContentBox>
+                )}
+                {boundingBox !== undefined && (
+                  <Box width={{ xs: '100%' }} sx={{ mt: 2, mb: 2 }}>
+                    <Map polygon={boundingBox} />
+                  </Box>
+                )}
+                <DataQualitySummary latestDataset={latestDataset} />
+              </ContentBox>
+            )}
+            <FeedSummary
+              feed={feed}
+              latestDataset={latestDataset}
+              width={{ xs: '100%', md: '55%' }}
+            />
+
+            {feed?.data_type === 'gtfs_rt' && relatedFeeds !== undefined && (
+              <AssociatedFeeds
+                feeds={relatedFeeds.filter((f) => f?.id !== feed.id)}
+                gtfsRtFeeds={relatedGtfsRtFeeds.filter(
+                  (f) => f?.id !== feed.id,
+                )}
+              />
+            )}
+          </Grid>
+        </Grid>
+      </Grid>
+      {feed?.data_type === 'gtfs' && hasDatasets && (
+        <Grid item xs={12}>
+          <PreviousDatasets datasets={datasets} />
+        </Grid>
+      )}
+    </Grid>,
   );
 }

--- a/web-app/src/app/store/dataset-reducer.ts
+++ b/web-app/src/app/store/dataset-reducer.ts
@@ -24,6 +24,12 @@ export const datasetSlice = createSlice({
   name: 'dataset',
   initialState,
   reducers: {
+    clearDataset: (state) => {
+      state.data = initialState.data;
+      state.errors = initialState.errors;
+      state.status = initialState.status;
+      state.datasetId = initialState.datasetId;
+    },
     updateDatasetId: (
       state,
       action: PayloadAction<{
@@ -77,6 +83,7 @@ export const {
   loadingDataset,
   loadingDatasetFail,
   loadingDatasetSuccess,
+  clearDataset,
 } = datasetSlice.actions;
 
 export default datasetSlice.reducer;

--- a/web-app/src/app/store/dataset-selectors.ts
+++ b/web-app/src/app/store/dataset-selectors.ts
@@ -10,6 +10,10 @@ export const selectDatasetsData = (
   return state.dataset.data;
 };
 
+export const selectDatasetsLoadingStatus = (
+  state: RootState,
+): 'loading' | 'loaded' => state.dataset.status;
+
 export const selectLatestDatasetsData = (
   state: RootState,
 ): components['schemas']['GtfsDataset'] | undefined => {


### PR DESCRIPTION
**Summary:**

### Root Cause
The redux store keeps the state when switching between screens. This is why some properties from different data types were accessed, causing null pointer exceptions.

### The fix

I created a wrapper function to process feed information when the correct feed data is loaded into the store. This is determined by comparing the feedId parameter with the feed identifier from the store.

### Other minor fixes

- When visiting GTFS feed and then GTFS-RT feed; the section corresponding to the last updated dataset was visible. This is due to the dataset state was not cleared while loading the feed for the first time.
- The warning message "Unable to download this feed. If there is a more recent URL for..." was visible for a few seconds when landing on the feed screen for GTFS and GTFS-RT feeds. 


**Expected behavior:** 

The feed screen is render with the feed's information related to feed id passed as a page parameter.

**Testing tips:**

Reproduce this issue in QA,

- Go to home screen
- Click Browse Feeds
- Open a GTFS-RT feed
- Go back to the Feeds screen
- Open a GTFS feed

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
