### PR TITLE
fix: Set the country if missing from DB in the populate script

### DIFF
--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -27,7 +27,7 @@ datasets_download_first_date: Final[datetime] = datetime.strptime(date_string, d
 def populate_database(db: Database, data_dirs: str):
     try:
 
-        # Check if connected to localhost
+        # Check if connected to test DB.
         url = make_url(db.engine.url)
         if not is_test_db(url):
             raise Exception("Not connected to MobilityDatabaseTest, aborting operation")
@@ -52,7 +52,6 @@ def populate_database(db: Database, data_dirs: str):
         db_helper.initialize(trigger_downstream_tasks=False)
 
         # Make a list of all the extra_test_data.json files in the test_data directories and load the data
-        # Make a list of all the sources_test.csv in test_data and keep only if the file exists
         json_filepaths = []
         for dir in data_dirs:
 


### PR DESCRIPTION
**Summary:**
Closes #694 

Added code to set the country in the populate script. This will work only for new entries
For old entries, added a post-processing operation in the populate script that looks at all the location table entries and adds the country if it's missing. The country is obtained from the country code already in the table entry.

**Expected behavior:** 

All locations should now have a country if the country code has a corresponding country

**Testing tips:**

Tested locally with a location table on which I set all countries to null. Test that the post processing sets the countries properly.
Tested also by deleting the DB and rerun the populate script. The countries should also be set properly as they are considered new entries.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
