### PR TITLE
fix: Modified to not run the full metadata tests in some circumstances

### DIFF
--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -5,6 +5,9 @@ on:
   workflow_call:
   repository_dispatch: # Update on mobility-database-catalog repo dispatch
     types: [ catalog-sources-updated-test ]
+  push: # Update on merge on main branch if the changelog file has been updated
+    branches:
+      - 655-integration-tests-is-blocking-catalog-update-in-prod
 jobs:
   update-qa: # Update the QA database first
     uses: ./.github/workflows/db-update.yml
@@ -23,7 +26,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
-    if: github.event_name == 'repository_dispatch'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/integration-tests.yml
     needs:
       - update-qa

--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   workflow_call:
   repository_dispatch: # Update on mobility-database-catalog repo dispatch
-    types: [ catalog-sources-updated ]
+    types: [ catalog-sources-updated-test ]
 jobs:
   update-qa: # Update the QA database first
     uses: ./.github/workflows/db-update.yml
@@ -32,30 +32,30 @@ jobs:
       ENVIRONMENT: 'qa'
     secrets:
       REFRESH_TOKEN: ${{ secrets.QA_API_TEST_REFRESH_TOKEN }}
-  update:
-    uses: ./.github/workflows/db-update.yml
-    needs:
-      - integration-tests-qa
-    with:
-      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
-      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
-      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-    secrets:
-      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
-      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
-      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-  integration-tests-prod:
-    if: github.event_name == 'repository_dispatch'
-    uses: ./.github/workflows/integration-tests.yml
-    needs: update
-    with:
-      API_URL: "https://api.mobilitydatabase.org"
-      ENVIRONMENT: 'prod'
-    secrets:
-      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}
+#  update:
+#    uses: ./.github/workflows/db-update.yml
+#    needs:
+#      - integration-tests-qa
+#    with:
+#      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
+#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+#      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
+#      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+#      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+#    secrets:
+#      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
+#      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
+#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#  integration-tests-prod:
+#    if: github.event_name == 'repository_dispatch'
+#    uses: ./.github/workflows/integration-tests.yml
+#    needs: update
+#    with:
+#      API_URL: "https://api.mobilitydatabase.org"
+#      ENVIRONMENT: 'prod'
+#    secrets:
+#      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}

--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -4,10 +4,7 @@ on:
   workflow_dispatch:
   workflow_call:
   repository_dispatch: # Update on mobility-database-catalog repo dispatch
-    types: [ catalog-sources-updated-test ]
-  push: # Update on merge on main branch if the changelog file has been updated
-    branches:
-      - 655-integration-tests-is-blocking-catalog-update-in-prod
+    types: [ catalog-sources-updated ]
 jobs:
   update-qa: # Update the QA database first
     uses: ./.github/workflows/db-update.yml
@@ -26,7 +23,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/integration-tests.yml
     needs:
       - update-qa
@@ -35,30 +32,30 @@ jobs:
       ENVIRONMENT: 'qa'
     secrets:
       REFRESH_TOKEN: ${{ secrets.QA_API_TEST_REFRESH_TOKEN }}
-#  update:
-#    uses: ./.github/workflows/db-update.yml
-#    needs:
-#      - integration-tests-qa
-#    with:
-#      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
-#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-#      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
-#      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-#      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-#    secrets:
-#      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
-#      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
-#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-#  integration-tests-prod:
-#    if: github.event_name == 'repository_dispatch'
-#    uses: ./.github/workflows/integration-tests.yml
-#    needs: update
-#    with:
-#      API_URL: "https://api.mobilitydatabase.org"
-#      ENVIRONMENT: 'prod'
-#    secrets:
-#      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}
+  update:
+    uses: ./.github/workflows/db-update.yml
+    needs:
+      - integration-tests-qa
+    with:
+      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
+      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
+      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+    secrets:
+      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
+      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
+      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+  integration-tests-prod:
+    if: github.event_name == 'repository_dispatch'
+    uses: ./.github/workflows/integration-tests.yml
+    needs: update
+    with:
+      API_URL: "https://api.mobilitydatabase.org"
+      ENVIRONMENT: 'prod'
+    secrets:
+      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,8 +50,14 @@ jobs:
         pip install -r requirements.txt
 
     - name: Health Check
