### PR TITLE
fix: integration tests is blocking catalog update in prod - correction

### DIFF
--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
   repository_dispatch: # Update on mobility-database-catalog repo dispatch
-    types: [ catalog-sources-updated ]
+    types: [ catalog-sources-updated-test ]
+  push: # Update on merge on main branch if the changelog file has been updated
+    branches:
+      - 655-integration-tests-is-blocking-catalog-update-in-prod-2
 jobs:
   update-qa: # Update the QA database first
     uses: ./.github/workflows/db-update.yml
@@ -23,7 +26,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
-    if: github.event_name == 'repository_dispatch'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/integration-tests.yml
     needs:
       - update-qa
@@ -32,30 +35,30 @@ jobs:
       ENVIRONMENT: 'qa'
     secrets:
       REFRESH_TOKEN: ${{ secrets.QA_API_TEST_REFRESH_TOKEN }}
-  update:
-    uses: ./.github/workflows/db-update.yml
-    needs:
-      - integration-tests-qa
-    with:
-      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
-      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
-      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-    secrets:
-      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
-      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
-      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-  integration-tests-prod:
-    if: github.event_name == 'repository_dispatch'
-    uses: ./.github/workflows/integration-tests.yml
-    needs: update
-    with:
-      API_URL: "https://api.mobilitydatabase.org"
-      ENVIRONMENT: 'prod'
-    secrets:
-      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}
+#  update:
+#    uses: ./.github/workflows/db-update.yml
+#    needs:
+#      - integration-tests-qa
+#    with:
+#      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
+#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+#      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
+#      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+#      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+#    secrets:
+#      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
+#      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
+#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#  integration-tests-prod:
+#    if: github.event_name == 'repository_dispatch'
+#    uses: ./.github/workflows/integration-tests.yml
+#    needs: update
+#    with:
+#      API_URL: "https://api.mobilitydatabase.org"
+#      ENVIRONMENT: 'prod'
+#    secrets:
+#      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}

--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -4,61 +4,58 @@ on:
   workflow_dispatch:
   workflow_call:
   repository_dispatch: # Update on mobility-database-catalog repo dispatch
-    types: [ catalog-sources-updated-test ]
-  push: # Update on merge on main branch if the changelog file has been updated
-    branches:
-      - 655-integration-tests-is-blocking-catalog-update-in-prod-2
+    types: [ catalog-sources-updated ]
 jobs:
-#  update-qa: # Update the QA database first
-#    uses: ./.github/workflows/db-update.yml
-#    with:
-#      PROJECT_ID: ${{ vars.QA_MOBILITY_FEEDS_PROJECT_ID }}
-#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-#      DB_NAME: ${{ vars.QA_POSTGRE_SQL_DB_NAME }}
-#      ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
-#      DB_ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
-#    secrets:
-#      DB_USER_PASSWORD: ${{ secrets.QA_POSTGRE_USER_PASSWORD }}
-#      DB_USER_NAME: ${{ secrets.QA_POSTGRE_USER_NAME }}
-#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+  update-qa: # Update the QA database first
+    uses: ./.github/workflows/db-update.yml
+    with:
+      PROJECT_ID: ${{ vars.QA_MOBILITY_FEEDS_PROJECT_ID }}
+      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+      DB_NAME: ${{ vars.QA_POSTGRE_SQL_DB_NAME }}
+      ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
+      DB_ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
+    secrets:
+      DB_USER_PASSWORD: ${{ secrets.QA_POSTGRE_USER_PASSWORD }}
+      DB_USER_NAME: ${{ secrets.QA_POSTGRE_USER_NAME }}
+      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
+      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/integration-tests.yml
-#    needs:
-#      - update-qa
+    needs:
+      - update-qa
     with:
       API_URL: 'https://api-qa.mobilitydatabase.org'
       ENVIRONMENT: 'qa'
     secrets:
       REFRESH_TOKEN: ${{ secrets.QA_API_TEST_REFRESH_TOKEN }}
-#  update:
-#    uses: ./.github/workflows/db-update.yml
-#    needs:
-#      - integration-tests-qa
-#    with:
-#      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
-#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-#      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
-#      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-#      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
-#    secrets:
-#      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
-#      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
-#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
-#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-#  integration-tests-prod:
-#    if: github.event_name == 'repository_dispatch'
-#    uses: ./.github/workflows/integration-tests.yml
-#    needs: update
-#    with:
-#      API_URL: "https://api.mobilitydatabase.org"
-#      ENVIRONMENT: 'prod'
-#    secrets:
-#      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}
+  update:
+    uses: ./.github/workflows/db-update.yml
+    needs:
+      - integration-tests-qa
+    with:
+      PROJECT_ID: ${{ vars.PROD_MOBILITY_FEEDS_PROJECT_ID }}
+      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+      DB_NAME: ${{ vars.PROD_POSTGRE_SQL_DB_NAME }}
+      ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+      DB_ENVIRONMENT: ${{ vars.PROD_MOBILITY_FEEDS_ENVIRONMENT }}
+    secrets:
+      DB_USER_PASSWORD: ${{ secrets.PROD_POSTGRE_USER_PASSWORD }}
+      DB_USER_NAME: ${{ secrets.PROD_POSTGRE_USER_NAME }}
+      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.PROD_GCP_MOBILITY_FEEDS_SA_KEY }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+  integration-tests-prod:
+    if: github.event_name == 'repository_dispatch'
+    uses: ./.github/workflows/integration-tests.yml
+    needs: update
+    with:
+      API_URL: "https://api.mobilitydatabase.org"
+      ENVIRONMENT: 'prod'
+    secrets:
+      REFRESH_TOKEN: ${{ secrets.PROD_API_TEST_REFRESH_TOKEN }}

