### PR TITLE
Feat: 748 add feed form minor changes

### DIFF
--- a/web-app/.eslintrc.json
+++ b/web-app/.eslintrc.json
@@ -27,8 +27,8 @@
       "unused-imports/no-unused-imports": "error",
       "react/react-in-jsx-scope": "off",
       "prettier/prettier": "error",
-      "@typescript-eslint/ban-tslint-comment": "off"
-
+      "@typescript-eslint/ban-tslint-comment": "off",
+      "react/prop-types": "off"
     }
   }
   

--- a/web-app/cypress/e2e/addFeedForm.cy.ts
+++ b/web-app/cypress/e2e/addFeedForm.cy.ts
@@ -95,7 +95,6 @@ describe('Add Feed Form', () => {
       cy.get('[data-cy=thirdStepSubmit]').click();
       // Step 4
       cy.get('[data-cy=fourthStepSubmit]').click();
-      cy.assetMuiError('[data-cy=dataProducerEmailLabel]');
       cy.assetMuiError('[data-cy=dataAuditLabel]');
       cy.assetMuiError('[data-cy=logoPermissionLabel]');
     });

--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -38,7 +38,7 @@
     },
     "errorSubmitting": "An error occurred while submitting the form.",
     "submittingFeed": "Submitting the feed...",
-    "errorUrl": "The URL format requires http:// or https://"
+    "errorUrl": "The URL must start with a valid protocol: http:// or https://"
   },
   "seeFullList": "See full list",
   "hideFullList": "Hide full list",

--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -38,13 +38,14 @@
     },
     "errorSubmitting": "An error occurred while submitting the form.",
     "submittingFeed": "Submitting the feed...",
-    "errorUrl": "The URL format is invalid"
+    "errorUrl": "The URL format requires http:// or https://"
   },
   "seeFullList": "See full list",
   "hideFullList": "Hide full list",
   "producerDownloadUrl": "Producer download URL",
   "copyDownloadUrl": "Copy download URL",
   "producerUrlCopied": "Producer url copied to clipboard",
+  "linkToLicense": "Link to feed license",
   "authenticationType": "Authentication type",
   "selectAuthenticationType": "Please select an authentication type",
   "registerToDownloadFeed": "Register to download feed",

