### PR TITLE
hotfix: default filtering for location

### DIFF
--- a/web-app/src/app/screens/Analytics/GTFSFeedAnalytics/GTFSFeedAnalyticsTable.tsx
+++ b/web-app/src/app/screens/Analytics/GTFSFeedAnalytics/GTFSFeedAnalyticsTable.tsx
@@ -74,7 +74,7 @@ export const useTableColumns = (
         header: 'Locations',
         size: 220,
         filterVariant: 'autocomplete',
-        filterFn: 'doesNotInclude',
+        filterFn: 'contains',
         columnFilterModeOptions: [
           'contains',
           'startsWith',


### PR DESCRIPTION
**Summary:**
Hotfix for the default behaviour of the location filter for the GTFS metrics