-      if: github.event_name == 'repository_dispatch'
-      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
+      # When triggered by a repo dispatch the API code is not deployed so there could be discrepencies
+      # between the code running the tests and the code running the API. Do do the Meta
+      run: |
+        heath_check_classes="BasicMetadataEndpointTests"
+        if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+          health_check_classes += ",MetadataEndpointTests"
+        fi
+        ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c $health_check_classes
       env:
         FILE_PATH: ${{ env.FILE_PATH }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,6 +53,8 @@ jobs:
       # When triggered by a repo dispatch the API code is not deployed so there could be discrepencies
       # between the code running the tests and the code running the API. Do do the Meta
       run: |
+        set -x
+        set -v
         heath_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
           health_check_classes += ",MetadataEndpointTests"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         set -x
         set -v
-        heath_check_classes="BasicMetadataEndpointTests"
+        health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
           health_check_classes += ",MetadataEndpointTests"
         fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,9 +52,9 @@ jobs:
     - name: Health Check
       # When triggered by a repo dispatch the API code is not deployed so there could be discrepancies
       # between the code running the tests and the code running the API. In that case don't do the
-      # MetadataEndpointTests since it make exact comparisons of the hash and version.
+      # MetadataEndpointTests since it makes exact comparisons of the hash and version.
       # The BasicMetadataEndpointTests just looks at the hash and version format, without looking
-      # at the exact values, so always do them.
+      # at the exact values, so always do these tests.
       run: |
         health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,6 @@ jobs:
 
     - name: Health Check
       if: github.event_name == 'push'
-      uses: ./.github/workflows/integration-tests.yml
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
       env:
         FILE_PATH: ${{ env.FILE_PATH }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,11 +50,12 @@ jobs:
         pip install -r requirements.txt
 
     - name: Health Check
-      # When triggered by a repo dispatch the API code is not deployed so there could be discrepencies
-      # between the code running the tests and the code running the API. Do do the Meta
+      # When triggered by a repo dispatch the API code is not deployed so there could be discrepancies
+      # between the code running the tests and the code running the API. In that case don't do the
+      # MetadataEndpointTests since it make exact comparisons of the hash and version.
+      # The BasicMetadataEndpointTests just looks at the hash and version format, without looking
+      # at the exact values, so always do them.
       run: |
-        set -x
-        set -v
         health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
           health_check_classes += ",MetadataEndpointTests"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Health Check
-      if: github.event_name == 'repository_dispatch'
+      if: github.event_name == 'push'
       uses: ./.github/workflows/integration-tests.yml
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
       env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,13 +50,15 @@ jobs:
         pip install -r requirements.txt
 
     - name: Health Check
+      if: github.event_name == 'repository_dispatch'
+      uses: ./.github/workflows/integration-tests.yml
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
       env:
         FILE_PATH: ${{ env.FILE_PATH }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
 
     - name: Run Integration Tests
-      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH
+      run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -x MetadataEndpointTests
       env:
         FILE_PATH: ${{ env.FILE_PATH }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
@@ -69,7 +71,3 @@ jobs:
         path: |
           integration-tests/src/integration_tests_log.html
           integration-tests/src/datasets_validation.csv
-          
-          
-          
-

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Health Check
-      if: github.event_name == 'push'
+      if: github.event_name == 'repository_dispatch'
       run: ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c MetadataEndpointTests
       env:
         FILE_PATH: ${{ env.FILE_PATH }}

--- a/integration-tests/src/endpoints/integration_tests.py
+++ b/integration-tests/src/endpoints/integration_tests.py
@@ -163,7 +163,7 @@ class IntegrationTests:
             and method_name != "test_all"
         ]
 
-    def test_all(self, target_classes=[]):
+    def test_all(self, target_classes=[], excluded_classes=[]):
         """Test all endpoints."""
         console = self.console
         console.clear()
@@ -198,7 +198,12 @@ class IntegrationTests:
         test_methods = [
             (child, self.get_test_methods_for_class(child))
             for child in child_classes
-            if child.__name__ in target_classes or not len(target_classes)
+            if (child.__name__ in target_classes if len(target_classes) > 0 else True)
+            and (
+                child.__name__ not in excluded_classes
+                if len(excluded_classes) > 0
+                else True
+            )
         ]
 
         n_tests = sum(len(methods) for _, methods in test_methods)

--- a/integration-tests/src/endpoints/metadata.py
+++ b/integration-tests/src/endpoints/metadata.py
@@ -5,6 +5,11 @@ from endpoints.integration_tests import IntegrationTests
 
 
 class BasicMetadataEndpointTests(IntegrationTests):
+    """
+    This class is used to perform basic tests on the metadata endpoint of the API.
+    It will check if the format of the hash and version obtained from the API is correct.
+    """
+
     def __init__(self, file_path, access_token, url, progress):
         super().__init__(file_path, access_token, url, progress=progress)
 
@@ -44,6 +49,12 @@ class BasicMetadataEndpointTests(IntegrationTests):
 
 
 class MetadataEndpointTests(IntegrationTests):
+    """
+    This class is used to perform more detailed tests on the metadata endpoint of the API.
+    It check if the hash and version from the API are the proper ones.
+    Don't call this if the API and tests run on different versions.
+    """
+
     def __init__(self, file_path, access_token, url, progress):
         super().__init__(file_path, access_token, url, progress=progress)
         self.version_info_path = os.path.join(
@@ -69,7 +80,6 @@ class MetadataEndpointTests(IntegrationTests):
             expected_long_commit_hash,
             expected_extracted_version,
         ) = self.read_version_info_from_file()
-        expected_extracted_version += "Allo"
 
         # Verify that the commit hash matches the long commit hash from the version_info file
         assert api_commit_hash == expected_long_commit_hash, (

--- a/integration-tests/src/endpoints/metadata.py
+++ b/integration-tests/src/endpoints/metadata.py
@@ -7,44 +7,40 @@ from endpoints.integration_tests import IntegrationTests
 class BasicMetadataEndpointTests(IntegrationTests):
     def __init__(self, file_path, access_token, url, progress):
         super().__init__(file_path, access_token, url, progress=progress)
-        self.version_info_path = os.path.join(
-            os.path.dirname(__file__), "../../../api/src/version_info"
-        )
 
-    def read_version_info(self):
-        """Read the version_info file and extract the long commit hash and extracted version"""
-        with open(self.version_info_path, "r") as file:
-            content = file.read()
-            long_commit_hash = re.search(r"LONG_COMMIT_HASH=(\w+)", content).group(1)
-            extracted_version = re.search(r"EXTRACTED_VERSION=(\S+)", content).group(1)
-        return long_commit_hash, extracted_version
-
-    def test_metadata(self):
+    @staticmethod
+    def read_version_info_from_api(integrationTestsObject):
         """Test retrieval of GTFS feeds"""
-        response = self.get_response("v1/metadata")
+        response = integrationTestsObject.get_response("v1/metadata")
         assert (
             response.status_code == 200
         ), f"Expected 200 status code for metadata, got {response.status_code}."
         metadata = response.json()
-
-        version = metadata["version"]
+        api_version = metadata["version"]
         assert (
-            version is not None
-        ), f"Could not extract version from metadata = {metadata}"
+            api_version is not None
+        ), f"Could not get proper version from API metadata = {metadata}"
 
+        api_commit_hash = metadata["commit_hash"]
+        assert (
+            api_commit_hash is not None
+        ), f"Could not get proper commit_hash from API metadata = {metadata}"
+
+        return api_commit_hash, api_version
+
+    def test_metadata(self):
+        (
+            api_commit_hash,
+            api_version,
+        ) = BasicMetadataEndpointTests.read_version_info_from_api(self)
         assert re.match(
-            r"^v\d+\.\d+\.\d+(_SNAPSHOT)?$", version
-        ), f"Found version but not the right format. metadata = {metadata}"
-
-        commit_hash = metadata["commit_hash"]
-        assert (
-            commit_hash is not None
-        ), f"Could not extract commit_hash from metadata = {metadata}"
+            r"^v\d+\.\d+\.\d+(_SNAPSHOT)?$", api_version
+        ), f"version from the API not the right format. version = {api_version}"
 
         # For the commit hash, it's safe to say it should be more than 20 characters.
         assert (
-            len(commit_hash) > 20
-        ), f"Commit hash seems too short in metadata = {metadata}"
+            len(api_commit_hash) > 20
+        ), f"Commit hash from API seems too short  = {api_commit_hash}"
 
 
 class MetadataEndpointTests(IntegrationTests):
@@ -54,7 +50,7 @@ class MetadataEndpointTests(IntegrationTests):
             os.path.dirname(__file__), "../../../api/src/version_info"
         )
 