--- a/web-app/src/app/screens/FeedSubmission/Form/FirstStep.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/FirstStep.tsx
@@ -234,11 +234,11 @@ export default function FormFirstStep({
                   {t('oldFeedLink')}
                 </FormLabel>
                 <Controller
-                  rules={
-                    isUpdatingFeed === 'yes' && dataType === 'gtfs'
-                      ? { required: t('form.oldFeedLinkRequired') }
-                      : {}
-                  }
+                  rules={{
+                    required: t('form.oldFeedLinkRequired'),
+                    validate: (value) =>
+                      isValidFeedLink(value ?? '') || t('form.errorUrl'),
+                  }}
                   control={control}
                   name='oldFeedLink'
                   render={({ field }) => (

--- a/web-app/src/app/screens/FeedSubmission/Form/FourthStep.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/FourthStep.tsx
@@ -1,5 +1,4 @@
 import {
-  Typography,
   Grid,
   FormControl,
   FormLabel,
@@ -17,6 +16,7 @@ import {
 } from 'react-hook-form';
 import { type YesNoFormInput, type FeedSubmissionFormFormInput } from '.';
 import { useTranslation } from 'react-i18next';
+import FormLabelDescription from './components/FormLabelDescription';
 
 export interface FeedSubmissionFormInputFourthStep {
   dataProducerEmail?: string;
@@ -70,32 +70,20 @@ export default function FormFourthStep({
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid container direction={'column'} rowSpacing={2}>
           <Grid item>
-            <FormControl
-              component='fieldset'
-              fullWidth
-              error={errors.dataProducerEmail !== undefined}
-            >
-              <FormLabel
-                component='legend'
-                required
-                data-cy='dataProducerEmailLabel'
-              >
+            <FormControl component='fieldset' fullWidth>
+              <FormLabel component='legend' data-cy='dataProducerEmailLabel'>
                 {t('dataProducerEmail')}
-                <br></br>
-                <Typography variant='caption' color='textSecondary'>
-                  {t('dataProducerEmailDetails')}
-                </Typography>
               </FormLabel>
+              <FormLabelDescription>
+                {t('dataProducerEmailDetails')}
+              </FormLabelDescription>
               <Controller
-                rules={{ required: t('form.dataProducerEmailRequired') }}
                 control={control}
                 name='dataProducerEmail'
                 render={({ field }) => (
                   <TextField
                     className='md-small-input'
                     {...field}
-                    error={errors.dataProducerEmail !== undefined}
-                    helperText={errors.dataProducerEmail?.message ?? ''}
                     data-cy='dataProducerEmail'
                   />
                 )}
@@ -109,11 +97,10 @@ export default function FormFourthStep({
             >
               <FormLabel required data-cy='dataAuditLabel'>
                 {t('interestedInDataAudit')}
-                <br></br>
-                <Typography variant='caption' color='textSecondary'>
-                  {t('interestedInDataAuditDetails')}
-                </Typography>
               </FormLabel>
+              <FormLabelDescription>
+                {t('interestedInDataAuditDetails')}
+              </FormLabelDescription>
               <Controller
                 control={control}
                 name='isInterestedInQualityAudit'
@@ -167,11 +154,11 @@ export default function FormFourthStep({
             >
               <FormLabel required data-cy='logoPermissionLabel'>
                 {t('hasLogoPermission')}
-                <br></br>
-                <Typography variant='caption' color='textSecondary'>
-                  {t('hasLogoPermissionDetails')}
-                </Typography>
               </FormLabel>
+              <FormLabelDescription>
+                {t('hasLogoPermissionDetails')}
+              </FormLabelDescription>
+
               <Controller
                 control={control}
                 name='hasLogoPermission'
@@ -196,13 +183,10 @@ export default function FormFourthStep({
           </Grid>
           <Grid item>
             <FormControl component='fieldset' fullWidth>
-              <FormLabel>
-                {t('whatToolsCreateGtfs')}
-                <br></br>
-                <Typography variant='caption' color='textSecondary'>
-                  {t('whatToolsCreateGtfsDetails')}
-                </Typography>
-              </FormLabel>
+              <FormLabel>{t('whatToolsCreateGtfs')}</FormLabel>
+              <FormLabelDescription>
+                {t('whatToolsCreateGtfsDetails')}
+              </FormLabelDescription>
               <Controller
                 control={control}
                 name='whatToolsUsedText'

--- a/web-app/src/app/screens/FeedSubmission/Form/SecondStep.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/SecondStep.tsx
@@ -14,6 +14,7 @@ import { type FeedSubmissionFormFormInput } from '.';
 import { useTranslation } from 'react-i18next';
 import { getCountryDataList } from 'countries-list';
 import { useState } from 'react';
+import FormLabelDescription from './components/FormLabelDescription';
 
 export interface FeedSubmissionFormInputSecondStep {
   country: string;
@@ -123,13 +124,10 @@ export default function FormSecondStep({
           </Grid>
           <Grid item>
             <FormControl component='fieldset' fullWidth>
-              <FormLabel component='legend'>
-                {t('common:name')}
-                <br></br>
-                <Typography variant='caption'>
-                  {t('feedNameDetails')}
-                </Typography>
-              </FormLabel>
+              <FormLabel component='legend'>{t('common:name')}</FormLabel>
+              <FormLabelDescription>
+                {t('feedNameDetails')}
+              </FormLabelDescription>
               <Controller
                 control={control}
                 name='name'

--- a/web-app/src/app/screens/FeedSubmission/Form/SecondStepRealtime.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/SecondStepRealtime.tsx
@@ -10,6 +10,7 @@ import { type SubmitHandler, Controller, useForm } from 'react-hook-form';
 import { type AuthTypes, type FeedSubmissionFormFormInput } from '.';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isValidFeedLink } from '../../../services/feeds/utils';
 
 export interface FeedSubmissionFormInputSecondStepRT {
   tripUpdates: string;
@@ -77,9 +78,24 @@ export default function FormSecondStepRT({
     }
   }, [tripUpdates, vehiclePositions, serviceAlerts]);
 
-  const gtfsRtLinkValidation = (): undefined | string => {
+  const gtfsRtLinkValidation = (
+    rtType: 'tu' | 'vp' | 'sa',
+  ): boolean | string => {
     if (tripUpdates !== '' || vehiclePositions !== '' || serviceAlerts !== '') {
-      return undefined;
+      switch (rtType) {
+        case 'tu':
+          return tripUpdates !== ''
+            ? isValidFeedLink(tripUpdates) || t('form.errorUrl')
+            : true;
+        case 'vp':
+          return vehiclePositions !== ''
+            ? isValidFeedLink(vehiclePositions) || t('form.errorUrl')
+            : true;
+        case 'sa':
+          return serviceAlerts !== ''
+            ? isValidFeedLink(serviceAlerts) || t('form.errorUrl')
+            : true;
+      }
     } else {
       return t('form.atLeastOneRealtimeFeed');
     }
@@ -109,7 +125,7 @@ export default function FormSecondStepRT({
               <Controller
                 control={control}
                 name='serviceAlerts'
-                rules={{ validate: gtfsRtLinkValidation }}
+                rules={{ validate: () => gtfsRtLinkValidation('sa') }}
                 render={({ field }) => (
                   <TextField
                     className='md-small-input'
@@ -124,15 +140,30 @@ export default function FormSecondStepRT({
           </Grid>
           {isFeedUpdate && (
             <Grid item mb={2}>
-              <FormControl component='fieldset' fullWidth>
+              <FormControl
+                component='fieldset'
+                fullWidth
+                error={errors.oldServiceAlerts !== undefined}
+              >
                 <FormLabel component='legend'>
                   {t('oldServiceAlertsFeed')}
                 </FormLabel>
                 <Controller
                   control={control}
                   name='oldServiceAlerts'
+                  rules={{
+                    validate: (value) => {
+                      if (value === '' || value === undefined) return true;
+                      return isValidFeedLink(value) || t('form.errorUrl');
+                    },
+                  }}
                   render={({ field }) => (
-                    <TextField className='md-small-input' {...field} />
+                    <TextField
+                      className='md-small-input'
+                      {...field}
+                      helperText={errors.oldServiceAlerts?.message ?? ''}
+                      error={errors.oldServiceAlerts !== undefined}
+                    />
                   )}
                 />
               </FormControl>
@@ -150,7 +181,7 @@ export default function FormSecondStepRT({
               <Controller
                 control={control}
                 name='tripUpdates'
-                rules={{ validate: gtfsRtLinkValidation }}
+                rules={{ validate: () => gtfsRtLinkValidation('tu') }}
                 render={({ field }) => (
                   <TextField
                     className='md-small-input'
@@ -164,15 +195,30 @@ export default function FormSecondStepRT({
           </Grid>
           {isFeedUpdate && (
             <Grid item mb={2}>
-              <FormControl component='fieldset' fullWidth>
+              <FormControl
+                component='fieldset'
+                fullWidth
+                error={errors.oldTripUpdates !== undefined}
+              >
                 <FormLabel component='legend'>
                   {t('oldTripUpdatesFeed')}
                 </FormLabel>
                 <Controller
                   control={control}
                   name='oldTripUpdates'
+                  rules={{
+                    validate: (value) => {
+                      if (value === '' || value === undefined) return true;
+                      return isValidFeedLink(value) || t('form.errorUrl');
+                    },
+                  }}
                   render={({ field }) => (
-                    <TextField className='md-small-input' {...field} />
+                    <TextField
+                      className='md-small-input'
+                      {...field}
+                      helperText={errors.oldTripUpdates?.message ?? ''}
+                      error={errors.oldTripUpdates !== undefined}
+                    />
                   )}
                 />
               </FormControl>
@@ -190,7 +236,7 @@ export default function FormSecondStepRT({
               <Controller
                 control={control}
                 name='vehiclePositions'
-                rules={{ validate: gtfsRtLinkValidation }}
+                rules={{ validate: () => gtfsRtLinkValidation('vp') }}
                 render={({ field }) => (
                   <TextField
                     className='md-small-input'
@@ -204,15 +250,30 @@ export default function FormSecondStepRT({
           </Grid>
           {isFeedUpdate && (
             <Grid item mb={2}>
-              <FormControl component='fieldset' fullWidth>
+              <FormControl
+                component='fieldset'
+                fullWidth
+                error={errors.oldVehiclePositions !== undefined}
+              >
                 <FormLabel component='legend'>
                   {t('oldVehiclePositionsFeed')}
                 </FormLabel>
                 <Controller
                   control={control}
                   name='oldVehiclePositions'
+                  rules={{
+                    validate: (value) => {
+                      if (value === '' || value === undefined) return true;
+                      return isValidFeedLink(value) || t('form.errorUrl');
+                    },
+                  }}
                   render={({ field }) => (
-                    <TextField className='md-small-input' {...field} />
+                    <TextField
+                      className='md-small-input'
+                      {...field}
+                      helperText={errors.oldVehiclePositions?.message ?? ''}
+                      error={errors.oldVehiclePositions !== undefined}
+                    />
                   )}
                 />
               </FormControl>
@@ -220,15 +281,30 @@ export default function FormSecondStepRT({
           )}
 
           <Grid item>
-            <FormControl component='fieldset' fullWidth>
+            <FormControl
+              component='fieldset'
+              fullWidth
+              error={errors.gtfsRelatedScheduleLink !== undefined}
+            >
               <FormLabel component='legend'>
                 {t('relatedGtfsScheduleFeed')}
               </FormLabel>
               <Controller
                 control={control}
                 name='gtfsRelatedScheduleLink'
+                rules={{
+                  validate: (value) => {
+                    if (value === '' || value === undefined) return true;
+                    return isValidFeedLink(value) || t('form.errorUrl');
+                  },
+                }}
                 render={({ field }) => (
-                  <TextField className='md-small-input' {...field} />
+                  <TextField
+                    className='md-small-input'
+                    {...field}
+                    helperText={errors.gtfsRelatedScheduleLink?.message ?? ''}
+                    error={errors.gtfsRelatedScheduleLink !== undefined}
+                  />
                 )}
               />
             </FormControl>

--- a/web-app/src/app/screens/FeedSubmission/Form/ThirdStep.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/ThirdStep.tsx
@@ -1,5 +1,4 @@
 import {
-  Typography,
   Grid,
   FormControl,
   FormLabel,
@@ -17,6 +16,8 @@ import {
 } from 'react-hook-form';
 import { type FeedSubmissionFormFormInput, type AuthTypes } from '.';
 import { useTranslation } from 'react-i18next';
+import { isValidFeedLink } from '../../../services/feeds/utils';
+import FormLabelDescription from './components/FormLabelDescription';
 
 export interface FeedSubmissionFormInputThirdStep {
   licensePath?: string;
@@ -69,26 +70,38 @@ export default function FormThirdStep({
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid container direction={'column'} rowSpacing={2}>
           <Grid item>
-            <FormControl component='fieldset' fullWidth>
-              <FormLabel component='legend'>Link to feed license</FormLabel>
+            <FormControl
+              component='fieldset'
+              fullWidth
+              error={errors.licensePath !== undefined}
+            >
+              <FormLabel component='legend'>{t('linkToLicense')}</FormLabel>
               <Controller
+                rules={{
+                  validate: (value) => {
+                    if (value === '' || value === undefined) return true;
+                    return isValidFeedLink(value) || t('form.errorUrl');
+                  },
+                }}
                 control={control}
                 name='licensePath'
                 render={({ field }) => (
-                  <TextField className='md-small-input' {...field} />
+                  <TextField
+                    className='md-small-input'
+                    {...field}
+                    helperText={errors.licensePath?.message ?? ''}
+                    error={errors.licensePath !== undefined}
+                  />
                 )}
               />
             </FormControl>
           </Grid>
           <Grid item>
             <FormControl component='fieldset'>
-              <FormLabel>
-                {t('isAuthRequired')}
-                <br></br>
-                <Typography variant='caption' color='textSecondary'>
-                  {t('isAuthRequiredDetails')}
-                </Typography>
-              </FormLabel>
+              <FormLabel>{t('isAuthRequired')}</FormLabel>
+              <FormLabelDescription>
+                {t('isAuthRequiredDetails')}
+              </FormLabelDescription>
               <Select
                 value={authType === 'None - 0' ? authType : 'choiceRequired'}
                 sx={{ width: '200px' }}
@@ -156,7 +169,11 @@ export default function FormThirdStep({
                   <Controller
                     control={control}
                     name='authSignupLink'
-                    rules={{ required: t('common:form.required') }}
+                    rules={{
+                      required: t('common:form.required'),
+                      validate: (value) =>
+                        isValidFeedLink(value ?? '') || t('form.errorUrl'),
+                    }}
                     render={({ field }) => (
                       <TextField
                         className='md-small-input'
@@ -170,13 +187,10 @@ export default function FormThirdStep({
               </Grid>
               <Grid item>
                 <FormControl component='fieldset' fullWidth>
-                  <FormLabel>
-                    {t('form.authType.parameterName')}
-                    <br></br>
-                    <Typography variant='caption'>
-                      {t('form.authType.parameterNameDetail')}
-                    </Typography>
-                  </FormLabel>
+                  <FormLabel>{t('form.authType.parameterName')}</FormLabel>
+                  <FormLabelDescription>
+                    {t('form.authType.parameterNameDetail')}
+                  </FormLabelDescription>
                   <Controller
                     control={control}
                     name='authParameterName'

--- a/web-app/src/app/screens/FeedSubmission/Form/components/FormLabelDescription.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/components/FormLabelDescription.tsx
@@ -1,0 +1,18 @@
+import { Typography } from '@mui/material';
+import { type ReactNode } from 'react';
+
+interface FormLabelDescriptionProps {
+  children: ReactNode;
+}
+
+const FormLabelDescription: React.FC<FormLabelDescriptionProps> = ({
+  children,
+}) => {
+  return (
+    <Typography variant='caption' mb={'4px'}>
+      {children}
+    </Typography>
+  );
+};
+
+export default FormLabelDescription;

--- a/web-app/src/app/services/feeds/utils.spec.ts
+++ b/web-app/src/app/services/feeds/utils.spec.ts
@@ -54,37 +54,20 @@ describe('Feeds Utils', () => {
     );
   });
 
-  it('should validate feed links correctly', () => {
-    const link1 = 'https://gtfs.translink.ca/v2/gtfsposition';
-    expect(isValidFeedLink(link1)).toBe(true);
-
-    const link2 = 'gtfs.translink.ca/v2/gtfsposition';
-    expect(isValidFeedLink(link2)).toBe(false);
-
-    const link3 =
-      'http://whistler.mapstrat.com/current/gtfrealtime_TripUpdates.bin';
-    expect(isValidFeedLink(link3)).toBe(true);
-
-    const link4 = 'http://gtfs.halifax.ca/realtime/Vehicle/VehiclePositions.pb';
-    expect(isValidFeedLink(link4)).toBe(true);
-
-    const link5 = 'http://api.tampa.onebusaway.org:8088/trip-updates';
-    expect(isValidFeedLink(link5)).toBe(true);
-
-    const link6 =
-      'https://transitfeeds.com/p/via-metropolitan-transit/62/latest/download';
-    expect(isValidFeedLink(link6)).toBe(true);
-
-    const link7 = '//transitfeeds.com/p/';
-    expect(isValidFeedLink(link7)).toBe(false);
-
-    const link8 =
-      'https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip';
-    expect(isValidFeedLink(link8)).toBe(true);
-
-    const link9 = 'HTTP://gtfs.translink.ca/v2/gtfsposition';
-    expect(isValidFeedLink(link9)).toBe(true);
-
-    expect(isValidFeedLink('')).toBe(false);
+  /* eslint-disable max-len */
+  it.each([
+    [true,  'https://gtfs.translink.ca/v2/gtfsposition'],
+    [false, 'gtfs.translink.ca/v2/gtfsposition'],
+    [true,  'http://whistler.mapstrat.com/current/gtfrealtime_TripUpdates.bin'],
+    [true,  'http://gtfs.halifax.ca/realtime/Vehicle/VehiclePositions.pb'],
+    [true,  'http://api.tampa.onebusaway.org:8088/trip-updates'],
+    [true,  'https://transitfeeds.com/p/via-metropolitan-transit/62/latest/download'],
+    [false, '//transitfeeds.com/p/'],
+    [true,  'https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip'],
+    [true,  'HTTP://gtfs.translink.ca/v2/gtfsposition'],
+    [false, 'http://.'],
+    [false, ''],
+  ])('should retrun %s when input is %s', (expected, input) => {
+    expect(isValidFeedLink(input)).toBe(expected);
   });
 });

--- a/web-app/src/app/services/feeds/utils.spec.ts
+++ b/web-app/src/app/services/feeds/utils.spec.ts
@@ -54,17 +54,22 @@ describe('Feeds Utils', () => {
     );
   });
 
-  /* eslint-disable max-len */
   it.each([
-    [true,  'https://gtfs.translink.ca/v2/gtfsposition'],
+    [true, 'https://gtfs.translink.ca/v2/gtfsposition'],
     [false, 'gtfs.translink.ca/v2/gtfsposition'],
-    [true,  'http://whistler.mapstrat.com/current/gtfrealtime_TripUpdates.bin'],
-    [true,  'http://gtfs.halifax.ca/realtime/Vehicle/VehiclePositions.pb'],
-    [true,  'http://api.tampa.onebusaway.org:8088/trip-updates'],
-    [true,  'https://transitfeeds.com/p/via-metropolitan-transit/62/latest/download'],
+    [true, 'http://whistler.mapstrat.com/current/gtfrealtime_TripUpdates.bin'],
+    [true, 'http://gtfs.halifax.ca/realtime/Vehicle/VehiclePositions.pb'],
+    [true, 'http://api.tampa.onebusaway.org:8088/trip-updates'],
+    [
+      true,
+      'https://transitfeeds.com/p/via-metropolitan-transit/62/latest/download',
+    ],
     [false, '//transitfeeds.com/p/'],
-    [true,  'https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip'],
-    [true,  'HTTP://gtfs.translink.ca/v2/gtfsposition'],
+    [
+      true,
+      'https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip',
+    ],
+    [true, 'HTTP://gtfs.translink.ca/v2/gtfsposition'],
     [false, 'http://.'],
     [false, ''],
   ])('should retrun %s when input is %s', (expected, input) => {

--- a/web-app/src/app/services/feeds/utils.spec.ts
+++ b/web-app/src/app/services/feeds/utils.spec.ts
@@ -82,6 +82,9 @@ describe('Feeds Utils', () => {
       'https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip';
     expect(isValidFeedLink(link8)).toBe(true);
 
+    const link9 = 'HTTP://gtfs.translink.ca/v2/gtfsposition';
+    expect(isValidFeedLink(link9)).toBe(true);
+
     expect(isValidFeedLink('')).toBe(false);
   });
 });

--- a/web-app/src/app/services/feeds/utils.ts
+++ b/web-app/src/app/services/feeds/utils.ts
@@ -83,6 +83,7 @@ export function getLocationName(
 }
 
 export function isValidFeedLink(feedLink: string): boolean {
+  const lowercaseFeedLink = feedLink.toLowerCase();
   const urlPattern = /^(https?:\/\/)[\w.-]+(:\d+)?(\/[\w.-]*)*$/;
-  return urlPattern.test(feedLink ?? '');
+  return urlPattern.test(lowercaseFeedLink ?? '');
 }

--- a/web-app/src/app/services/feeds/utils.ts
+++ b/web-app/src/app/services/feeds/utils.ts
@@ -84,6 +84,6 @@ export function getLocationName(
 
 export function isValidFeedLink(feedLink: string): boolean {
   const lowercaseFeedLink = feedLink.toLowerCase();
-  const urlPattern = /^(https?:\/\/)[\w.-]+(:\d+)?(\/[\w.-]*)*$/;
+  const urlPattern = /^(https?:\/\/)([^\s$.?#].[^\s]*)$/;
   return urlPattern.test(lowercaseFeedLink ?? '');
 }


### PR DESCRIPTION
closes #748 
**Summary:**

Changes
- URL Validation added to: auth sign up link, old feed link, license path, all gtfs rt links (including old)
- Data producer is now optional
- Form label description styling updated for uniformity
- validating feed links now accept uppercase
- eslint rule updated

**Expected behavior:** 

All changes from https://github.com/MobilityData/mobility-feed-api/issues/748 should be addressed

**Testing tips:**

Go to the add feed form, and verify the ticket changes in https://github.com/MobilityData/mobility-feed-api/issues/748 and assure they work

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
![Screenshot 2024-10-01 at 11 53 08](https://github.com/user-attachments/assets/68c2084d-3b69-4af6-8fc3-5a5d11ea9109)
![Screenshot 2024-10-01 at 11 53 46](https://github.com/user-attachments/assets/68ec8d1e-ee6b-45c8-9c7d-306954d0cf0b)
![Screenshot 2024-10-01 at 11 54 09](https://github.com/user-attachments/assets/3236b176-20a1-40e2-9d0b-38e536a235e0)
![Screenshot 2024-10-01 at 11 54 20](https://github.com/user-attachments/assets/55d49763-6909-4122-a4ff-edd71ce434ed)


