### PR TITLE
feat: slack notification on add feed form

### DIFF
--- a/.github/workflows/web-app-deployer.yml
+++ b/.github/workflows/web-app-deployer.yml
@@ -26,6 +26,10 @@ on:
         description: The google sheet id for the feed submit form
         type: string
         required: false
+      SLACK_WEBHOOK_URL:
+        description: Slack webhook URL for add feed channel
+        type: string
+        required: false
     outputs:
       hosting_url:
         description: "The URL of the deployed web app"
@@ -240,7 +244,9 @@ jobs:
 
       - name: Set Firebase Feed Form Environment
         working-directory: functions/packages/feed-form
-        run: echo "FEED_SUBMIT_GOOGLE_SHEET_ID=${{  inputs.FEED_SUBMIT_GOOGLE_SHEET_ID }}" > .env
+        run: |
+          echo "FEED_SUBMIT_GOOGLE_SHEET_ID=${{  inputs.FEED_SUBMIT_GOOGLE_SHEET_ID }}" > .env
+          echo "SLACK_WEBHOOK_URL=${{  inputs.SLACK_WEBHOOK_URL }}" > .env
 
       - name: Deploy Firebase Functions
         working-directory: functions

--- a/.github/workflows/web-app-deployer.yml
+++ b/.github/workflows/web-app-deployer.yml
@@ -26,8 +26,8 @@ on:
         description: The google sheet id for the feed submit form
         type: string
         required: false
-      SLACK_WEBHOOK_URL:
-        description: Slack webhook URL for add feed channel
+      OP_SLACK_WEBHOOK_URL:
+        description: 1Password Slack webhook URL secret reference for add feed channel
         type: string
         required: false
     outputs:
@@ -141,6 +141,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: 1Password - Load Secrets
+        uses: 1Password/load-secrets-action@v2.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{inputs.OP_SLACK_WEBHOOK_URL}}
+
       - name: Authenticate to Google Cloud DEV
         if: ${{ inputs.FIREBASE_PROJECT == 'dev' }}
         uses: google-github-actions/auth@v2
@@ -246,7 +254,7 @@ jobs:
         working-directory: functions/packages/feed-form
         run: |
           echo "FEED_SUBMIT_GOOGLE_SHEET_ID=${{  inputs.FEED_SUBMIT_GOOGLE_SHEET_ID }}" > .env
-          echo "SLACK_WEBHOOK_URL=${{  inputs.SLACK_WEBHOOK_URL }}" >> .env
+          echo "SLACK_WEBHOOK_URL=${{ env.SLACK_WEBHOOK_URL }}" >> .env
 
       - name: Deploy Firebase Functions
         working-directory: functions

--- a/.github/workflows/web-app-deployer.yml
+++ b/.github/workflows/web-app-deployer.yml
@@ -246,7 +246,7 @@ jobs:
         working-directory: functions/packages/feed-form
         run: |
           echo "FEED_SUBMIT_GOOGLE_SHEET_ID=${{  inputs.FEED_SUBMIT_GOOGLE_SHEET_ID }}" > .env
-          echo "SLACK_WEBHOOK_URL=${{  inputs.SLACK_WEBHOOK_URL }}" > .env
+          echo "SLACK_WEBHOOK_URL=${{  inputs.SLACK_WEBHOOK_URL }}" >> .env
 
       - name: Deploy Firebase Functions
         working-directory: functions

--- a/.github/workflows/web-app-deployer.yml
+++ b/.github/workflows/web-app-deployer.yml
@@ -144,7 +144,7 @@ jobs:
       - name: 1Password - Load Secrets
         uses: 1Password/load-secrets-action@v2.0.0
         with:
-          export-env: false
+          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SLACK_WEBHOOK_URL: ${{inputs.OP_SLACK_WEBHOOK_URL}}

--- a/.github/workflows/web-dev.yml
+++ b/.github/workflows/web-dev.yml
@@ -5,9 +5,21 @@ on:
 
 jobs:
     deploy-web-app:
-        name: Deploy Web App
+      name: Deploy Web App DEV
+      runs-on:
+        labels: ubuntu-latest
+      steps:
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2.0.0
+        with:
+          export-env: true # Export loaded secrets as environment variables
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
+
+      - name: Deploy Web App
         uses: ./.github/workflows/web-app-deployer.yml
         with:
           FIREBASE_PROJECT: dev
           FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
