### PR TITLE
chore: upgrade python packages in functions and set runtime to python 3.11 - Firebase functions runtime to Node 20

### DIFF
--- a/.github/workflows/datasets-batch-deployer.yml
+++ b/.github/workflows/datasets-batch-deployer.yml
@@ -39,6 +39,9 @@ on:
         description: Service account key
         required: true
 
+env:
+  python_version: '3.11'
+
 jobs:
   terraform:
     name: 'Terraform'
@@ -79,6 +82,10 @@ jobs:
         run: |
           docker compose --env-file ./config/.env.local up -d postgres
         working-directory: ${{ github.workspace }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python_version }}
 
       - name: Install Liquibase
         run: |    

--- a/functions-python/batch_datasets/main_local_debug.py
+++ b/functions-python/batch_datasets/main_local_debug.py
@@ -16,9 +16,10 @@ from src.main import batch_datasets
 from dotenv import load_dotenv
 
 # Load environment variables from .env.local
-load_dotenv(dotenv_path='.env.local')
+load_dotenv(dotenv_path=".env.local")
 
 if __name__ == "__main__":
+
     class RequestObject:
         def __init__(self, headers):
             self.headers = headers

--- a/functions-python/batch_datasets/main_local_debug.py
+++ b/functions-python/batch_datasets/main_local_debug.py
@@ -1,0 +1,27 @@
+# Code to be able to debug locally without affecting the runtime cloud function
+
+#
+# Requirements:
+# - Google Cloud SDK installed
+# - Make sure to have the following environment variables set in your .env.local file
+# - Local database in running state
+# - Pub/Sub emulator running
+#   - gcloud beta emulators pubsub start --project=project-id --host-port='localhost:8043'
+# - Google Datastore emulator running
+#   - gcloud beta emulators datastore start --project=project-id --host-port='localhost:8042'
+
+# Usage:
+# - python batch_datasets/main_local_debug.py
+from src.main import batch_datasets
+from dotenv import load_dotenv
+
+# Load environment variables from .env.local
+load_dotenv(dotenv_path='.env.local')
+
+if __name__ == "__main__":
+    class RequestObject:
+        def __init__(self, headers):
+            self.headers = headers
+
+    request = RequestObject({"X-Cloud-Trace-Context": "1234567890abcdef"})
+    batch_datasets(request)

--- a/functions-python/batch_datasets/requirements.txt
+++ b/functions-python/batch_datasets/requirements.txt
@@ -1,15 +1,20 @@
+# Common packages
 functions-framework==3.*
-google-cloud-pubsub
 google-cloud-logging
-google-cloud-datastore
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
-cloudevents~=1.10.1
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+google-cloud-pubsub
+google-cloud-datastore
+cloudevents~=1.10.1