-    def read_version_info(self):
+    def read_version_info_from_file(self):
         """Read the version_info file and extract the long commit hash and extracted version"""
         with open(self.version_info_path, "r") as file:
             content = file.read()
@@ -63,34 +59,25 @@ class MetadataEndpointTests(IntegrationTests):
         return long_commit_hash, extracted_version
 
     def test_metadata(self):
-        """Test retrieval of GTFS feeds"""
-        response = self.get_response("v1/metadata")
-        assert (
-            response.status_code == 200
-        ), f"Expected 200 status code for metadata, got {response.status_code}."
-        metadata = response.json()
-
-        version = metadata["version"]
-        assert (
-            version is not None
-        ), f"Could not extract version from metadata = {metadata}"
-
-        commit_hash = metadata["commit_hash"]
-        assert (
-            commit_hash is not None
-        ), f"Could not extract commit_hash from metadata = {metadata}"
+        (
+            api_commit_hash,
+            api_version,
+        ) = BasicMetadataEndpointTests.read_version_info_from_api(self)
 
         # Read the expected values from the version_info file
-        expected_long_commit_hash, expected_extracted_version = self.read_version_info()
+        (
+            expected_long_commit_hash,
+            expected_extracted_version,
+        ) = self.read_version_info_from_file()
         expected_extracted_version += "Allo"
 
         # Verify that the commit hash matches the long commit hash from the version_info file
