### PR TITLE
chore: replace docker-compose by docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Folder `api` contains source code of the API implementation. This repository rel
 
 ## Requirements.
 
-The tested and recommended Python version: `~=3.11`.
+The tested and recommended with the following versions:
+- Python: `~=3.11`
+- Docker: `>=20.10`
 
 ### External dependencies
  - docker

--- a/functions-python/README.md
+++ b/functions-python/README.md
@@ -48,7 +48,7 @@ or
 ```
 - Start local and test database
 ```
-docker-compose --env-file ./config/.env.local up -d liquibase-test
+docker compose --env-file ./config/.env.local up -d liquibase-test
 ```
 
 # Local variables
@@ -61,7 +61,7 @@ export MY_AWESOME_KEY=MY_AWESOME_VALUE
 If a folder `tests` is added to a function's folder, the script `api-tests.sh` will execute the tests without any further configuration.
 Make sure the testing database is running before executing the tests.
 ```
-docker-compose --env-file ./config/.env.local up -d liquibase-test
+docker compose --env-file ./config/.env.local up -d liquibase-test
 ```
 Execute all tests within the functions-python folder
 ```

--- a/scripts/docker-localdb-rebuild-data.sh
+++ b/scripts/docker-localdb-rebuild-data.sh
@@ -89,7 +89,7 @@ rm -rf $data_dir
 sleep 5
 
 # Start the container and run the liquibase
-docker-compose --env-file $SCRIPT_PATH/../config/.env.local -f $SCRIPT_PATH/../docker-compose.yaml up -d $docker_service
+docker compose --env-file $SCRIPT_PATH/../config/.env.local -f $SCRIPT_PATH/../docker-compose.yaml up -d $docker_service
 # wait for the liquibase to finish
 sleep 20
 


### PR DESCRIPTION
**Summary:**

As docker 20.10 `docker-compose` has been replaced by `docker compose` command. This PR replace the use of the legacy command.

**Expected behavior:** 

The changes in the build script don't impact the python functions deployment.

**Testing tips:**

- Upgrade your local docker to +=20.10
- Execute 
```
./scripts/docker-localdb-rebuild-data.sh
```
- Verify that the local docker DB is correctly updated.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
