### PR TITLE
Feat:feature bypass

### DIFF
--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -6,7 +6,12 @@ jest.mock('firebase/compat/app', () => ({
         settings: { minimumFetchIntervalMillis: 3600000 },
     })),
 }));
-describe.only('doesUserHaveBypass', () => {
+describe('doesUserHaveBypass', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should return false if userEmail is null', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
     expect(doesUserHaveBypass(byPassConfig, null)).toBe(false);
@@ -45,5 +50,12 @@ describe.only('doesUserHaveBypass', () => {
   it('should return false if user is not in list', () => {
     const byPassConfig: ByPassConfig = { regex: ['alex@example.com', 'bill@example.com'] };
     expect(doesUserHaveBypass(byPassConfig, 'cris@example.com')).toBe(false);
+  });
+
+  it('should not break the function if there is an invalid regex', () => {
+    jest.spyOn(console, 'error')
+    const byPassConfig: ByPassConfig = { regex: ['alex@example.org(', 'bill@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'bill@example.com')).toBe(true);
+    expect(console.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -1,0 +1,49 @@
+import { ByPassConfig } from '../interface/RemoteConfig';
+import { doesUserHaveBypass } from './RemoteConfigProvider'; // Adjust the import based on your file structure
+jest.mock('firebase/compat/app', () => ({
+    initializeApp: jest.fn(),
+    remoteConfig: jest.fn(() => ({
+        settings: { minimumFetchIntervalMillis: 3600000 },
+    })),
+}));
+describe.only('doesUserHaveBypass', () => {
+  it('should return false if userEmail is null', () => {
+    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, null)).toBe(false);
+  });
+
+  it('should return false if userEmail is undefined', () => {
+    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, undefined)).toBe(false);
+  });
+
+  it('should return true if userEmail matches one of the regex patterns', () => {
+    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'test@example.com')).toBe(true);
+  });
+
+  it('should return false if userEmail does not match any regex patterns', () => {
+    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'test@otherdomain.com')).toBe(false);
+  });
+
+  it('should return true if userEmail matches multiple regex patterns', () => {
+    const byPassConfig: ByPassConfig = { regex: ['.*@example.com', '.*@another.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'test@another.com')).toBe(true);
+  });
+
+  it('should return false if byPassConfig has an empty regex array', () => {
+    const byPassConfig: ByPassConfig = { regex: [] };
+    expect(doesUserHaveBypass(byPassConfig, 'test@example.com')).toBe(false);
+  });
+
+  it('should return true if user is in list of regex', () => {
+    const byPassConfig: ByPassConfig = { regex: ['alex@example.com', 'bill@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'bIll@example.com')).toBe(true);
+  });
+
+  it('should return false if user is not in list', () => {
+    const byPassConfig: ByPassConfig = { regex: ['alex@example.com', 'bill@example.com'] };
+    expect(doesUserHaveBypass(byPassConfig, 'cris@example.com')).toBe(false);
+  });
+});

--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -1,61 +1,70 @@
-import { ByPassConfig } from '../interface/RemoteConfig';
-import { doesUserHaveBypass } from './RemoteConfigProvider'; // Adjust the import based on your file structure
+import { type ByPassConfig } from '../interface/RemoteConfig';
+import { userHasBypass } from './RemoteConfigProvider'; // Adjust the import based on your file structure
 jest.mock('firebase/compat/app', () => ({
-    initializeApp: jest.fn(),
-    remoteConfig: jest.fn(() => ({
-        settings: { minimumFetchIntervalMillis: 3600000 },
-    })),
+  initializeApp: jest.fn(),
+  remoteConfig: jest.fn(() => ({
+    settings: { minimumFetchIntervalMillis: 3600000 },
+  })),
 }));
-describe('doesUserHaveBypass', () => {
-
+describe('userHasBypass', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should return false if userEmail is null', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, null)).toBe(false);
+    expect(userHasBypass(byPassConfig, null)).toBe(false);
   });
 
   it('should return false if userEmail is undefined', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, undefined)).toBe(false);
+    expect(userHasBypass(byPassConfig, undefined)).toBe(false);
   });
 
   it('should return true if userEmail matches one of the regex patterns', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'test@example.com')).toBe(true);
+    expect(userHasBypass(byPassConfig, 'test@example.com')).toBe(true);
   });
 
   it('should return false if userEmail does not match any regex patterns', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'test@otherdomain.com')).toBe(false);
