### PR TITLE
Feat: 647 display multiple countries format

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -17,6 +17,7 @@
     "@turf/center": "^6.5.0",
     "@types/i18next": "^13.0.0",
     "@types/leaflet": "^1.9.12",
+    "country-code-emoji": "^2.3.0",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "firebase": "^10.4.0",

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { ContentCopy, ContentCopyOutlined } from '@mui/icons-material';
 import {
+  getLocationName,
   type GTFSFeedType,
   type GTFSRTFeedType,
 } from '../../services/feeds/utils';
@@ -75,12 +76,7 @@ export default function FeedSummary({
           {t('location')}
         </Typography>
         <Typography variant='body1' data-testid='location'>
-          {feed?.locations !== undefined
-            ? Object.values(feed?.locations[0])
-                .filter((v) => v !== null)
-                .reverse()
-                .join(', ')
-            : ''}
+          {getLocationName(feed?.locations)}
         </Typography>
       </Box>
       <Box sx={boxElementStyle}>

--- a/web-app/src/app/screens/Feeds/SearchTable.tsx
+++ b/web-app/src/app/screens/Feeds/SearchTable.tsx
@@ -17,8 +17,8 @@ import {
   type GTFSFeedType,
   type GTFSRTFeedType,
   type AllFeedsType,
+  getLocationName,
 } from '../../services/feeds/utils';
-import { type FeedLocations } from '../../types';
 import BusAlertIcon from '@mui/icons-material/BusAlert';
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -73,25 +73,6 @@ export const getDataTypeElement = (
       </DataTypeHolder>
     );
   }
-};
-
-const getLocationName = (locations: FeedLocations): string => {
-  if (locations?.[0] === undefined) {
-    return '';
-  }
-  const firstLocation = locations[0];
-  const municipality =
-    firstLocation.municipality !== undefined &&
-    firstLocation.municipality !== null
-      ? `${firstLocation.municipality}, `
-      : '';
-  const subdivison =
-    firstLocation.subdivision_name !== undefined &&
-    firstLocation.subdivision_name !== null
-      ? `${firstLocation.subdivision_name}, `
-      : '';
-  const countryCode = firstLocation.country_code ?? '';
-  return municipality + subdivison + countryCode;
 };
 
 export default function SearchTable({

--- a/web-app/src/app/services/feeds/utils.spec.ts
+++ b/web-app/src/app/services/feeds/utils.spec.ts
@@ -1,0 +1,52 @@
+import { getLocationName, type FeedLocation } from './utils';
+
+const mockLocationMultiple: FeedLocation = [
+  {
+    country_code: 'US',
+    country: 'United States',
+    subdivision_name: 'California',
+    municipality: 'Los Angeles',
+  },
+  {
+    country_code: 'CA',
+    country: 'Canada',
+    subdivision_name: 'Ontario',
+    municipality: 'Toronto',
+  },
+];
+
+const mockLocationSingle: FeedLocation = [
+  {
+    country_code: 'US',
+    country: 'United States',
+    subdivision_name: 'California',
+    municipality: 'Los Angeles',
+  },
+];
+
+const mockLocationMultipleMinimal: FeedLocation = [
+  {
+    country_code: 'ES',
+    country: 'Spain',
+  },
+  {
+    country_code: 'CA',
+    country: 'Canada',
+    subdivision_name: 'Ontario',
+    municipality: 'Toronto',
+  },
+];
+
+describe('Feeds Utils', () => {
+  it('should format location names correctly', () => {
+    expect(getLocationName(mockLocationMultiple)).toBe(
+      '🇺🇸 United States, California, Los Angeles | 🇨🇦 Canada, Ontario, Toronto',
+    );
+    expect(getLocationName(mockLocationSingle)).toBe(
+      '🇺🇸 United States, California, Los Angeles',
+    );
+    expect(getLocationName(mockLocationMultipleMinimal)).toBe(
+      '🇪🇸 Spain | 🇨🇦 Canada, Ontario, Toronto',
+    );
+  });
+});

--- a/web-app/src/app/services/feeds/utils.spec.ts
+++ b/web-app/src/app/services/feeds/utils.spec.ts
@@ -1,6 +1,6 @@
-import { getLocationName, type FeedLocation } from './utils';
+import { getLocationName, type EntityLocations } from './utils';
 
-const mockLocationMultiple: FeedLocation = [
+const mockLocationMultiple: EntityLocations = [
   {
     country_code: 'US',
     country: 'United States',
@@ -15,7 +15,7 @@ const mockLocationMultiple: FeedLocation = [
   },
 ];
 
-const mockLocationSingle: FeedLocation = [
+const mockLocationSingle: EntityLocations = [
   {
     country_code: 'US',
     country: 'United States',
@@ -24,7 +24,7 @@ const mockLocationSingle: FeedLocation = [
   },
 ];
 
-const mockLocationMultipleMinimal: FeedLocation = [
+const mockLocationMultipleMinimal: EntityLocations = [
   {
     country_code: 'ES',
     country: 'Spain',

--- a/web-app/src/app/services/feeds/utils.ts
+++ b/web-app/src/app/services/feeds/utils.ts
@@ -1,7 +1,10 @@
-import { type paths } from './types';
+import countryCodeEmoji from 'country-code-emoji';
+import { type paths, type components } from './types';
 
 export type AllFeedsType =
   paths['/v1/search']['get']['responses'][200]['content']['application/json'];
+
+export type FeedLocation = components['schemas']['Locations'];
 
 export type AllFeedsParams = paths['/v1/search']['get']['parameters'];
 
@@ -45,3 +48,29 @@ export type AllDatasetType =
   | paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json']
   | paths['/v1/datasets/gtfs/{id}']['get']['responses'][200]['content']['application/json']
   | undefined;
+
+export function getLocationName(locations: FeedLocation | undefined): string {
+  if (locations === undefined) {
+    return '';
+  }
+  let displayLocation = '';
+  locations.forEach((location, index) => {
+    if (location.country_code !== undefined) {
+      displayLocation += `${countryCodeEmoji(location.country_code)} `;
+    }
+    if (location.country !== undefined) {
+      displayLocation += `${location.country}`;
+    }
+    if (location.subdivision_name !== undefined) {
+      displayLocation += `, ${location.subdivision_name}`;
+    }
+    if (location.municipality !== undefined) {
+      displayLocation += `, ${location.municipality}`;
+    }
+
+    if (index < locations.length - 1) {
+      displayLocation += ' | ';
+    }
+  });
+  return displayLocation;
+}

--- a/web-app/src/app/services/feeds/utils.ts
+++ b/web-app/src/app/services/feeds/utils.ts
@@ -4,7 +4,7 @@ import { type paths, type components } from './types';
 export type AllFeedsType =
   paths['/v1/search']['get']['responses'][200]['content']['application/json'];
 
-export type FeedLocation = components['schemas']['Locations'];
+export type EntityLocations = components['schemas']['Locations'];
 
 export type AllFeedsParams = paths['/v1/search']['get']['parameters'];
 
@@ -49,7 +49,9 @@ export type AllDatasetType =
   | paths['/v1/datasets/gtfs/{id}']['get']['responses'][200]['content']['application/json']
   | undefined;
 
-export function getLocationName(locations: FeedLocation | undefined): string {
+export function getLocationName(
+  locations: EntityLocations | undefined,
+): string {
   if (locations === undefined) {
     return '';
   }

--- a/web-app/src/app/services/feeds/utils.ts
+++ b/web-app/src/app/services/feeds/utils.ts
@@ -55,16 +55,19 @@ export function getLocationName(locations: FeedLocation | undefined): string {
   }
   let displayLocation = '';
   locations.forEach((location, index) => {
-    if (location.country_code !== undefined) {
+    if (location.country_code !== undefined && location.country_code !== null) {
       displayLocation += `${countryCodeEmoji(location.country_code)} `;
     }
-    if (location.country !== undefined) {
+    if (location.country !== undefined && location.country !== null) {
       displayLocation += `${location.country}`;
     }
-    if (location.subdivision_name !== undefined) {
+    if (
+      location.subdivision_name !== undefined &&
+      location.subdivision_name !== null
+    ) {
       displayLocation += `, ${location.subdivision_name}`;
     }
-    if (location.municipality !== undefined) {
+    if (location.municipality !== undefined && location.municipality !== null) {
       displayLocation += `, ${location.municipality}`;
     }
 

--- a/web-app/src/app/types.ts
+++ b/web-app/src/app/types.ts
@@ -113,14 +113,6 @@ export type FeedErrors = {
 
 export type FeedStatus = 'loading' | 'loaded' | 'error';
 
-interface FeedLocation {
-  country_code?: string | undefined;
-  subdivision_name?: string | undefined;
-  municipality?: string | undefined;
-}
-
-export type FeedLocations = FeedLocation[] | undefined;
-
 export enum OauthProvider {
   Google = 'Google',
   Github = 'Github',

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -5465,6 +5465,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+country-code-emoji@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/country-code-emoji/-/country-code-emoji-2.3.0.tgz#17de6ef57964467568a53ae9fb30044371a5055c"
+  integrity sha512-MqmIWr3aucoU/3XZU44e0sz6izAlErqaUYp9/NFzdnzb9TrwwornyW3ws2da5TSnpTUr2qP2840oJW9oNKXCoQ==
+
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz"


### PR DESCRIPTION
closes #647 
**Summary:**

Format the new country data as shown in the screenshots

**Expected behavior:** 

Location data should be shown as: 🇨🇦 Canada | 🇺🇸 United States

**Testing tips:**

Go on the search page and see if the location data is shown as above. TIP: Spain is a good search for many countries

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
![Screenshot 2024-08-14 at 14 24 37](https://github.com/user-attachments/assets/ec4f7371-22de-4907-b037-345dff5c983e)

![Screenshot 2024-08-14 at 14 34 45](https://github.com/user-attachments/assets/674b70f6-6087-40c8-b11a-8f9a3726e972)