-        assert commit_hash == expected_long_commit_hash, (
-            f"Commit hash from metadata ({commit_hash}) does not match expected long commit hash "
+        assert api_commit_hash == expected_long_commit_hash, (
+            f"Commit hash from metadata ({api_commit_hash}) does not match expected long commit hash "
             f"({expected_long_commit_hash})"
         )
 
         # Verify that the version matches the extracted version from the version_info file
         assert (
-            version == expected_extracted_version
-        ), f"Version from metadata ({version}) does not match expected extracted version ({expected_extracted_version})"
+            api_version == expected_extracted_version
+        ), f"Version from api ({api_version}) does not match expected extracted version ({expected_extracted_version})"

--- a/integration-tests/src/endpoints/metadata.py
+++ b/integration-tests/src/endpoints/metadata.py
@@ -48,6 +48,7 @@ class MetadataEndpointTests(IntegrationTests):
 
         # Read the expected values from the version_info file
         expected_long_commit_hash, expected_extracted_version = self.read_version_info()
+        expected_extracted_version += "Allo"
 
         # Verify that the commit hash matches the long commit hash from the version_info file
         assert commit_hash == expected_long_commit_hash, (

--- a/integration-tests/src/main.py
+++ b/integration-tests/src/main.py
@@ -43,11 +43,23 @@ def set_up_configs():
         default="",
         type=parse_class_list,
     )
+    parser.add_argument(
+        "--exclude_classes",
+        help="Optional, comma-separated list of test class names to exclude.",
+        default="",
+        type=parse_class_list,
+    )
     args = parser.parse_args()
     access_token = os.getenv("ACCESS_TOKEN", None)
     if access_token is None:
         raise ValueError("ACCESS_TOKEN environment variable is not set.")
-    return args.file_path, access_token, args.url, args.include_classes
+    return (
+        args.file_path,
+        access_token,
+        args.url,
+        args.include_classes,
+        args.exclude_classes,
+    )
 
 
 if __name__ == "__main__":
@@ -60,8 +72,14 @@ if __name__ == "__main__":
         if not ispkg:
             importlib.import_module(modname)
 
-    data_file_path, api_access_token, api_url, include_classes = set_up_configs()
+    (
+        data_file_path,
+        api_access_token,
+        api_url,
+        include_classes,
+        exclude_classes,
+    ) = set_up_configs()
 
     IntegrationTests(data_file_path, api_access_token, api_url).test_all(
-        target_classes=include_classes
+        target_classes=include_classes, excluded_classes=exclude_classes
     )

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -8,25 +8,28 @@
 #   -u  URL of the API to test against
 #   -f  File path for the data file to be used in tests
 #   -c  Optional, comma-separated list of test class names to include
