### PR TITLE
fix: empty search query with no additional parameter returns HTTP 500

### DIFF
--- a/api/src/feeds/impl/models/basic_feed_impl.py
+++ b/api/src/feeds/impl/models/basic_feed_impl.py
@@ -61,4 +61,3 @@ class BasicFeedImpl(BaseFeedImpl, BasicFeed):
         Enabling `from_orm` method to create a model instance from a SQLAlchemy row object."""
 
         from_attributes = True
-        orm_mode = True

--- a/api/src/feeds/impl/models/search_feed_item_result_impl.py
+++ b/api/src/feeds/impl/models/search_feed_item_result_impl.py
@@ -77,9 +77,10 @@ class SearchFeedItemResultImpl(SearchFeedItemResult):
 
     @classmethod
     def _translate_locations(cls, feed_search_row):
+        """Translate location information in the feed search row.
+        This method modifies the locations in the feed search row in place."""
         if feed_search_row.locations is None:
             return
-        """Translate location information in the feed search row."""
         country_translations = cls._create_translation_dict(feed_search_row.country_translations)
         subdivision_translations = cls._create_translation_dict(feed_search_row.subdivision_name_translations)
         municipality_translations = cls._create_translation_dict(feed_search_row.municipality_translations)

--- a/api/tests/unittest/models/test_search_feed_item_result_impl.py
+++ b/api/tests/unittest/models/test_search_feed_item_result_impl.py
@@ -5,6 +5,7 @@ from faker import Faker
 
 from feeds.impl.models.search_feed_item_result_impl import SearchFeedItemResultImpl
 from feeds_gen.models.latest_dataset import LatestDataset
+from feeds_gen.models.location import Location
 from feeds_gen.models.source_info import SourceInfo
 
 fake = Faker()
@@ -127,3 +128,64 @@ class TestSearchFeeds200ResponseResultsInnerImpl(unittest.TestCase):
             item = copy.deepcopy(search_item)
             item.data_type = "unknown"
             SearchFeedItemResultImpl.from_orm(item)
+
+    def test_from_orm_locations_country_provided(self):
+        """Test that the country is not replaced with the translation."""
+        item = copy.deepcopy(search_item)
+        item.data_type = "gtfs"
+        item.locations = [
+            {
+                "country_code": "CA",
+                "country": "CanadaNotReplaced",
+                "subdivision_name": "subdivision_name",
+                "municipality": "municipality",
+            }
+        ]
+        result = SearchFeedItemResultImpl.from_orm(item)
+        assert result.data_type == "gtfs"
+        assert result.locations == [
+            Location(
+                country_code="CA",
+                country="CanadaNotReplaced",
+                subdivision_name="subdivision_name",
+                municipality="municipality",
+            )
+        ]
+
+    def test_from_orm_locations_country_missing(self):
+        """Test that the country is not replaced with the translation."""
+        item = copy.deepcopy(search_item)
+        item.data_type = "gtfs"
+        item.locations = [
+            {
+                "country_code": "CA",
+                "country": "",
+                "subdivision_name": "subdivision_name",
+                "municipality": "municipality",
+            }
+        ]
+        result = SearchFeedItemResultImpl.from_orm(item)
+        assert result.data_type == "gtfs"
+        assert result.locations == [
+            Location(
+                country_code="CA", country="Canada", subdivision_name="subdivision_name", municipality="municipality"
+            )
+        ]
+
+    def test_from_orm_locations_country_invalid_code(self):
+        """Test that the country is not replaced with the translation."""
+        item = copy.deepcopy(search_item)
+        item.data_type = "gtfs"
+        item.locations = [
+            {
+                "country_code": "XY",
+                "country": "",
+                "subdivision_name": "subdivision_name",
+                "municipality": "municipality",
+            }
+        ]
+        result = SearchFeedItemResultImpl.from_orm(item)
+        assert result.data_type == "gtfs"
+        assert result.locations == [
+            Location(country_code="XY", country="", subdivision_name="subdivision_name", municipality="municipality")
+        ]


### PR DESCRIPTION
**Summary:**

Added conditionals and protecting code to handle cases for missing locations, missing country and invalid country code.


**Expected behavior:** 

The search endpoint returns all GTFS and GTFS-rt feeds when no parameters are passed.

**Testing tips:**

- Setup local API environment
- Query the search endpoint by passing an empty search. Example:
```
curl --location 'https://api-qa.mobilitydatabase.org//v1/search?search_query=' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer REPLACE_ME_WITH_ACCESS_TOKEN'
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