-        secrets: inherit
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/web-dev.yml
+++ b/.github/workflows/web-dev.yml
@@ -5,21 +5,10 @@ on:
 
 jobs:
     deploy-web-app:
-      name: Deploy Web App DEV
-      runs-on:
-        labels: ubuntu-latest
-      steps:
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2.0.0
-        with:
-          export-env: true # Export loaded secrets as environment variables
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
-
-      - name: Deploy Web App
+        name: Deploy Web App
         uses: ./.github/workflows/web-app-deployer.yml
         with:
           FIREBASE_PROJECT: dev
           FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          OP_SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
+        secrets: inherit

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -7,16 +7,28 @@ on:
       - "web-app/**"
       - "functions/**"
       - ".github/workflows/web-*.yml"
-jobs:
+jobs:    
   deploy-web-app:
     name: Deploy Web App
-    uses: ./.github/workflows/web-app-deployer.yml
-    with:
-      FIREBASE_PROJECT: dev
-      PREVIEW_DEPLOYMENT: true
-      FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
-      PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
-    secrets: inherit
+    runs-on:
+        labels: ubuntu-latest
+    steps:
+    - name: Load secrets from 1Password
+      uses: 1password/load-secrets-action@v2.0.0
+      with:
+        export-env: true # Export loaded secrets as environment variables
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
+
+    - name: Deploy Web App
+      uses: ./.github/workflows/web-app-deployer.yml
+      with:
+        FIREBASE_PROJECT: dev
+        PREVIEW_DEPLOYMENT: true
+        FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
+        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
 
   update-pr-comment:
     name: Update PR comments

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -8,30 +8,14 @@ on:
       - "functions/**"
       - ".github/workflows/web-*.yml"
 jobs:
-  load-secrets:
-    name: Load Secrets and Deploy Web App
-    runs-on: ubuntu-latest
-    steps:
-      - name: 1Password - Load Secrets
-        id: op-load-secret
-        uses: 1Password/load-secrets-action@v2.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
-    outputs:  # Pass the secret loaded from this job as an output
-      SLACK_WEBHOOK_URL: ${{ steps.op-load-secret.outputs.SLACK_WEBHOOK_URL }}
 
   deploy-web-app:
-    name: Deploy Web App
-    needs: load-secrets
     uses: ./.github/workflows/web-app-deployer.yml
     with:
       FIREBASE_PROJECT: dev
       PREVIEW_DEPLOYMENT: true
       FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
-      SLACK_WEBHOOK_URL: ${{ needs.load-secrets.outputs.SLACK_WEBHOOK_URL }}
+      OP_SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
       PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
     secrets: inherit
 

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -12,10 +12,7 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Load secrets from 1Password
+    - name: 1Password - Load Secrets
       uses: 1password/load-secrets-action@v2.0.0
       with:
         export-env: true # Export loaded secrets as environment variables

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -12,6 +12,9 @@ jobs:
     name: Deploy Web App
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Load secrets from 1Password
       uses: 1password/load-secrets-action@v2.0.0
       with:

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -8,26 +8,33 @@ on:
       - "functions/**"
       - ".github/workflows/web-*.yml"
 jobs:
-  deploy-web-app:
-    name: Deploy Web App
+  load-secrets:
+    name: Load Secrets and Deploy Web App
     runs-on: ubuntu-latest
     steps:
-    - name: 1Password - Load Secrets
-      uses: 1password/load-secrets-action@v2.0.0
-      with:
-        export-env: true # Export loaded secrets as environment variables
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password" # dev
+      - name: 1Password - Load Secrets
+        id: op-load-secret
+        uses: 1Password/load-secrets-action@v2.0.0
+        with:
+          export-env: true # Export loaded secrets as environment variables
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
+    outputs:  # Pass the secret loaded from this job as an output
+      SLACK_WEBHOOK_URL: ${{ steps.op-load-secret.outputs.SLACK_WEBHOOK_URL }}
 