--- a/functions-python/batch_datasets/src/main.py
+++ b/functions-python/batch_datasets/src/main.py
@@ -137,7 +137,7 @@ def batch_datasets(request):
         print(f"Publishing {data_str} to {topic_path}.")
         future = publish(publisher, topic_path, data_str.encode("utf-8"))
         future.add_done_callback(
-            lambda _: publish_callback(future, feed["stable_id"], topic_path)
+            lambda _: publish_callback(future, feed.stable_id, topic_path)
         )
     BatchExecutionService().save(
         BatchExecution(

--- a/functions-python/batch_process_dataset/.env.rename_me
+++ b/functions-python/batch_process_dataset/.env.rename_me
@@ -1,0 +1,9 @@
+# Environment variables for tokens function to run locally. Delete this line after rename the file.
+FEEDS_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/MobilityDatabase
+PROJECT_ID=my-project-id
+DATASTORE_DATASET=my-project-id
+DATASTORE_EMULATOR_HOST=localhost:8044
+DATASTORE_EMULATOR_HOST_PATH=localhost:8044/datastore
+DATASTORE_HOST=http://localhost:8044
+DATASTORE_PROJECT_ID=my-project-id
+

--- a/functions-python/batch_process_dataset/main_local_debug.py
+++ b/functions-python/batch_process_dataset/main_local_debug.py
@@ -3,6 +3,7 @@ import base64
 import json
 
 from cloudevents.http import CloudEvent
+
 #
 # Requirements:
 # - Google Cloud SDK installed
@@ -20,7 +21,7 @@ from dotenv import load_dotenv
 from batch_process_dataset.src.main import process_dataset
 
 # Load environment variables from .env.local
-load_dotenv(dotenv_path='.env.local')
+load_dotenv(dotenv_path=".env.local")
 
 if __name__ == "__main__":
     attributes = {
@@ -29,17 +30,21 @@ if __name__ == "__main__":
     }
     data = {
         "message": {
-            "data": base64.b64encode(json.dumps({
-                "execution_id": "execution_id",
-                "producer_url": "producer_url",
-                "feed_stable_id": "feed_stable_id",
-                "feed_id": "feed_id",
-                "dataset_id": "dataset_id",
-                "dataset_hash": "dataset_hash",
-                "authentication_type": 0,
-                "authentication_info_url": "authentication_info_url",
-                "api_key_parameter_name": "api_key_parameter_name"
-            }).encode("utf-8")).decode("utf-8")
+            "data": base64.b64encode(
+                json.dumps(
+                    {
+                        "execution_id": "execution_id",
+                        "producer_url": "producer_url",
+                        "feed_stable_id": "feed_stable_id",
+                        "feed_id": "feed_id",
+                        "dataset_id": "dataset_id",
+                        "dataset_hash": "dataset_hash",
+                        "authentication_type": 0,
+                        "authentication_info_url": "authentication_info_url",
+                        "api_key_parameter_name": "api_key_parameter_name",
+                    }
+                ).encode("utf-8")
+            ).decode("utf-8")
         }
     }
     cloud_event = CloudEvent(attributes, data)

--- a/functions-python/batch_process_dataset/main_local_debug.py
+++ b/functions-python/batch_process_dataset/main_local_debug.py
@@ -1,0 +1,46 @@
+# Code to be able to debug locally without affecting the runtime cloud function
+import base64
+import json
+
+from cloudevents.http import CloudEvent
+#
+# Requirements:
+# - Google Cloud SDK installed
+# - Make sure to have the following environment variables set in your .env.local file
+# - Local database in running state
+# - Pub/Sub emulator running
+#   - gcloud beta emulators pubsub start --project=project-id --host-port='localhost:8043'
+# - Google Datastore emulator running
+#   - gcloud beta emulators datastore start --project=project-id --host-port='localhost:8042' --no-store-on-disk
+
+# Usage:
+# - python batch_process_dataset/main_local_debug.py
+
+from dotenv import load_dotenv
+from batch_process_dataset.src.main import process_dataset
+
+# Load environment variables from .env.local
+load_dotenv(dotenv_path='.env.local')
+
+if __name__ == "__main__":
+    attributes = {
+        "type": "com.google.cloud.pubsub.topic.publish",
+        "source": "//pubsub.googleapis.com/projects/sample-project/topics/sample-topic",
+    }
+    data = {
+        "message": {
+            "data": base64.b64encode(json.dumps({
+                "execution_id": "execution_id",
+                "producer_url": "producer_url",
+                "feed_stable_id": "feed_stable_id",
+                "feed_id": "feed_id",
+                "dataset_id": "dataset_id",
+                "dataset_hash": "dataset_hash",
+                "authentication_type": 0,
+                "authentication_info_url": "authentication_info_url",
+                "api_key_parameter_name": "api_key_parameter_name"
+            }).encode("utf-8")).decode("utf-8")
+        }
+    }
+    cloud_event = CloudEvent(attributes, data)
+    process_dataset(cloud_event)

--- a/functions-python/batch_process_dataset/requirements.txt
+++ b/functions-python/batch_process_dataset/requirements.txt
@@ -1,21 +1,24 @@
+# Common packages
 functions-framework==3.*
+google-cloud-logging
+psycopg2-binary==2.9.6
+aiohttp~=3.10.5
+asyncio~=3.4.3
+urllib3~=2.2.2
+requests~=2.32.3
+attrs~=23.1.0
+pluggy~=1.3.0
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
 google-cloud-storage
 google-cloud-pubsub
-google-cloud-logging
 google-api-core
 google-cloud-firestore
 google-cloud-datastore
 google-cloud-bigquery
-psycopg2-binary==2.9.6
-aiohttp
-asyncio
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
 cloudevents~=1.10.1
-requests_mock
-Faker
-pytest~=7.4.3
-urllib3-mock
-requests-mock

--- a/functions-python/batch_process_dataset/requirements_dev.txt
+++ b/functions-python/batch_process_dataset/requirements_dev.txt
@@ -2,3 +2,4 @@ Faker
 pytest~=7.4.3
 urllib3-mock
 requests-mock
+python-dotenv~=1.0.0

--- a/functions-python/big_query_ingestion/requirements.txt
+++ b/functions-python/big_query_ingestion/requirements.txt
@@ -1,15 +1,22 @@
+# Common packages
 functions-framework==3.*
 google-cloud-logging
-google-cloud-bigquery
-google-cloud-storage
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+google-cloud-bigquery
+google-cloud-storage
+
+# Additional packages for this function
 pandas

--- a/functions-python/extract_location/requirements.txt
+++ b/functions-python/extract_location/requirements.txt
@@ -1,17 +1,24 @@
+# Common packages
 functions-framework==3.*
-google-cloud-pubsub
 google-cloud-logging
-google-cloud-datastore
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
-cloudevents~=1.10.1
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+google-cloud-pubsub
+google-cloud-datastore
+cloudevents~=1.10.1
+
+# Additional packages for this function
 gtfs-kit
 pandas

--- a/functions-python/gbfs_validator/requirements.txt
+++ b/functions-python/gbfs_validator/requirements.txt
@@ -1,15 +1,23 @@
+# Common packages
 functions-framework==3.*
+google-cloud-logging
+psycopg2-binary==2.9.6
+aiohttp~=3.10.5
+asyncio~=3.4.3
+urllib3~=2.2.2
+requests~=2.32.3
+attrs~=23.1.0
+pluggy~=1.3.0
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
 google-cloud-storage
 google-cloud-pubsub
-google-cloud-logging
 google-api-core
 google-cloud-firestore
 google-cloud-datastore
-psycopg2-binary==2.9.6
-aiohttp
-asyncio
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
 cloudevents~=1.10.1

--- a/functions-python/preprocessed_analytics/requirements.txt
+++ b/functions-python/preprocessed_analytics/requirements.txt
@@ -1,15 +1,22 @@
+# Common packages
 functions-framework==3.*
 google-cloud-logging
-google-cloud-bigquery
-google-cloud-storage
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+google-cloud-bigquery
+google-cloud-storage
+
+# Additional packages for this function
 pandas

--- a/functions-python/update_validation_report/requirements.txt
+++ b/functions-python/update_validation_report/requirements.txt
@@ -1,15 +1,20 @@
+# Common packages
 functions-framework==3.*
 google-cloud-logging
-google-cloud-storage
-google-cloud-workflows
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
-cloudevents~=1.10.1
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+cloudevents~=1.10.1
+google-cloud-storage
+google-cloud-workflows

--- a/functions-python/validation_report_processor/requirements.txt
+++ b/functions-python/validation_report_processor/requirements.txt
@@ -1,13 +1,18 @@
+# Common packages
 functions-framework==3.*
 google-cloud-logging
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
-cloudevents~=1.10.1
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+cloudevents~=1.10.1

--- a/functions-python/validation_to_ndjson/requirements.txt
+++ b/functions-python/validation_to_ndjson/requirements.txt
@@ -1,15 +1,22 @@
+# Common packages
 functions-framework==3.*
 google-cloud-logging
-google-cloud-bigquery
-google-cloud-storage
 psycopg2-binary==2.9.6
-aiohttp~=3.8.6
+aiohttp~=3.10.5
 asyncio~=3.4.3
-urllib3~=2.1.0
-SQLAlchemy==2.0.23
-geoalchemy2==0.14.7
-requests~=2.31.0
+urllib3~=2.2.2
+requests~=2.32.3
 attrs~=23.1.0
 pluggy~=1.3.0
-certifi~=2023.7.22
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+google-cloud-bigquery
+google-cloud-storage
+
+# Additional packages for this function
 pandas

--- a/functions/firebase.json
+++ b/functions/firebase.json
@@ -2,6 +2,7 @@
   "functions": [
     {
       "source": "packages/user-api",
+      "runtime": "nodejs20",
       "codebase": "user-api",
       "ignore": [
         "node_modules",
@@ -17,6 +18,7 @@
     },
     {
       "source": "packages/feed-form",
+      "runtime": "nodejs20",
       "codebase": "feed-form",
       "ignore": [
         "node_modules",

--- a/infra/batch/vars.tf
+++ b/infra/batch/vars.tf
@@ -45,7 +45,7 @@ variable "job_attempt_deadline" {
 variable "python_runtime" {
   type = string
   description = "Python runtime version"
-  default = "python310"
+  default = "python311"
 }
 
 variable "public_hosted_datasets_dns" {

--- a/infra/functions-python/vars.tf
+++ b/infra/functions-python/vars.tf
@@ -32,7 +32,7 @@ variable "environment" {
 variable "python_runtime" {
   type = string
   description = "Python runtime version"
-  default = "python310"
+  default = "python311"
 }
 
 variable "datasets_bucket_name" {

--- a/infra/metrics/vars.tf
+++ b/infra/metrics/vars.tf
@@ -32,7 +32,7 @@ variable "environment" {
 variable "python_runtime" {
   type = string
   description = "Python runtime version"
-  default = "python310"
+  default = "python311"
 }
 
 variable "gtfs_datasets_storage_bucket" {


### PR DESCRIPTION
**Summary:**

- Upgrade Python functions to 3.11 runtime to align with the DB API. 
- Re-organized dependencies to prepare future refactoring to have a base requirements file for all GCP functions.
- Upgrade Firebase runtime functions to Node 20
- Tested in DEV environment

**Expected behavior:** 
- Python functions runtime must be in the 3.11 version
- Firebase functions runtime must be in the 20 version.

**Testing tips:**
- Upgrade your local environment to Python 3.11
- Make sure all tests pass locally
- Run functions and execute them locally or in DEV environment

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
