### PR TITLE
feat: big query procedure for comparing validator versions

### DIFF
--- a/bigquery/compare-validation-reports.sql
+++ b/bigquery/compare-validation-reports.sql
@@ -74,15 +74,15 @@ WITH
   )
 
 SELECT
-  feedId,
-  code,
-  COALESCE(severity_previous, severity_current) AS severity,
-  totalNotices_previous AS total_previous,
-  totalNotices_current AS total_current,
-  GREATEST(totalNotices_current - totalNotices_previous, 0) AS new_notices,
-  GREATEST(totalNotices_previous - totalNotices_current, 0) AS dropped_notices
+  feedId AS `Feed ID`,
+  code AS `Code`,
+  COALESCE(severity_previous, severity_current) AS `Severity`,
+  totalNotices_previous AS `Total Previous`,
+  totalNotices_current AS `Total Current`,
+  GREATEST(totalNotices_current - totalNotices_previous, 0) AS `New Notices`,
+  GREATEST(totalNotices_previous - totalNotices_current, 0) AS `Dropped Notices`
 FROM
   merged_reports
 ORDER BY
-  new_notices DESC,
-  dropped_notices DESC;
+  `New Notices` DESC,
+  `Dropped Notices` DESC

--- a/bigquery/compare-validation-reports.sql
+++ b/bigquery/compare-validation-reports.sql
@@ -1,0 +1,93 @@
+CREATE OR REPLACE PROCEDURE `${project_id}.data_analytics.compare_validation_reports`(
+  previous_version STRING,
+  current_version STRING
+)
+BEGIN
+  CREATE TEMP TABLE merged_reports AS
+  WITH
+    validation_report AS (
+      SELECT
+        *,
+        summary.validatorVersion
+      FROM
+        `${project_id}.data_analytics.gtfs_validation_reports_*`
+    ),
+    most_recent_reports AS (
+      SELECT
+        t1.*
+      FROM (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
+        FROM
+          validation_report
+        WHERE
+          summary.validatorVersion = current_version
+      ) AS t1
+      WHERE row_num = 1
+    ),
+    old_version_reports AS (
+      SELECT
+        t1.*
+      FROM (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
+        FROM
+          validation_report
+        WHERE
+          summary.validatorVersion = previous_version
+      ) AS t1
+      WHERE row_num = 1
+    ),
+    most_recent_notices AS (
+      SELECT
+        feedId,
+        datasetId,
+        notice.code,
+        notice.severity,
+        notice.totalNotices
+      FROM
+        most_recent_reports,
+        UNNEST(notices) AS notice
+    ),
+    old_version_notices AS (
+      SELECT
+        feedId,
+        datasetId,
+        notice.code,
+        notice.severity,
+        notice.totalNotices
+      FROM
+        old_version_reports,
+        UNNEST(notices) AS notice
+    )
+  SELECT
+    COALESCE(most_recent_notices.feedId, old_version_notices.feedId) AS feedId,
+    COALESCE(most_recent_notices.code, old_version_notices.code) AS code,
+    old_version_notices.severity AS severity_previous,
+    most_recent_notices.severity AS severity_current,
+    IFNULL(old_version_notices.totalNotices, 0) AS totalNotices_previous,
+    IFNULL(most_recent_notices.totalNotices, 0) AS totalNotices_current
+  FROM
+    old_version_notices
+  FULL OUTER JOIN
+    most_recent_notices
+  ON
+    old_version_notices.feedId = most_recent_notices.feedId
+    AND old_version_notices.code = most_recent_notices.code;
+
+  SELECT
+    feedId AS `Feed ID`,
+    code AS `Code`,
+    COALESCE(severity_previous, severity_current) AS `Severity`,
+    totalNotices_previous AS `Total Previous`,
+    totalNotices_current AS `Total Current`,
+    GREATEST(totalNotices_current - totalNotices_previous, 0) AS `New Notices`,
+    GREATEST(totalNotices_previous - totalNotices_current, 0) AS `Dropped Notices`
+  FROM
+    merged_reports
+  ORDER BY
+    `New Notices` DESC,
+    `Dropped Notices` DESC;
+END;