-    - name: Deploy Web App
-      uses: ./.github/workflows/web-app-deployer.yml
-      with:
-        FIREBASE_PROJECT: dev
-        PREVIEW_DEPLOYMENT: true
-        FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
-        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-        PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
+  deploy-web-app:
+    name: Deploy Web App
+    needs: load-secrets
+    uses: ./.github/workflows/web-app-deployer.yml
+    with:
+      FIREBASE_PROJECT: dev
+      PREVIEW_DEPLOYMENT: true
+      FEED_SUBMIT_GOOGLE_SHEET_ID: "1iXwux9hM4p5Li1EGgwx-8hU3sMDnF15yTflqmGjiZqE"
+      SLACK_WEBHOOK_URL: ${{ needs.load-secrets.outputs.SLACK_WEBHOOK_URL }}
+      PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
+    secrets: inherit
+
 
   update-pr-comment:
     name: Update PR comments

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -19,7 +19,6 @@ jobs:
       PREVIEW_HOST_NAME: "pr-${{ github.event.number }}"
     secrets: inherit
 
-
   update-pr-comment:
     name: Update PR comments
     runs-on: ubuntu-latest

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -16,7 +16,7 @@ jobs:
         id: op-load-secret
         uses: 1Password/load-secrets-action@v2.0.0
         with:
-          export-env: true # Export loaded secrets as environment variables
+          export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"

--- a/.github/workflows/web-pr.yml
+++ b/.github/workflows/web-pr.yml
@@ -7,11 +7,10 @@ on:
       - "web-app/**"
       - "functions/**"
       - ".github/workflows/web-*.yml"
-jobs:    
+jobs:
   deploy-web-app:
     name: Deploy Web App
-    runs-on:
-        labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Load secrets from 1Password
       uses: 1password/load-secrets-action@v2.0.0
@@ -19,7 +18,7 @@ jobs:
         export-env: true # Export loaded secrets as environment variables
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
+        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password" # dev
 
     - name: Deploy Web App
       uses: ./.github/workflows/web-app-deployer.yml

--- a/.github/workflows/web-prod.yml
+++ b/.github/workflows/web-prod.yml
@@ -4,24 +4,12 @@ on:
     workflow_call:
 
 jobs:
-  deploy-web-app:
-    name: Deploy Web App Prod
-    runs-on:
-      labels: ubuntu-latest
-    steps:
-    - name: Load secrets from 1Password
-      uses: 1password/load-secrets-action@v2.0.0
-      with:
-        export-env: true # Export loaded secrets as environment variables
-      env:
-        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Slack webhook URLs/rdpfgrmnbxqaelgi5oky3lryz4/internal-add-feeds"
-
-    - name: Deploy Web App
-      uses: ./.github/workflows/web-app-deployer.yml
-      with:
-        FIREBASE_PROJECT: prod
-        REACT_APP_GOOGLE_ANALYTICS_ID: ${{ vars.PROD_REACT_APP_GOOGLE_ANALYTICS_ID }}
-        FEED_SUBMIT_GOOGLE_SHEET_ID: "10eIUxWVtLmc2EATiwivgXBf4bOMErOnq7GFIoRedXHU"
-        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-
+    deploy-web-app:
+        name: Deploy Web App
+        uses: ./.github/workflows/web-app-deployer.yml
+        with:
+          FIREBASE_PROJECT: prod
+          REACT_APP_GOOGLE_ANALYTICS_ID: ${{ vars.PROD_REACT_APP_GOOGLE_ANALYTICS_ID }}
+          FEED_SUBMIT_GOOGLE_SHEET_ID: "10eIUxWVtLmc2EATiwivgXBf4bOMErOnq7GFIoRedXHU"
+          OP_SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Slack webhook URLs/rdpfgrmnbxqaelgi5oky3lryz4/internal-add-feeds"
+        secrets: inherit

--- a/.github/workflows/web-prod.yml
+++ b/.github/workflows/web-prod.yml
@@ -4,11 +4,24 @@ on:
     workflow_call:
 
 jobs:
