### PR TITLE
feat: Remove "Authentication Info" link at the top of the page

### DIFF
--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -36,6 +36,8 @@ export default function FeedSummary({
 }: FeedSummaryProps): React.ReactElement {
   const [snackbarOpen, setSnackbarOpen] = React.useState(false);
 
+  const hasAuthenticationInfo = !!feed?.source_info?.authentication_info_url;
+
   return (
     <ContentBox
       width={width}
@@ -121,6 +123,33 @@ export default function FeedSummary({
           {feed?.data_type === 'gtfs_rt' && 'GTFS Realtime'}
         </Typography>
       </Box>
+
+      <Box sx={boxElementStyle}>
+        <Typography
+          variant='subtitle1'
+          gutterBottom
+          sx={{ fontWeight: 'bold' }}
+        >
+          Authentication type
+        </Typography>
+        <Typography data-testid='data-type'>
+          {feed?.source_info?.authentication_type === 1 && 'API Key'}
+          {feed?.source_info?.authentication_type === 2 && 'HTTP Header'}
+        </Typography>
+      </Box>
+
+      {hasAuthenticationInfo && (
+        <Button disableElevation variant='contained' sx={{ marginRight: 2 }}>
+          <a
+            href={feed?.source_info?.authentication_info_url}
+            target='_blank'
+            className='btn-link'
+            rel='noreferrer'
+          >
+            Register to download this feed
+          </a>
+        </Button>
+      )}
 
       {feed?.data_type === 'gtfs' &&
         feed?.feed_contact_email !== undefined &&

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -36,7 +36,9 @@ export default function FeedSummary({
 }: FeedSummaryProps): React.ReactElement {
   const [snackbarOpen, setSnackbarOpen] = React.useState(false);
 
-  const hasAuthenticationInfo = !!feed?.source_info?.authentication_info_url;
+  const hasAuthenticationInfo =
+    feed?.source_info?.authentication_info_url !== undefined &&
+    feed?.source_info.authentication_info_url.trim() !== '';
 
   return (
     <ContentBox

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -297,24 +297,6 @@ export default function Feed(): React.ReactElement {
               </a>
             </Button>
           )}
-
-        {feed?.source_info?.authentication_info_url !== undefined &&
-          feed?.source_info?.authentication_info_url !== '' && (
-            <Button
-              disableElevation
-              variant='contained'
-              sx={{ marginRight: 2 }}
-            >
-              <a
-                href={feed?.source_info?.authentication_info_url}
-                target='_blank'
-                className='btn-link'
-                rel='noreferrer'
-              >
-                See Authentication info
-              </a>
-            </Button>
-          )}
       </Grid>
       <Grid item xs={12}>
         <Grid item xs={12} container rowSpacing={2}>


### PR DESCRIPTION
**Summary:**
Closes #602 
Remove "Authentication Info" link at the top of the page
When the authentication type is not 0 (so either 1 or 2), display the associated auth type (API Key or HTTP Header) with a link to the authentication info link in the Register button

**Expected behavior:** 
mdb-1636
![image](https://github.com/user-attachments/assets/6ee33128-b7f6-4651-b949-34d817dae45d)

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