--- a/bigquery/compare-validation-reports.sql
+++ b/bigquery/compare-validation-reports.sql
@@ -1,93 +1,88 @@
-CREATE OR REPLACE PROCEDURE `${project_id}.data_analytics.compare_validation_reports`(
-  previous_version STRING,
-  current_version STRING
-)
-BEGIN
-  CREATE TEMP TABLE merged_reports AS
-  WITH
-    validation_report AS (
+WITH
+  validation_report AS (
+    SELECT
+      *,
+      summary.validatorVersion
+    FROM
+      `${project_id}.data_analytics.gtfs_validation_reports_*`
+  ),
+  most_recent_reports AS (
+    SELECT
+      t1.*
+    FROM (
       SELECT
         *,
-        summary.validatorVersion
+        ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
       FROM
-        `${project_id}.data_analytics.gtfs_validation_reports_*`
-    ),
-    most_recent_reports AS (
+        validation_report
+      WHERE
+        summary.validatorVersion = current_version
+    ) AS t1
+    WHERE row_num = 1
+  ),
+  old_version_reports AS (
+    SELECT
+      t1.*
+    FROM (
       SELECT
-        t1.*
-      FROM (
-        SELECT
-          *,
-          ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
-        FROM
-          validation_report
-        WHERE
-          summary.validatorVersion = current_version
-      ) AS t1
-      WHERE row_num = 1
-    ),
-    old_version_reports AS (
-      SELECT
-        t1.*
-      FROM (
-        SELECT
-          *,
-          ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
-        FROM
-          validation_report
-        WHERE
-          summary.validatorVersion = previous_version
-      ) AS t1
-      WHERE row_num = 1
-    ),
-    most_recent_notices AS (
-      SELECT
-        feedId,
-        datasetId,
-        notice.code,
-        notice.severity,
-        notice.totalNotices
+        *,
+        ROW_NUMBER() OVER (PARTITION BY feedId ORDER BY validatedAt DESC) AS row_num
       FROM
-        most_recent_reports,
-        UNNEST(notices) AS notice
-    ),
-    old_version_notices AS (
-      SELECT
-        feedId,
-        datasetId,
-        notice.code,
-        notice.severity,
-        notice.totalNotices
-      FROM
-        old_version_reports,
-        UNNEST(notices) AS notice
-    )
-  SELECT
-    COALESCE(most_recent_notices.feedId, old_version_notices.feedId) AS feedId,
-    COALESCE(most_recent_notices.code, old_version_notices.code) AS code,
-    old_version_notices.severity AS severity_previous,
-    most_recent_notices.severity AS severity_current,
-    IFNULL(old_version_notices.totalNotices, 0) AS totalNotices_previous,
-    IFNULL(most_recent_notices.totalNotices, 0) AS totalNotices_current
-  FROM
-    old_version_notices
-  FULL OUTER JOIN
-    most_recent_notices
-  ON
-    old_version_notices.feedId = most_recent_notices.feedId
-    AND old_version_notices.code = most_recent_notices.code;
+        validation_report
+      WHERE
+        summary.validatorVersion = previous_version
+    ) AS t1
+    WHERE row_num = 1
+  ),
+  most_recent_notices AS (
+    SELECT
+      feedId,
+      datasetId,
+      notice.code,
+      notice.severity,
+      notice.totalNotices
+    FROM
+      most_recent_reports,
+      UNNEST(notices) AS notice
+  ),
+  old_version_notices AS (
+    SELECT
+      feedId,
+      datasetId,
+      notice.code,
+      notice.severity,
+      notice.totalNotices
+    FROM
+      old_version_reports,
+      UNNEST(notices) AS notice
+  ),
+  merged_reports AS (
+    SELECT
+      COALESCE(most_recent_notices.feedId, old_version_notices.feedId) AS feedId,
+      COALESCE(most_recent_notices.code, old_version_notices.code) AS code,
+      old_version_notices.severity AS severity_previous,
+      most_recent_notices.severity AS severity_current,
+      IFNULL(old_version_notices.totalNotices, 0) AS totalNotices_previous,
+      IFNULL(most_recent_notices.totalNotices, 0) AS totalNotices_current
+    FROM
+      old_version_notices
+    FULL OUTER JOIN
+      most_recent_notices
+    ON
+      old_version_notices.feedId = most_recent_notices.feedId
+      AND old_version_notices.code = most_recent_notices.code
+  )
 
-  SELECT
-    feedId AS `Feed ID`,
-    code AS `Code`,
-    COALESCE(severity_previous, severity_current) AS `Severity`,
-    totalNotices_previous AS `Total Previous`,
-    totalNotices_current AS `Total Current`,
-    GREATEST(totalNotices_current - totalNotices_previous, 0) AS `New Notices`,
-    GREATEST(totalNotices_previous - totalNotices_current, 0) AS `Dropped Notices`
-  FROM
-    merged_reports
-  ORDER BY
-    `New Notices` DESC,
-    `Dropped Notices` DESC;
-END;
+SELECT
+  feedId,
+  code,
+  COALESCE(severity_previous, severity_current) AS severity,
+  totalNotices_previous AS total_previous,
+  totalNotices_current AS total_current,
+  GREATEST(totalNotices_current - totalNotices_previous, 0) AS new_notices,
+  GREATEST(totalNotices_previous - totalNotices_current, 0) AS dropped_notices
+FROM
+  merged_reports
+ORDER BY
+  new_notices DESC,
+  dropped_notices DESC;

--- a/infra/metrics/main.tf
+++ b/infra/metrics/main.tf
@@ -526,10 +526,10 @@ resource "google_cloudfunctions2_function" "gbfs_preprocessed_analytics" {
 }
 
 # 2.8 Compare validation reports routine
