### PR TITLE
Made the version verification more lax in integration tests

### DIFF
--- a/integration-tests/src/endpoints/metadata.py
+++ b/integration-tests/src/endpoints/metadata.py
@@ -39,7 +39,7 @@ class BasicMetadataEndpointTests(IntegrationTests):
             api_version,
         ) = BasicMetadataEndpointTests.read_version_info_from_api(self)
         assert re.match(
-            r"^v\d+\.\d+\.\d+(_SNAPSHOT)?$", api_version
+            r"^v\d+\.\d+\.\d+.*$", api_version
         ), f"version from the API not the right format. version = {api_version}"
 
         # For the commit hash, it's safe to say it should be more than 20 characters.


### PR DESCRIPTION
**Summary:**

Metadata integration test was too restrictive when checking the format of the version. Now it will accept any suffix (including _RC1)

**Expected behavior:** 

**Testing tips:**


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
