### PR TITLE
fix(build): Executing integration tests on Qa and PROD in db update only for repository dispatch

### DIFF
--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -23,6 +23,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
+    if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/integration-tests.yml
     needs:
       - update-qa
@@ -50,6 +51,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-prod:
+    if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/integration-tests.yml
     needs: update
     with:


### PR DESCRIPTION
**Summary:**

Release GH action is failing due to differences between the code version and the target environment. 
Example of failing action, [here](https://github.com/MobilityData/mobility-feed-api/actions/runs/10184766911/job/28173237980).
**Expected behavior:** 

Release GH action runs, ignoring integration tests in QA and PROD for DB Update action.

**Testing tips:**

Create a release...

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