-resource "google_bigquery_routine" "compare_validation_reports" {
+resource "google_bigquery_routine" "compare_validation_reports_function" {
   dataset_id = var.dataset_id
   routine_id = "compare_validation_reports"
-  routine_type = "PROCEDURE"
+  routine_type = "TABLE_VALUED_FUNCTION"
 
   language = "SQL"
   definition_body = templatefile("${path.module}/../../bigquery/compare-validation-reports.sql", {
@@ -543,6 +543,17 @@ resource "google_bigquery_routine" "compare_validation_reports" {
     name = "current_version"
     data_type = jsonencode({ "typeKind" : "STRING" })
   }
+  return_table_type = jsonencode({
+    "columns": [
+      { "name": "feedId", "type": { "typeKind": "STRING" } },
+      { "name": "code", "type": { "typeKind": "STRING" } },
+      { "name": "severity", "type": { "typeKind": "STRING" } },
+      { "name": "total_previous", "type": { "typeKind": "INT64" } },
+      { "name": "total_current", "type": { "typeKind": "INT64" } },
+      { "name": "new_notices", "type": { "typeKind": "INT64" } },
+      { "name": "dropped_notices", "type": { "typeKind": "INT64" } }
+    ]
+  })
 }
 
 

--- a/infra/metrics/main.tf
+++ b/infra/metrics/main.tf
@@ -545,13 +545,13 @@ resource "google_bigquery_routine" "compare_validation_reports_function" {
   }
   return_table_type = jsonencode({
     "columns": [
-      { "name": "feedId", "type": { "typeKind": "STRING" } },
-      { "name": "code", "type": { "typeKind": "STRING" } },
-      { "name": "severity", "type": { "typeKind": "STRING" } },
-      { "name": "total_previous", "type": { "typeKind": "INT64" } },
-      { "name": "total_current", "type": { "typeKind": "INT64" } },
-      { "name": "new_notices", "type": { "typeKind": "INT64" } },
-      { "name": "dropped_notices", "type": { "typeKind": "INT64" } }
+      { "name": "Feed ID", "type": { "typeKind": "STRING" } },
+      { "name": "Code", "type": { "typeKind": "STRING" } },
+      { "name": "Severity", "type": { "typeKind": "STRING" } },
+      { "name": "Total Previous", "type": { "typeKind": "INT64" } },
+      { "name": "Total Current", "type": { "typeKind": "INT64" } },
+      { "name": "New Notices", "type": { "typeKind": "INT64" } },
+      { "name": "Dropped Notices", "type": { "typeKind": "INT64" } }
     ]
   })
 }

--- a/infra/metrics/main.tf
+++ b/infra/metrics/main.tf
@@ -525,6 +525,27 @@ resource "google_cloudfunctions2_function" "gbfs_preprocessed_analytics" {
 
 }
 
+# 2.8 Compare validation reports routine
+resource "google_bigquery_routine" "compare_validation_reports" {
+  dataset_id = var.dataset_id
+  routine_id = "compare_validation_reports"
+  routine_type = "PROCEDURE"
+
+  language = "SQL"
+  definition_body = templatefile("${path.module}/../../bigquery/compare-validation-reports.sql", {
+    project_id = var.project_id
+  })
+  arguments {
+    name = "previous_version"
+    data_type = jsonencode({ "typeKind" : "STRING" })
+  }
+  arguments {
+    name = "current_version"
+    data_type = jsonencode({ "typeKind" : "STRING" })
+  }
+}
+
+
 
 # Grant permissions to the service account
 # 1. BigQuery roles


### PR DESCRIPTION
**Summary:**
This PR introduces a new BigQuery function and updates the infrastructure to enable comparison of validation reports between two specified versions.

### BigQuery Table Value Function
- **[`bigquery/compare-validation-reports.sql`](diffhunk://#diff-12e7d8893d913364357a469a83a00431fc1a7d0ba73935e1b0aaf378d73ac3c5R1-R93)**: Added a new function, `compare_validation_reports`, designed to compare validation reports between a previous and a current version. This procedure generates a merged report highlighting the differences in validation notices, including new and dropped notices.

### Terraform Configuration
- **[`infra/metrics/main.tf`](diffhunk://#diff-c4e8cb223e8b8ff846332198c8ca30c5f829ddafc0e02fbf31ca19e07e064ae2R528-R548)**: Updated Terraform configuration to include a new BigQuery routine resource, `compare_validation_reports`. This change ensures the deployment and management of the new function in the infrastructure.

**Testing Instructions:**
To test the function, execute the following call in the dev environment:
```sql
SELECT * FROM `mobility-feeds-dev.data_analytics.compare_validation_reports`('5.0.1', '5.0.2-SNAPSHOT');
```

[Example of connected sheet with the results](https://docs.google.com/spreadsheets/d/1oNbvORgBNr-3j3yL5fj6cOVmQLXwI-0wDGpflA-_Z14/edit?usp=sharing)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