-    deploy-web-app:
-        name: Deploy Web App
-        uses: ./.github/workflows/web-app-deployer.yml
-        with:
-          FIREBASE_PROJECT: prod
-          REACT_APP_GOOGLE_ANALYTICS_ID: ${{ vars.PROD_REACT_APP_GOOGLE_ANALYTICS_ID }}
-          FEED_SUBMIT_GOOGLE_SHEET_ID: "10eIUxWVtLmc2EATiwivgXBf4bOMErOnq7GFIoRedXHU"
-        secrets: inherit
+  deploy-web-app:
+    name: Deploy Web App Prod
+    runs-on:
+      labels: ubuntu-latest
+    steps:
+    - name: Load secrets from 1Password
+      uses: 1password/load-secrets-action@v2.0.0
+      with:
+        export-env: true # Export loaded secrets as environment variables
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Slack webhook URLs/rdpfgrmnbxqaelgi5oky3lryz4/internal-add-feeds"
+
+    - name: Deploy Web App
+      uses: ./.github/workflows/web-app-deployer.yml
+      with:
+        FIREBASE_PROJECT: prod
+        REACT_APP_GOOGLE_ANALYTICS_ID: ${{ vars.PROD_REACT_APP_GOOGLE_ANALYTICS_ID }}
+        FEED_SUBMIT_GOOGLE_SHEET_ID: "10eIUxWVtLmc2EATiwivgXBf4bOMErOnq7GFIoRedXHU"
+        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+

--- a/.github/workflows/web-qa.yml
+++ b/.github/workflows/web-qa.yml
@@ -11,4 +11,5 @@ jobs:
           FIREBASE_PROJECT: qa
           REACT_APP_GOOGLE_ANALYTICS_ID: ${{ vars.QA_REACT_APP_GOOGLE_ANALYTICS_ID }}
           FEED_SUBMIT_GOOGLE_SHEET_ID: "1GZeO3kFBFr073bSHuClhTiKt7KEad8vWM01Clo-rOVQ"
+          OP_SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/wm52iemzzm2cwfaoakwaufthuq/password"
         secrets: inherit

--- a/functions/packages/feed-form/package.json
+++ b/functions/packages/feed-form/package.json
@@ -17,6 +17,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "axios": "^1.7.7",
     "firebase": "^10.6.0",
     "firebase-admin": "^11.8.0",
     "firebase-functions": "^4.3.1",

--- a/functions/packages/feed-form/src/impl/feed-form-impl.ts
+++ b/functions/packages/feed-form/src/impl/feed-form-impl.ts
@@ -232,7 +232,11 @@ async function sendSlackWebhook(spreadsheetId: string) {
         },
       ],
     };
-    await axios.post(slackWebhookUrl, slackMessage);
+    await axios.post(slackWebhookUrl, slackMessage).catch((error) => {
+      logger.error("Error sending Slack webhook:", error);
+    });
+  } else {
+    logger.error("Slack webhook URL is not defined");
   }
 }
 /* eslint-enable max-len */

--- a/functions/packages/feed-form/src/impl/feed-form-impl.ts
+++ b/functions/packages/feed-form/src/impl/feed-form-impl.ts
@@ -3,6 +3,7 @@ import {GoogleAuth} from "google-auth-library";
 import * as logger from "firebase-functions/logger";
 import {type FeedSubmissionFormRequestBody} from "./types";
 import {type CallableRequest, HttpsError} from "firebase-functions/v2/https";
+import axios from "axios";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/spreadsheets",
@@ -27,12 +28,13 @@ export const writeToSheet = async (
     const formData: FeedSubmissionFormRequestBody = request.data;
     const rows = buildFeedRows(formData, uid);
     await rawDataSheet.addRows(rows, {insert: true});
-
+    sendSlackWebhook(sheetId);
     return {message: "Data written to the new sheet successfully!"};
   } catch (error) {
     logger.error("Error writing to sheet:", error);
     throw new HttpsError(
-      "internal", "An error occurred while writing to the sheet."
+      "internal",
+      "An error occurred while writing to the sheet."
     );
   }
 };
