### PR TITLE
fix: revert changes in metadata api endpoint

### DIFF
--- a/api/src/feeds/impl/metadata_api_impl.py
+++ b/api/src/feeds/impl/metadata_api_impl.py
@@ -23,17 +23,13 @@ class MetadataApiImpl(BaseMetadataApi):
             # Create a configparser object
             config = configparser.ConfigParser()
 
-            # The version_info file is in api/src subdirectory. We're not sure which directory this code is running
-            # (and it's different for tests), but we will assume api is in the path.
             current_directory = os.getcwd()
 
-            root_directory = current_directory.split("/api", 1)[0]
-            if root_directory is None:
-                raise Exception(
-                    "Cannot find version_info file. "
-                    + f"Cannot find api in the path to the current working directory = {current_directory}"
-                )
-            file = root_directory + "/api/src/version_info"
+            file = "version_info"
+            # The config file is on api/src. Normally the cwd is api/src, but with unit tests it's api. In that case
+            # add /src
+            if current_directory.endswith("api"):
+                file = os.path.join("src", file)
 
             # Read the properties file. This file should have been filled as part of the build.
             config.read(file)


### PR DESCRIPTION
**Summary:**

Fixes #639 
I'm reverting changes in PR #585 as the metadata endpoint returned `null` in the version and commit_hash. The previous code is still relevant; we only add the `src` suffix when the folder ends in `API`; otherwise, the file is on the "relative" root of the source.

Health check passed [here](https://github.com/MobilityData/mobility-feed-api/actions/runs/10184295233/job/28171640163)

This PR was deployed to QA for testing, and the endpoint result is as expected:
```
{
    "version": "v1.2.1_SNAPSHOT",
    "commit_hash": "dce5fc44517f8228d04ec5e08ec7a47b251a390a"
}
```
**Expected behavior:** 

The deployed endpoint return the proper version and commit hash values.

**Testing tips:**

The only way to test it is to deploy it in a real environment. 
Test in QA
- Grab an access token from the tokens' API or from an UI deployed to DEV(use any open or previous UI PR)
- Hit the DEV metadata endpoint and expect a valid return. Example call,
```
curl --location 'https://api-qa.mobilitydatabase.org//v1/metadata' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer YOUR_ACCESS_TOKEN_HERE'
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