--- a/.github/workflows/db-update-prod.yml
+++ b/.github/workflows/db-update-prod.yml
@@ -9,27 +9,27 @@ on:
     branches:
       - 655-integration-tests-is-blocking-catalog-update-in-prod-2
 jobs:
-  update-qa: # Update the QA database first
-    uses: ./.github/workflows/db-update.yml
-    with:
-      PROJECT_ID: ${{ vars.QA_MOBILITY_FEEDS_PROJECT_ID }}
-      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
-      DB_NAME: ${{ vars.QA_POSTGRE_SQL_DB_NAME }}
-      ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
-      DB_ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
-    secrets:
-      DB_USER_PASSWORD: ${{ secrets.QA_POSTGRE_USER_PASSWORD }}
-      DB_USER_NAME: ${{ secrets.QA_POSTGRE_USER_NAME }}
-      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
-      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
-      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#  update-qa: # Update the QA database first
+#    uses: ./.github/workflows/db-update.yml
+#    with:
+#      PROJECT_ID: ${{ vars.QA_MOBILITY_FEEDS_PROJECT_ID }}
+#      REGION: ${{ vars.MOBILITY_FEEDS_REGION }}
+#      DB_NAME: ${{ vars.QA_POSTGRE_SQL_DB_NAME }}
+#      ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
+#      DB_ENVIRONMENT: ${{ vars.QA_MOBILITY_FEEDS_ENVIRONMENT }}
+#    secrets:
+#      DB_USER_PASSWORD: ${{ secrets.QA_POSTGRE_USER_PASSWORD }}
+#      DB_USER_NAME: ${{ secrets.QA_POSTGRE_USER_NAME }}
+#      DB_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
+#      GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      DB_GCP_MOBILITY_FEEDS_SA_KEY: ${{ secrets.QA_GCP_MOBILITY_FEEDS_SA_KEY }}
+#      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+#      POSTGRE_SQL_INSTANCE_NAME: ${{ secrets.DB_INSTANCE_NAME }}
   integration-tests-qa: # Run integration tests on QA
     if: github.event_name == 'push'
     uses: ./.github/workflows/integration-tests.yml
-    needs:
-      - update-qa
+#    needs:
+#      - update-qa
     with:
       API_URL: 'https://api-qa.mobilitydatabase.org'
       ENVIRONMENT: 'qa'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,7 +60,7 @@ jobs:
         set -v
         health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" != "repository_dispatch" ]]; then
-          health_check_classes += ",MetadataEndpointTests"
+          health_check_classes+=",MetadataEndpointTests"
         fi
         ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c $health_check_classes
       env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
       # at the exact values, so always do these tests.
       run: |
         health_check_classes="BasicMetadataEndpointTests"
-        if [[ "${{ github.event_name }}" != "push" ]]; then
+        if [[ "${{ github.event_name }}" != "repository_dispatch" ]]; then
           health_check_classes += ",MetadataEndpointTests"
         fi
         ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c $health_check_classes

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,8 +56,6 @@ jobs:
       # The BasicMetadataEndpointTests just looks at the hash and version format, without looking
       # at the exact values, so always do these tests.
       run: |
-        set -x
-        set -v
         health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" != "repository_dispatch" ]]; then
           health_check_classes+=",MetadataEndpointTests"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,6 +56,8 @@ jobs:
       # The BasicMetadataEndpointTests just looks at the hash and version format, without looking
       # at the exact values, so always do these tests.
       run: |
+        set -x
+        set -v
         health_check_classes="BasicMetadataEndpointTests"
         if [[ "${{ github.event_name }}" != "repository_dispatch" ]]; then
           health_check_classes += ",MetadataEndpointTests"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
       # at the exact values, so always do these tests.
       run: |
         health_check_classes="BasicMetadataEndpointTests"
-        if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+        if [[ "${{ github.event_name }}" != "push" ]]; then
           health_check_classes += ",MetadataEndpointTests"
         fi
         ./scripts/integration-tests.sh -u ${{ inputs.API_URL }} -f $FILE_PATH -c $health_check_classes


### PR DESCRIPTION
**Summary:**

While looking at the action logs from #673, I noticed that `MetadataEndpointTests` was not run.
This should happens only with the trigger is `repository_dispatch`

**Expected behavior:** 

MetadataEndpointTests should run in the Health Check after a PR merge.

**Testing tips:**



Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
