### PR TITLE
fix: fix invalid feeds credentials variable name

### DIFF
--- a/functions-python/batch_process_dataset/src/main.py
+++ b/functions-python/batch_process_dataset/src/main.py
@@ -75,18 +75,22 @@ class DatasetProcessor:
         self.authentication_type = authentication_type
         self.api_key_parameter_name = api_key_parameter_name
         self.date = datetime.now().strftime("%Y%m%d%H%M")
-        feeds_credentials = self.get_feed_credentials()
-        if feeds_credentials is None and self.authentication_type != 0:
-            raise Exception(
-                f"Error getting feed credentials for feed {self.feed_stable_id}"
-            )
-        self.feed_credentials = feeds_credentials.get(self.feed_stable_id, None)
+        if self.authentication_type != 0:
+            logging.info(f"Getting feed credentials for feed {self.feed_stable_id}")
+            self.feed_credentials = self.get_feed_credentials(self.feed_stable_id)
+            if self.feed_credentials is None:
+                raise Exception(
+                    f"Error getting feed credentials for feed {self.feed_stable_id}"
+                )
+        else:
+            self.feed_credentials = None
         self.public_hosted_datasets_url = public_hosted_datasets_url
 
         self.init_status = None
         self.init_status_additional_data = None
 
-    def get_feed_credentials(self) -> str | None:
+    @staticmethod
+    def get_feed_credentials(feed_stable_id) -> str | None:
         """
         Gets the feed credentials from the environment variable
         """
@@ -96,7 +100,7 @@ class DatasetProcessor:
                 logging.warning("No feed credentials found.")
                 return None
             feeds_credentials = json.loads(all_creds)
-            return feeds_credentials.get(self.feed_stable_id, None)
+            return feeds_credentials.get(feed_stable_id, None)
         except Exception as e:
             logging.error(f"Error getting feed credentials: {e}")
             return None

--- a/functions-python/batch_process_dataset/src/main.py
+++ b/functions-python/batch_process_dataset/src/main.py
@@ -95,11 +95,7 @@ class DatasetProcessor:
         Gets the feed credentials from the environment variable
         """
         try:
-            all_creds = os.getenv("FEEDS_CREDENTIALS", "{}")
-            if all_creds is None:
-                logging.warning("No feed credentials found.")
-                return None
-            feeds_credentials = json.loads(all_creds)
+            feeds_credentials = json.loads(os.getenv("FEEDS_CREDENTIALS", "{}"))
             return feeds_credentials.get(feed_stable_id, None)
         except Exception as e:
             logging.error(f"Error getting feed credentials: {e}")

--- a/functions-python/batch_process_dataset/src/main.py
+++ b/functions-python/batch_process_dataset/src/main.py
@@ -76,7 +76,7 @@ class DatasetProcessor:
         self.authentication_type = authentication_type
         self.api_key_parameter_name = api_key_parameter_name
         self.date = datetime.now().strftime("%Y%m%d%H%M")
-        feeds_credentials = ast.literal_eval(os.getenv("FEED_CREDENTIALS", "{}"))
+        feeds_credentials = ast.literal_eval(os.getenv("FEEDS_CREDENTIALS", "{}"))
         self.feed_credentials = feeds_credentials.get(self.feed_stable_id, None)
         self.public_hosted_datasets_url = public_hosted_datasets_url
 

--- a/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
+++ b/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
@@ -290,6 +290,40 @@ class TestDatasetProcessor(unittest.TestCase):
         )
 
     @patch.dict(
+        os.environ,
+        {"FEEDS_CREDENTIALS": "not a JSON string"},
+    )
+    def test_fails_authenticated_feed_creds_invalid(self):
+        session = get_testing_session()
+        feeds = session.query(Gtfsfeed).all()
+        feed_id = feeds[0].id
+
+        producer_url = "https://testproducer.com/data"
+        feed_stable_id = "test_stable_id"
+        execution_id = "test_execution_id"
+        latest_hash = "old_hash"
+        bucket_name = "test-bucket"
+        authentication_type = 1
+        api_key_parameter_name = "test_api_key"
+
+        with self.assertRaises(Exception) as context:
+            DatasetProcessor(
+                producer_url,
+                feed_id,
+                feed_stable_id,
+                execution_id,
+                latest_hash,
+                bucket_name,
+                authentication_type,
+                api_key_parameter_name,
+                test_hosted_public_url,
+            )
+        self.assertEqual(
+            str(context.exception),
+            "Error getting feed credentials for feed test_stable_id",
+        )
+
+    @patch.dict(
         os.environ, {"FEEDS_CREDENTIALS": '{"test_stable_id": "test_credentials"}'}
     )
     def test_process_no_change(self):
@@ -384,3 +418,32 @@ class TestDatasetProcessor(unittest.TestCase):
             assert False
         except AttributeError:
             assert True
+
+    @patch("batch_process_dataset.src.main.Logger")
+    @patch("batch_process_dataset.src.main.DatasetTraceService")
+    def test_process_dataset_missing_stable_id(self, mock_dataset_trace, _):
+        db_url = os.getenv("TEST_FEEDS_DATABASE_URL", default=default_db_url)
+        os.environ["FEEDS_DATABASE_URL"] = db_url
+
+        # Mock data for the CloudEvent
+        mock_data = {
+            "execution_id": "test_execution_id",
+            "producer_url": "https://testproducer.com/data",
+            "feed_stable_id": "",
+            "feed_id": "test_feed_id",
+            "dataset_id": "test_dataset_id",
+            "dataset_hash": "test_dataset_hash",
+            "authentication_type": 0,
+            "api_key_parameter_name": None,
+        }
+
+        cloud_event = create_cloud_event(mock_data)
+
+        mock_dataset_trace.save.return_value = None
+        mock_dataset_trace.get_by_execution_and_stable_ids.return_value = 0
+        # Call the function
+        result = process_dataset(cloud_event)
+        assert (
+            result
+            == "Function completed with errors, missing stable= or execution_id=test_execution_id"
+        )


### PR DESCRIPTION
**Summary:**

Fix a misspelling in the feeds credentials variable name that blocks authenticated feeds from being downloaded.

**Expected behavior:** 

Authenticated feeds are downloaded.

**Testing tips:**

Tested on DEV environment, [here an example of an authenticated feed downloaded](https://mobility-feeds-dev--pr-699-7543h9pe.web.app/feeds/mdb-1847)
Successfully trace of a dataset updated, [here](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22batch-process-dataset-dev%22%0Aresource.labels.location%20%3D%20%22northamerica-northeast1%22%0Aseverity%3E%3DDEFAULT%0Atrace%3D%22projects%2Fmobility-feeds-dev%2Ftraces%2Ff9847126d2276a247670d5b3896641ab%22;storageScope=project;cursorTimestamp=2024-08-20T23:50:42.552376Z;startTime=2024-08-20T17:31:19.569Z;endTime=2024-08-20T23:52:51.226Z?project=mobility-feeds-dev)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