+    expect(userHasBypass(byPassConfig, 'test@otherdomain.com')).toBe(
+      false,
+    );
   });
 
   it('should return true if userEmail matches multiple regex patterns', () => {
-    const byPassConfig: ByPassConfig = { regex: ['.*@example.com', '.*@another.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'test@another.com')).toBe(true);
+    const byPassConfig: ByPassConfig = {
+      regex: ['.*@example.com', '.*@another.com'],
+    };
+    expect(userHasBypass(byPassConfig, 'test@another.com')).toBe(true);
   });
 
   it('should return false if byPassConfig has an empty regex array', () => {
     const byPassConfig: ByPassConfig = { regex: [] };
-    expect(doesUserHaveBypass(byPassConfig, 'test@example.com')).toBe(false);
+    expect(userHasBypass(byPassConfig, 'test@example.com')).toBe(false);
   });
 
   it('should return true if user is in list of regex', () => {
-    const byPassConfig: ByPassConfig = { regex: ['alex@example.com', 'bill@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'bIll@example.com')).toBe(true);
+    const byPassConfig: ByPassConfig = {
+      regex: ['alex@example.com', 'bill@example.com'],
+    };
+    expect(userHasBypass(byPassConfig, 'bIll@example.com')).toBe(true);
   });
 
   it('should return false if user is not in list', () => {
-    const byPassConfig: ByPassConfig = { regex: ['alex@example.com', 'bill@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'cris@example.com')).toBe(false);
+    const byPassConfig: ByPassConfig = {
+      regex: ['alex@example.com', 'bill@example.com'],
+    };
+    expect(userHasBypass(byPassConfig, 'cris@example.com')).toBe(false);
   });
 
   it('should not break the function if there is an invalid regex', () => {
-    jest.spyOn(console, 'error')
-    const byPassConfig: ByPassConfig = { regex: ['alex@example.org(', 'bill@example.com'] };
-    expect(doesUserHaveBypass(byPassConfig, 'bill@example.com')).toBe(true);
+    jest.spyOn(console, 'error');
+    const byPassConfig: ByPassConfig = {
+      regex: ['alex@example.org(', 'bill@example.com'],
+    };
+    expect(userHasBypass(byPassConfig, 'bill@example.com')).toBe(true);
     expect(console.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -28,9 +28,7 @@ describe('userHasBypass', () => {
 
   it('should return false if userEmail does not match any regex patterns', () => {
     const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
-    expect(userHasBypass(byPassConfig, 'test@otherdomain.com')).toBe(
-      false,
-    );
+    expect(userHasBypass(byPassConfig, 'test@otherdomain.com')).toBe(false);
   });
 
   it('should return true if userEmail matches multiple regex patterns', () => {

--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -1,5 +1,5 @@
-import { type ByPassConfig } from '../interface/RemoteConfig';
-import { userHasBypass } from './RemoteConfigProvider'; // Adjust the import based on your file structure
+import { type BypassConfig } from '../interface/RemoteConfig';
+import { userHasBypass } from './RemoteConfigProvider';
 jest.mock('firebase/compat/app', () => ({
   initializeApp: jest.fn(),
   remoteConfig: jest.fn(() => ({
@@ -12,57 +12,55 @@ describe('userHasBypass', () => {
   });
 
   it('should return false if userEmail is null', () => {
-    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    const byPassConfig: BypassConfig = { regex: ['.*@example.com'] };
     expect(userHasBypass(byPassConfig, null)).toBe(false);
   });
 
   it('should return false if userEmail is undefined', () => {
-    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    const byPassConfig: BypassConfig = { regex: ['.*@example.com'] };
     expect(userHasBypass(byPassConfig, undefined)).toBe(false);
   });
 
   it('should return true if userEmail matches one of the regex patterns', () => {
-    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    const byPassConfig: BypassConfig = { regex: ['.*@example.com'] };
     expect(userHasBypass(byPassConfig, 'test@example.com')).toBe(true);
   });
 
   it('should return false if userEmail does not match any regex patterns', () => {
-    const byPassConfig: ByPassConfig = { regex: ['.*@example.com'] };
+    const byPassConfig: BypassConfig = { regex: ['.*@example.com'] };
     expect(userHasBypass(byPassConfig, 'test@otherdomain.com')).toBe(false);
   });
 
   it('should return true if userEmail matches multiple regex patterns', () => {
-    const byPassConfig: ByPassConfig = {
+    const byPassConfig: BypassConfig = {
       regex: ['.*@example.com', '.*@another.com'],
     };
     expect(userHasBypass(byPassConfig, 'test@another.com')).toBe(true);
   });
 
   it('should return false if byPassConfig has an empty regex array', () => {
-    const byPassConfig: ByPassConfig = { regex: [] };
+    const byPassConfig: BypassConfig = { regex: [] };
     expect(userHasBypass(byPassConfig, 'test@example.com')).toBe(false);
   });
 
   it('should return true if user is in list of regex', () => {
-    const byPassConfig: ByPassConfig = {
+    const byPassConfig: BypassConfig = {
       regex: ['alex@example.com', 'bill@example.com'],
     };
     expect(userHasBypass(byPassConfig, 'bIll@example.com')).toBe(true);
   });
 
   it('should return false if user is not in list', () => {
-    const byPassConfig: ByPassConfig = {
+    const byPassConfig: BypassConfig = {
       regex: ['alex@example.com', 'bill@example.com'],
     };
     expect(userHasBypass(byPassConfig, 'cris@example.com')).toBe(false);
   });
 
   it('should not break the function if there is an invalid regex', () => {
-    jest.spyOn(console, 'error');
-    const byPassConfig: ByPassConfig = {
+    const byPassConfig: BypassConfig = {
       regex: ['alex@example.org(', 'bill@example.com'],
     };
     expect(userHasBypass(byPassConfig, 'bill@example.com')).toBe(true);
-    expect(console.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/web-app/src/app/context/RemoteConfigProvider.spec.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.spec.tsx
@@ -26,6 +26,11 @@ describe('userHasBypass', () => {
     expect(userHasBypass(byPassConfig, 'test@example.com')).toBe(true);
   });
 
+  it('should return true if userEmail matches one of the more complex regex patterns', () => {
+    const byPassConfig: BypassConfig = { regex: ['[^@]+@example.com'] };
+    expect(userHasBypass(byPassConfig, 'TesTtest@example.com')).toBe(true);
+  });
+
   it('should return false if userEmail does not match any regex patterns', () => {
     const byPassConfig: BypassConfig = { regex: ['.*@example.com'] };
     expect(userHasBypass(byPassConfig, 'test@otherdomain.com')).toBe(false);

--- a/web-app/src/app/context/RemoteConfigProvider.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.tsx
@@ -30,8 +30,12 @@ export function doesUserHaveBypass(byPassConfig: ByPassConfig, userEmail: string
     return false;
   }
   byPassConfig.regex.forEach((regex) => {
-    if(userEmail.match(new RegExp(regex, 'i')) !== null) {
-      hasBypass = true;
+    try {
+      if(userEmail.match(new RegExp(regex, 'i')) !== null) {
+        hasBypass = true;
+      }
+    } catch (e) {
+      console.error(`Invalid regex: ${regex}`);
     }
   });
   return hasBypass;

--- a/web-app/src/app/context/RemoteConfigProvider.tsx
+++ b/web-app/src/app/context/RemoteConfigProvider.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { remoteConfig, app } from '../../firebase';
 import {
-  type ByPassConfig,
+  type BypassConfig,
   defaultRemoteConfigValues,
   type RemoteConfigValues,
 } from '../interface/RemoteConfig';
@@ -25,7 +25,7 @@ interface RemoteConfigProviderProps {
 }
 
 export function userHasBypass(
-  byPassConfig: ByPassConfig,
+  byPassConfig: BypassConfig,
   userEmail: string | null | undefined,
 ): boolean {
   let hasBypass = false;
@@ -37,9 +37,7 @@ export function userHasBypass(
       if (userEmail.match(new RegExp(regex, 'i')) !== null) {
         hasBypass = true;
       }
-    } catch (e) {
-      console.error(`Invalid regex: ${regex}`);
-    }
+    } catch (e) {}
   });
   return hasBypass;
 }
@@ -61,7 +59,8 @@ export const RemoteConfigProvider = ({
           const rawValue = remoteConfig.getValue(key);
           const rawValueLower = rawValue.asString().toLowerCase();
           if (rawValueLower === 'true' || rawValueLower === 'false') {
-            const bypassConfig: ByPassConfig = JSON.parse(
+            // Boolean
+            const bypassConfig: BypassConfig = JSON.parse(
               remoteConfig.getValue('featureFlagBypass').asString(),
             );
             const hasBypass = userHasBypass(

--- a/web-app/src/app/interface/RemoteConfig.ts
+++ b/web-app/src/app/interface/RemoteConfig.ts
@@ -2,7 +2,7 @@ import { remoteConfig } from '../../firebase';
 
 type FirebaseDefaultConfig = typeof remoteConfig.defaultConfig;
 
-export interface ByPassConfig {
+export interface BypassConfig {
   regex: string[];
 }
 
@@ -30,7 +30,7 @@ export interface RemoteConfigValues extends FirebaseDefaultConfig {
   featureFlagBypass: string;
 }
 
-const featureByPassDefault: ByPassConfig = {
+const featureByPassDefault: BypassConfig = {
   regex: [],
 };
 

--- a/web-app/src/app/interface/RemoteConfig.ts
+++ b/web-app/src/app/interface/RemoteConfig.ts
@@ -2,6 +2,10 @@ import { remoteConfig } from '../../firebase';
 
 type FirebaseDefaultConfig = typeof remoteConfig.defaultConfig;
 
+export interface ByPassConfig {
+  regex: string[];
+}
+
 export interface RemoteConfigValues extends FirebaseDefaultConfig {
   enableAppleSSO: boolean;
   enableFeedsPage: boolean;
@@ -23,6 +27,11 @@ export interface RemoteConfigValues extends FirebaseDefaultConfig {
   gtfsMetricsBucketEndpoint: string;
   /** GBFS metrics' bucket endpoint */
   gbfsMetricsBucketEndpoint: string;
+  featureFlagBypass: string;
+}
+
+const featureByPassDefault: ByPassConfig = {
+  regex: [],
 }
 
 // Add default values for remote config here
@@ -36,6 +45,7 @@ export const defaultRemoteConfigValues: RemoteConfigValues = {
     'https://storage.googleapis.com/mobilitydata-gtfs-analytics-dev',
   gbfsMetricsBucketEndpoint:
     'https://storage.googleapis.com/mobilitydata-gbfs-analytics-dev',
+  featureFlagBypass: JSON.stringify(featureByPassDefault),
 };
 
 remoteConfig.defaultConfig = defaultRemoteConfigValues;

--- a/web-app/src/app/interface/RemoteConfig.ts
+++ b/web-app/src/app/interface/RemoteConfig.ts
@@ -32,7 +32,7 @@ export interface RemoteConfigValues extends FirebaseDefaultConfig {
 
 const featureByPassDefault: ByPassConfig = {
   regex: [],
-}
+};
 
 // Add default values for remote config here
 export const defaultRemoteConfigValues: RemoteConfigValues = {


### PR DESCRIPTION
closes #767 
**Summary:**

In an effort to test in PROD without testing in PROD, this PR introduces a remote config to allow certain emails to access all the feature flags even if they are diabled

**Expected behavior:** 

In the remote config, the values of `bypassFeatureFlag` you can put your email (or a regex) and with that email you will be able to access all feature flags (boolean) regardless of what their value is set as

![image](https://github.com/user-attachments/assets/0513fb0c-87a7-40f4-8511-8c6dd2e2f26f)

**Testing tips:**

Add your email to the regex value in the remote config for DEV, sign in with that email, and in the header you should see the translation selection in the top right. (that feature is currently false on all environments)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

When the email signed in is included in the featureflagBypass
![image](https://github.com/user-attachments/assets/36e71bcf-85bb-4a18-bb91-f352cfcd0b5d)

when it's not
![Screenshot 2024-10-23 at 13 05 29](https://github.com/user-attachments/assets/124eaa71-4de3-4b84-8b09-6217336b3520)

