### PR TITLE
navigation fix

### DIFF
--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -284,7 +284,7 @@ export default function DrawerAppBar(): React.ReactElement {
           <Box sx={{ display: { xs: 'none', md: 'block' } }}>
             {navigationItems.map((item) => (
               <Button
-                href={item.target}
+                href={item.external === true ? item.target : '/' + item.target}
                 key={item.title}
                 sx={{ color: item.color, minWidth: 'fit-content', mx: 1 }}
                 target={item.external === true ? '_blank' : '_self'}


### PR DESCRIPTION
**Summary:**

BUG

When navigating from the header it would be relative paths ex
`https://mobilitydatabase.org/feeds`-> click header FAQ -> `https://mobilitydatabase.org/feeds/faq`

FIX

`https://mobilitydatabase.org/feeds`-> click header FAQ -> `https://mobilitydatabase.org/faq`

**Expected behavior:** 

`https://mobilitydatabase.org/feeds`-> click header FAQ -> `https://mobilitydatabase.org/faq`

**Testing tips:**

Navigate from anywhere using header

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
