### PR TITLE
fix: 667 back navigation should also show previous search result

### DIFF
--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -127,9 +127,15 @@ export default function Feed(): React.ReactElement {
   }, [activeSearch, activePagination]);
 
   useEffect(() => {
-    const newQeury = searchParams.get('q') ?? '';
-    if (newQeury !== searchQuery) {
-      setSearchQuery(newQeury);
+    const newQuery = searchParams.get('q') ?? '';
+    if (newQuery !== searchQuery) {
+      setSearchQuery(newQuery);
+      setActiveSearch(newQuery);
+    }
+    const newOffset =
+      searchParams.get('o') !== null ? Number(searchParams.get('o')) : 1;
+    if (newOffset !== activePagination) {
+      setActivePagination(newOffset);
     }
   }, [searchParams]);
 


### PR DESCRIPTION
**Summary:**

Closes #667 

**Expected behavior:** 

When a user searches for California and then searches for New York, returning to the previous page should display the search results for California.

**Testing tips:**

goto feeds page and search for California, click page 2
do a new search for New York
click on back navigation button of browser
returning to the previous page should display the search results for California page 2

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