+#   -x  Optional, comma-separated list of test class names to exclude
 
 function print_help() {
-  echo "Usage: $0 -u <API URL> -f <FILE PATH> [-c <CLASS NAMES>]"
+  echo "Usage: $0 -u <API URL> -f <FILE PATH> [-c <CLASS NAMES>] [-x <CLASS NAMES>]"
   echo ""
   echo "Options:"
   echo "  -u  URL of the API to test against"
   echo "  -f  File path for the data file to be used in tests"
   echo "  -c  Optional, comma-separated list of test class names to include"
+  echo "  -x  Optional, comma-separated list of test class names to exclude."
   exit 1
 }
 
 # Initialize include_classes as an empty string
 INCLUDE_CLASSES=""
 
-while getopts ":u:f:c:h" opt; do
+while getopts ":u:f:c:x:h" opt; do
   case ${opt} in
     u ) URL=$OPTARG ;;
     f ) FILE_PATH=$OPTARG ;;
     c ) INCLUDE_CLASSES=$OPTARG ;;
+    x ) EXCLUDE_CLASSES=$OPTARG ;;
     h ) print_help ;;
     \? ) print_help ;;
   esac
@@ -80,9 +83,16 @@ pip install -r "$PARENT_DIR"/integration-tests/requirements.txt &> /dev/null
 
 export PYTHONPATH="${PARENT_DIR}:${PARENT_DIR}/integration-tests/src:${PARENT_DIR}/api/src"
 
+classes_args=""
 # Pass include_classes if it's not empty
-if [ -z "${INCLUDE_CLASSES}" ]; then
-  (cd "$PARENT_DIR"/integration-tests/src && python "$PARENT_DIR"/integration-tests/src/main.py --file_path "${FILE_PATH}" --url "$URL")
-else
-  (cd "$PARENT_DIR"/integration-tests/src && python "$PARENT_DIR"/integration-tests/src/main.py --file_path "${FILE_PATH}" --url "$URL" --include_classes "${INCLUDE_CLASSES}")
+if [ -n "${INCLUDE_CLASSES}" ]; then
+  classes_args="--include_classes ${INCLUDE_CLASSES}"
 fi
+
+if [ -n "${EXCLUDE_CLASSES}" ]; then
+  classes_args+=" --exclude_classes ${EXCLUDE_CLASSES}"
+fi
+
+(cd "$PARENT_DIR"/integration-tests/src && python "$PARENT_DIR"/integration-tests/src/main.py --file_path "${FILE_PATH}" --url "$URL" $classes_args)
+
+

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -93,5 +93,3 @@ if [ -n "${EXCLUDE_CLASSES}" ]; then
 fi
 
 (cd "$PARENT_DIR"/integration-tests/src && python "$PARENT_DIR"/integration-tests/src/main.py --file_path "${FILE_PATH}" --url "$URL" $classes_args)
-
-

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -84,7 +84,6 @@ pip install -r "$PARENT_DIR"/integration-tests/requirements.txt &> /dev/null
 export PYTHONPATH="${PARENT_DIR}:${PARENT_DIR}/integration-tests/src:${PARENT_DIR}/api/src"
 
 classes_args=""
-# Pass include_classes if it's not empty
 if [ -n "${INCLUDE_CLASSES}" ]; then
   classes_args="--include_classes ${INCLUDE_CLASSES}"
 fi


### PR DESCRIPTION
**Summary:**
closes #655
- Added code to exclude classes from integration test. 
- Modified integration test action so we exclude the metadata tests if the trigger is catalog-sources-updated, i.e. it comes from the mobility_database_repo.
- We still want to keep the health check in all cases (it yells us if we can talk to the API at least). Separated metadata tests into basic and normal. 
- The basic just make sure the API values returned have the right format.

**Expected behavior:** 

Integration should not fail for no good reason.

**Testing tips:**

- Ran integration-test.sh locally with the -x or -c arguments
- e.g. ./scripts/integration-tests.sh -u http://0.0.0.0:8080 -f "$FILE_PATH" -x MetadataEndpointTests
- check in the output that MetadataEndpointTests is not run.

I also tested with the GH actions, but the possibilities are limited. Here are the temporary changes I did in a testing branch:

- Added the trigger `push to branch` to db-update-prod.yml
- Kept only update-qa and integration-tests-qa jobs in that file. Commented out the other jobs.
- Modified the health_check step in integration-test.yml so the we check for "push" instead of "repository_dispatch"

I pushed the testing branch and the db-update-prod.yml is run. Make sure MetadataEndpointTests is not run in `Health Check` and `Run Integration Tests` steps

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