@@ -83,55 +85,42 @@ export function buildFeedRows(
   const rowsToAdd: RawRowData[] = [];
   if (formData.dataType === "gtfs") {
     rowsToAdd.push(
-      buildFeedRow(
-        formData,
-        {
-          dataTypeName: "GTFS Schedule",
-          downloadUrl: formData.feedLink ?? "",
-          currentUrl: formData.oldFeedLink ?? "",
-          uid,
-        }
-      )
+      buildFeedRow(formData, {
+        dataTypeName: "GTFS Schedule",
+        downloadUrl: formData.feedLink ?? "",
+        currentUrl: formData.oldFeedLink ?? "",
+        uid,
+      })
     );
   } else {
     if (formData.tripUpdates) {
       rowsToAdd.push(
-        buildFeedRow(
-          formData,
-          {
-            dataTypeName: "GTFS Realtime - Trip Updates",
-            downloadUrl: formData.tripUpdates ?? "",
-            currentUrl: formData.oldTripUpdates ?? "",
-            uid,
-          }
-
-        )
+        buildFeedRow(formData, {
+          dataTypeName: "GTFS Realtime - Trip Updates",
+          downloadUrl: formData.tripUpdates ?? "",
+          currentUrl: formData.oldTripUpdates ?? "",
+          uid,
+        })
       );
     }
     if (formData.vehiclePositions) {
       rowsToAdd.push(
-        buildFeedRow(
-          formData,
-          {
-            dataTypeName: "GTFS Realtime - Vehicle Positions",
-            downloadUrl: formData.vehiclePositions ?? "",
-            currentUrl: formData.oldVehiclePositions ?? "",
-            uid,
-          }
-        )
+        buildFeedRow(formData, {
+          dataTypeName: "GTFS Realtime - Vehicle Positions",
+          downloadUrl: formData.vehiclePositions ?? "",
+          currentUrl: formData.oldVehiclePositions ?? "",
+          uid,
+        })
       );
     }
     if (formData.serviceAlerts) {
       rowsToAdd.push(
-        buildFeedRow(
-          formData,
-          {
-            dataTypeName: "GTFS Realtime - Service Alerts",
-            downloadUrl: formData.serviceAlerts ?? "",
-            currentUrl: formData.oldServiceAlerts ?? "",
-            uid,
-          }
-        )
+        buildFeedRow(formData, {
+          dataTypeName: "GTFS Realtime - Service Alerts",
+          downloadUrl: formData.serviceAlerts ?? "",
+          currentUrl: formData.oldServiceAlerts ?? "",
+          uid,
+        })
       );
     }
   }
@@ -157,7 +146,6 @@ export function buildFeedRow(
   formData: FeedSubmissionFormRequestBody,
   formRowParameters: BuildRowParameters
 ): RawRowData {
-  /* eslint-enable max-len */
   const dateNow = new Date();
   return {
     [SheetCol.Status]: "Feed Submitted",
@@ -188,3 +176,63 @@ export function buildFeedRow(
     [SheetCol.LogoPermission]: formData.hasLogoPermission,
   };
 }
+
+/**
+ * Sends a Slack webhook message to the configured Slack webhook URL
+ * @param {string} spreadsheetId The ID of the Google Sheet
+ */
+async function sendSlackWebhook(spreadsheetId: string) {
+  const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+  const sheetUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit`;
+  if (slackWebhookUrl !== undefined && slackWebhookUrl !== "") {
+    const slackMessage = {
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "New Feed Added",
+          },
+        },
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "emoji",
+                  name: "inbox_tray",
+                },
+                {
+                  type: "text",
+                  text: "  A new entry was received in the OpenMobilityData source updates Google Sheet",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "type": "rich_text",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "link",
+                  "url": sheetUrl,
+                  "text": "View Feed",
+                  "style": {
+                    "bold": true,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    await axios.post(slackWebhookUrl, slackMessage);
+  }
+}
+/* eslint-enable max-len */

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -2141,6 +2141,15 @@ axios@^1.4.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"


### PR DESCRIPTION
closes #763 
**Summary:**

When the add feed form successfully adds a feed to the correct google sheet, it will send out a slack notification

**Expected behavior:** 

When in DEV as a feed is added through the form, it should send a notification to the slack channel #slack-test-channel (private channel)

When in PROD the channel will be #internal-add-feeds

**Testing tips:**

Submit a test form with the preview url and you should see a notification in the #slack-test-channel

Please make sure these boxes are checked before submitting your pull request - thanks!

**Notes**
Because we have a lot of control we can add high level information to the slack notification ex: GTFS or GTFS RT, is it from official producer, etc. Data that would be useful at a quick glance

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![image](https://github.com/user-attachments/assets/37883c43-a5fd-45d2-9df9-8d9fb55ba7d3)

