### PR TITLE
Fix: dispatch email on newly created account to verified email

### DIFF
--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -12,7 +12,12 @@ import AppleIcon from '@mui/icons-material/Apple';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch } from '../hooks';
 import { useRemoteConfig } from '../context/RemoteConfigProvider';
-import { login, loginFail, loginWithProvider } from '../store/profile-reducer';
+import {
+  login,
+  loginFail,
+  loginWithProvider,
+  verifyEmail,
+} from '../store/profile-reducer';
 import {
   OauthProvider,
   type EmailLogin,
@@ -110,6 +115,9 @@ export default function SignIn(): React.ReactElement {
     const provider = oathProviders[oauthProvider];
     signInWithPopup(auth, provider)
       .then((userCredential: UserCredential) => {
+        if (!userCredential.user.emailVerified) {
+          dispatch(verifyEmail());
+        }
         if (userCredential.user.email == null) {
           setShowNoEmailSnackbar(true);
         } else {


### PR DESCRIPTION
closes #693 

**Summary:**

When registering an account, sometimes the verification email would not send until "Send again" was clicked

**Expected behavior:** 

When the user registers for an account and it's through Github or Email, it should send the validation email without further action

**Testing tips:**

Create an account using any provider. Github and Email will ask you to verify email so ideal to use those. Once account is created, check if you got validation email.

**Reason for bug**

This bug exists because you can make an account through the sign-in page through the third party apps. Sign-in page doesn't dispatch email. Google and Apple do not verify email

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
