### PR TITLE
Removed some integration tests on QA when updating prod DB

### DIFF
--- a/functions-python/batch_datasets/src/main.py
+++ b/functions-python/batch_datasets/src/main.py
@@ -137,7 +137,7 @@ def batch_datasets(request):
         print(f"Publishing {data_str} to {topic_path}.")
         future = publish(publisher, topic_path, data_str.encode("utf-8"))
         future.add_done_callback(
-            lambda _: publish_callback(future, feed["stable_id"], topic_path)
+            lambda _: publish_callback(future, feed.stable_id, topic_path)
         )
     BatchExecutionService().save(
         BatchExecution(


### PR DESCRIPTION
**Summary:**

I noticed this exception in the logs for the batch-datasets-prod cloud run function:
```
Traceback (most recent call last):
  File "/layers/google.python.runtime/python/lib/python3.10/concurrent/futures/_base.py", line 342, in _invoke_callbacks
    callback(self)
  File "/workspace/main.py", line 140, in <lambda>
    lambda _: publish_callback(future, feed["stable_id"], topic_path)
  File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 48, in sqlalchemy.cyextension.resultproxy.BaseRow.__getitem__
TypeError: tuple indices must be integers or slices, not str
```
The only minor effect of that exception is that there is no log saying that the publish was done for the stable_id, or an error if the publish does not work.

It's really minor, but I thought I might as well correct it.
 
**Expected behavior:** 

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
