### PR TITLE
fix: 649 search screen back and forward browsers actions reacting on typying

### DIFF
--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -126,6 +126,13 @@ export default function Feed(): React.ReactElement {
     setSearchParams(newSearchParams);
   }, [activeSearch, activePagination]);
 
+  useEffect(() => {
+    const newQeury = searchParams.get('q') ?? '';
+    if (newQeury !== searchQuery) {
+      setSearchQuery(newQeury);
+    }
+  }, [searchParams]);
+
   const getSearchResultNumbers = (): string => {
     if (feedsData?.total !== undefined && feedsData?.total > 0) {
       const offset = getPaginationOffset(activePagination);
@@ -173,7 +180,7 @@ export default function Feed(): React.ReactElement {
                 sx={{
                   width: 'calc(100% - 100px)',
                 }}
-                defaultValue={searchQuery}
+                value={searchQuery}
                 placeholder={t('searchPlaceholder')}
                 onChange={(e) => {
                   setSearchQuery(e.target.value);

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -91,7 +91,9 @@ export default function Feed(): React.ReactElement {
   };
 
   const handleSearch = (): void => {
-    setSearchParams({ q: searchQuery });
+    if (searchQuery !== '') {
+      setSearchParams({ q: searchQuery });
+    }
     const paginationOffset = getPaginationOffset();
     if (user !== undefined) {
       dispatch(

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -80,6 +80,7 @@ export default function Feed(): React.ReactElement {
   const dispatch = useAppDispatch();
   const feedsData = useSelector(selectFeedsData);
   const feedStatus = useSelector(selectFeedsStatus);
+  let searchQuery = '';
 
   const getPaginationOffset = (activePagination?: number): number => {
     const paginationParam =
@@ -90,7 +91,7 @@ export default function Feed(): React.ReactElement {
   };
 
   const handleSearch = (): void => {
-    const searchQuery = searchParams.get('q') ?? '';
+    searchParams.set('q', searchQuery);
     const paginationOffset = getPaginationOffset();
     if (user !== undefined) {
       dispatch(
@@ -174,11 +175,9 @@ export default function Feed(): React.ReactElement {
                 sx={{
                   width: 'calc(100% - 100px)',
                 }}
-                value={searchParams.get('q') ?? ''}
                 placeholder={t('searchPlaceholder')}
                 onChange={(e) => {
-                  const searchValue = e.target.value;
-                  setSearchParams({ q: searchValue });
+                  searchQuery = e.target.value;
                 }}
                 InputProps={{
                   startAdornment: (

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -91,7 +91,7 @@ export default function Feed(): React.ReactElement {
   };
 
   const handleSearch = (): void => {
-    searchParams.set('q', searchQuery);
+    setSearchParams({ q: searchQuery });
     const paginationOffset = getPaginationOffset();
     if (user !== undefined) {
       dispatch(


### PR DESCRIPTION
**Summary:**
Closes #649 
update the URL query params only when the search action is dispatched, rather than with each character typed.

**Expected behavior:** 
search for new york in feeds screen, click back navigation button in the browser, it goes back to the previous page instead of  removing the previous keystroke.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
