### PR TITLE
fix: add feed faq is external link

### DIFF
--- a/web-app/src/app/screens/FeedSubmission/index.tsx
+++ b/web-app/src/app/screens/FeedSubmission/index.tsx
@@ -75,7 +75,11 @@ function Component(): React.ReactElement {
             >
               <Typography>
                 Do you have any questions about how to submit a feed?{' '}
-                <a href='/contribute-faq' style={{ fontWeight: 'bold' }}>
+                <a
+                  href='/contribute-faq'
+                  style={{ fontWeight: 'bold' }}
+                  target='blank'
+                >
                   Read our FAQ
                 </a>
               </Typography>


### PR DESCRIPTION
closes #775 

**Summary:**

On new add feed form, when clicking 'faq' it should open in new tab

**Expected behavior:** 

On new add feed form, when clicking 'faq' it should open in new tab

**Testing tips:**

GO to new add feed form and click the faq at the top. Should open in new tab

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
