### PR TITLE
feat: brand consolodation

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -47,7 +47,6 @@
     "recharts": "^2.12.7",
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.2.3",
-    "typeface-muli": "^1.1.13",
     "yup": "^1.3.2"
   },
   "peerDependencies": {

--- a/web-app/public/index.html
+++ b/web-app/public/index.html
@@ -24,6 +24,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
     <title>Mobility Database</title>
   </head>
   <body>

--- a/web-app/src/app/App.tsx
+++ b/web-app/src/app/App.tsx
@@ -15,7 +15,6 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
 function App(): React.ReactElement {
-  require('typeface-muli'); // Load font
   const dispatch = useDispatch();
   const [isAppReady, setIsAppReady] = useState(false);
 

--- a/web-app/src/app/Theme.ts
+++ b/web-app/src/app/Theme.ts
@@ -16,13 +16,23 @@ declare module '@mui/material/styles/createMixins' {
   }
 }
 
+export const fontFamily = {
+  primary: '"Mulish"',
+  secondary: '"IBM Plex Mono"',
+};
+
 const palette = {
   primary: {
     main: '#3959fa',
+    dark: '#002eea',
+    light: '#989ffc',
     contrastText: '#f9faff',
   },
   secondary: {
-    main: '#96a1ff',
+    main: '#96a1ff', // original mobility data purple
+    dark: '#4a5fe8',
+    light: '#e7e8ff',
+    contrastText: '#f9faff',
   },
   background: {
     default: '#ffffff',
@@ -47,7 +57,7 @@ export const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: '"Muli"',
+    fontFamily: fontFamily.primary,
   },
   components: {
     MuiFormLabel: {
@@ -79,6 +89,21 @@ export const theme = createTheme({
         root: {
           textTransform: 'none',
           boxShadow: 'none',
+          fontFamily: fontFamily.secondary,
+          boxSizing: 'border-box',
+          '&.MuiButton-contained': {
+            border: '2px solid transparent',
+          },
+          '&.MuiButton-containedPrimary:hover': {
+            boxShadow: 'none',
+            backgroundColor: 'transparent',
+            border: `2px solid ${palette.primary.main}`,
+            color: palette.primary.main,
+          },
+          '&.MuiButton-outlinedPrimary:hover': {
+            backgroundColor: palette.primary.main,
+            color: palette.primary.contrastText,
+          },
         },
       },
     },

--- a/web-app/src/app/Theme.ts
+++ b/web-app/src/app/Theme.ts
@@ -36,7 +36,7 @@ const palette = {
   },
   background: {
     default: '#ffffff',
-    paper: '#f7f7f7',
+    paper: '#F8F5F5',
   },
   text: {
     primary: '#474747',

--- a/web-app/src/app/components/Footer.tsx
+++ b/web-app/src/app/components/Footer.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSlack } from '@fortawesome/free-brands-svg-icons';
 import { GitHub, LinkedIn, OpenInNew } from '@mui/icons-material';
 import { MOBILITY_DATA_LINKS } from '../constants/Navigation';
+import { fontFamily } from '../Theme';
 
 const Footer: React.FC = () => {
   const navigateTo = (link: string): void => {
@@ -13,7 +14,7 @@ const Footer: React.FC = () => {
   };
 
   return (
-    <footer className='footer'>
+    <footer className='footer' style={{ fontFamily: fontFamily.secondary }}>
       <a
         href={'https://share.mobilitydata.org/mobility-database-feedback'}
         target={'_blank'}
@@ -21,7 +22,11 @@ const Footer: React.FC = () => {
         className={'btn-link'}
       >
         <Button
-          sx={{ textTransform: 'none', mb: 2 }}
+          sx={{
+            textTransform: 'none',
+            mb: 2,
+            fontFamily: fontFamily.secondary,
+          }}
           variant={'outlined'}
           endIcon={<OpenInNew />}
         >

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   MenuItem,
   Select,
+  type SxProps,
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -43,7 +44,7 @@ import { useRemoteConfig } from '../context/RemoteConfigProvider';
 import i18n from '../../i18n';
 import { NestedMenuItem } from 'mui-nested-menu';
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
-import { theme } from '../Theme';
+import { fontFamily, theme } from '../Theme';
 
 const drawerWidth = 240;
 const websiteTile = 'Mobility Database';
@@ -71,7 +72,7 @@ const DrawerContent: React.FC<{
         <Avatar src='/assets/MOBILTYDATA_logo_purple_M.png'></Avatar>
         <Typography
           variant='h6'
-          sx={{ my: 2, cursor: 'pointer' }}
+          sx={{ my: 2, cursor: 'pointer', color: theme.palette.primary.main }}
           data-testid='websiteTile'
         >
           {websiteTile}
@@ -94,7 +95,11 @@ const DrawerContent: React.FC<{
                 pl: '16px',
               }}
             >
-              <ListItemText>
+              <ListItemText
+                sx={{
+                  '.MuiTypography-root': { fontFamily: fontFamily.secondary },
+                }}
+              >
                 {item.title}{' '}
                 {item.external === true ? (
                   <OpenInNew sx={{ verticalAlign: 'middle' }} />
@@ -113,7 +118,10 @@ const DrawerContent: React.FC<{
             <TreeItem
               nodeId='1'
               label='GTFS Metrics'
-              sx={{ color: theme.palette.primary.main }}
+              sx={{
+                color: theme.palette.primary.main,
+                '.MuiTreeItem-label': { fontFamily: fontFamily.secondary },
+              }}
             >
               <TreeItem
                 nodeId='2'
@@ -182,7 +190,10 @@ const DrawerContent: React.FC<{
             <TreeItem
               nodeId='1'
               label='Account'
-              sx={{ color: theme.palette.primary.main }}
+              sx={{
+                color: theme.palette.primary.main,
+                '.MuiTreeItem-label': { fontFamily: fontFamily.secondary },
+              }}
               data-cy='accountHeader'
             >
               <TreeItem
@@ -290,6 +301,38 @@ export default function DrawerAppBar(): React.ReactElement {
 
   const metricsOptionsEnabled =
     config.enableMetrics || userEmail?.endsWith('mobilitydata.org') === true;
+  const AnimatedButtonStyling: SxProps = {
+    minWidth: 'fit-content',
+    px: 0,
+    mx: {
+      md: 1,
+      lg: 2,
+    },
+    fontFamily: fontFamily.secondary,
+    '&:hover': {
+      backgroundColor: 'transparent',
+      '&::after': {
+        transform: 'scaleX(1)',
+        left: 0,
+        right: 0,
+        transformOrigin: 'left',
+      },
+    },
+    '&::after': {
+      content: '""',
+      height: '2px',
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: theme.palette.primary.main,
+      opacity: 0.7,
+      transition: 'transform 0.9s cubic-bezier(0.19, 1, 0.22, 1)',
+      transform: 'scaleX(0)',
+      transformOrigin: 'right',
+      pointerEvents: 'none',
+    },
+  };
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -297,7 +340,11 @@ export default function DrawerAppBar(): React.ReactElement {
         component='nav'
         color='inherit'
         elevation={0}
-        sx={{ background: 'white' }}
+        sx={{
+          background: 'white',
+          fontFamily: fontFamily.secondary,
+          borderBottom: '1px solid rgba(0,0,0,0.2)',
+        }}
       >
         <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -325,6 +372,7 @@ export default function DrawerAppBar(): React.ReactElement {
                 component='div'
                 className='website-title'
                 sx={{
+                  ml: 1,
                   display: { xs: 'none', md: 'block' },
                 }}
               >
@@ -336,9 +384,9 @@ export default function DrawerAppBar(): React.ReactElement {
           <Box sx={{ display: { xs: 'none', md: 'block' } }}>
             {navigationItems.map((item) => (
               <Button
+                sx={AnimatedButtonStyling}
                 href={item.external === true ? item.target : '/' + item.target}
                 key={item.title}
-                sx={{ color: item.color, minWidth: 'fit-content', mx: 1 }}
                 target={item.external === true ? '_blank' : '_self'}
                 rel={item.external === true ? 'noopener noreferrer' : ''}
                 variant={'text'}
@@ -355,7 +403,7 @@ export default function DrawerAppBar(): React.ReactElement {
                   aria-haspopup='true'
                   endIcon={<ArrowDropDownIcon />}
                   onClick={handleMenuOpen}
-                  sx={{ color: 'black' }}
+                  sx={{ ...AnimatedButtonStyling, color: 'black' }}
                   id='analytics-button-menu'
                 >
                   Metrics
@@ -434,6 +482,7 @@ export default function DrawerAppBar(): React.ReactElement {
                   onClick={handleMenuOpen}
                   endIcon={<ArrowDropDownIcon />}
                   id='account-button-menu'
+                  sx={AnimatedButtonStyling}
                 >
                   Account
                 </Button>
@@ -464,7 +513,12 @@ export default function DrawerAppBar(): React.ReactElement {
                 </Menu>
               </>
             ) : (
-              <Button href={SIGN_IN_TARGET}>Login</Button>
+              <Button
+                sx={{ fontFamily: fontFamily.secondary }}
+                href={SIGN_IN_TARGET}
+              >
+                Login
+              </Button>
             )}
             {/* Testing language tool */}
             {config.enableLanguageToggle && currentLanguage !== undefined && (

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -30,7 +30,7 @@ import {
   buildNavigationItems,
 } from '../constants/Navigation';
 import type NavigationItem from '../interface/Navigation';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { selectIsAuthenticated, selectUserEmail } from '../store/selectors';
 import LogoutConfirmModal from './LogoutConfirmModal';
@@ -240,8 +240,10 @@ const DrawerContent: React.FC<{
 };
 
 export default function DrawerAppBar(): React.ReactElement {
+  const location = useLocation();
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [openDialog, setOpenDialog] = React.useState(false);
+  const [activeTab, setActiveTab] = React.useState('');
   const [navigationItems, setNavigationItems] = React.useState<
     NavigationItem[]
   >([]);
@@ -253,6 +255,10 @@ export default function DrawerAppBar(): React.ReactElement {
   i18n.on('languageChanged', (lang) => {
     setCurrentLanguage(i18n.language);
   });
+
+  React.useEffect(() => {
+    setActiveTab(location.pathname);
+  }, [location.pathname]);
 
   React.useEffect(() => {
     setNavigationItems(buildNavigationItems(config));
@@ -309,13 +315,18 @@ export default function DrawerAppBar(): React.ReactElement {
       lg: 2,
     },
     fontFamily: fontFamily.secondary,
-    '&:hover': {
+    '&:hover, &.active': {
       backgroundColor: 'transparent',
       '&::after': {
         transform: 'scaleX(1)',
         left: 0,
         right: 0,
         transformOrigin: 'left',
+      },
+    },
+    '&.active.short': {
+      '&::after': {
+        right: '20px',
       },
     },
     '&::after': {
@@ -391,6 +402,7 @@ export default function DrawerAppBar(): React.ReactElement {
                 rel={item.external === true ? 'noopener noreferrer' : ''}
                 variant={'text'}
                 endIcon={item.external === true ? <OpenInNew /> : null}
+                className={activeTab.includes(item.target) ? 'active' : ''}
               >
                 {item.title}
               </Button>
@@ -405,6 +417,9 @@ export default function DrawerAppBar(): React.ReactElement {
                   onClick={handleMenuOpen}
                   sx={{ ...AnimatedButtonStyling, color: 'black' }}
                   id='analytics-button-menu'
+                  className={
+                    activeTab.includes('metrics') ? 'active short' : ''
+                  }
                 >
                   Metrics
                 </Button>
@@ -483,6 +498,7 @@ export default function DrawerAppBar(): React.ReactElement {
                   endIcon={<ArrowDropDownIcon />}
                   id='account-button-menu'
                   sx={AnimatedButtonStyling}
+                  className={activeTab === '/account' ? 'active short' : ''}
                 >
                   Account
                 </Button>

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -346,7 +346,13 @@ export default function DrawerAppBar(): React.ReactElement {
   };
 
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        height: '64px',
+        mb: { xs: 2, md: 4 },
+      }}
+    >
       <AppBar
         component='nav'
         color='inherit'

--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -395,14 +395,19 @@ export default function DrawerAppBar(): React.ReactElement {
           <Box sx={{ display: { xs: 'none', md: 'block' } }}>
             {navigationItems.map((item) => (
               <Button
-                sx={AnimatedButtonStyling}
+                sx={{
+                  ...AnimatedButtonStyling,
+                  color: theme.palette.text.primary,
+                }}
                 href={item.external === true ? item.target : '/' + item.target}
                 key={item.title}
                 target={item.external === true ? '_blank' : '_self'}
                 rel={item.external === true ? 'noopener noreferrer' : ''}
                 variant={'text'}
                 endIcon={item.external === true ? <OpenInNew /> : null}
-                className={activeTab.includes(item.target) ? 'active' : ''}
+                className={
+                  activeTab.includes('/' + item.target) ? 'active' : ''
+                }
               >
                 {item.title}
               </Button>
@@ -415,7 +420,10 @@ export default function DrawerAppBar(): React.ReactElement {
                   aria-haspopup='true'
                   endIcon={<ArrowDropDownIcon />}
                   onClick={handleMenuOpen}
-                  sx={{ ...AnimatedButtonStyling, color: 'black' }}
+                  sx={{
+                    ...AnimatedButtonStyling,
+                    color: theme.palette.text.primary,
+                  }}
                   id='analytics-button-menu'
                   className={
                     activeTab.includes('metrics') ? 'active short' : ''

--- a/web-app/src/app/screens/About.tsx
+++ b/web-app/src/app/screens/About.tsx
@@ -5,6 +5,7 @@ import Container from '@mui/material/Container';
 import '../styles/SignUp.css';
 import { Button, Typography } from '@mui/material';
 import { OpenInNew } from '@mui/icons-material';
+import { theme } from '../Theme';
 
 export default function About(): React.ReactElement {
   return (
@@ -12,7 +13,6 @@ export default function About(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}
@@ -22,7 +22,7 @@ export default function About(): React.ReactElement {
         </Typography>
         <Box
           sx={{
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             mt: 2,
             p: 2,
             borderRadius: '6px 6px 0px 0px',

--- a/web-app/src/app/screens/Account.tsx
+++ b/web-app/src/app/screens/Account.tsx
@@ -259,7 +259,6 @@ export default function APIAccount(): React.ReactElement {
       component={'main'}
       maxWidth={false}
       sx={{
-        mt: 12,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',

--- a/web-app/src/app/screens/Analytics/GBFSFeedAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GBFSFeedAnalytics/index.tsx
@@ -276,8 +276,8 @@ export default function GBFSFeedAnalytics(): React.ReactElement {
   });
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
         GBFS Feeds Metrics
       </Typography>
       {error != null && (

--- a/web-app/src/app/screens/Analytics/GBFSNoticeAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GBFSNoticeAnalytics/index.tsx
@@ -212,9 +212,9 @@ export default function GBFSNoticeAnalytics(): React.ReactElement {
   }
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
-        GBFS Notices Metrics{' '}
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
+        GBFS Notices Metrics
       </Typography>
       {error != null && (
         <Alert severity='error'>

--- a/web-app/src/app/screens/Analytics/GBFSVersionAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GBFSVersionAnalytics/index.tsx
@@ -227,8 +227,8 @@ export default function GBFSVersionAnalytics(): React.ReactElement {
   });
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
         GBFS Versions Metrics{' '}
       </Typography>
       {error != null && (

--- a/web-app/src/app/screens/Analytics/GTFSFeatureAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GTFSFeatureAnalytics/index.tsx
@@ -260,8 +260,8 @@ export default function GTFSFeatureAnalytics(): React.ReactElement {
   });
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
         GTFS Features Metrics{' '}
       </Typography>
       {error != null && (

--- a/web-app/src/app/screens/Analytics/GTFSFeedAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GTFSFeedAnalytics/index.tsx
@@ -305,8 +305,8 @@ export default function GTFSFeedAnalytics(): React.ReactElement {
   });
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
         GTFS Feeds Metrics{' '}
       </Typography>
       {error != null && (

--- a/web-app/src/app/screens/Analytics/GTFSNoticeAnalytics/index.tsx
+++ b/web-app/src/app/screens/Analytics/GTFSNoticeAnalytics/index.tsx
@@ -266,8 +266,8 @@ export default function GTFSNoticeAnalytics(): React.ReactElement {
   });
 
   return (
-    <Box sx={{ m: 10 }}>
-      <Typography variant='h5' color='primary' sx={{ fontWeight: 700 }}>
+    <Box sx={{ mx: 6 }}>
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700, mb: 2 }}>
         GTFS Notices Metrics{' '}
       </Typography>
       {error != null && (

--- a/web-app/src/app/screens/ChangePassword.tsx
+++ b/web-app/src/app/screens/ChangePassword.tsx
@@ -91,7 +91,6 @@ export default function ChangePassword(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/web-app/src/app/screens/CompleteRegistration.tsx
+++ b/web-app/src/app/screens/CompleteRegistration.tsx
@@ -109,7 +109,6 @@ export default function CompleteRegistration(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/web-app/src/app/screens/ContactInformation.tsx
+++ b/web-app/src/app/screens/ContactInformation.tsx
@@ -38,7 +38,7 @@ export default function ContactInformation(): React.ReactElement {
   return (
     <Container
       component='main'
-      sx={{ mt: 12, display: 'flex', flexDirection: 'column' }}
+      sx={{ display: 'flex', flexDirection: 'column' }}
     >
       <CssBaseline />
       <Typography

--- a/web-app/src/app/screens/Contribute.tsx
+++ b/web-app/src/app/screens/Contribute.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import '../styles/SignUp.css';
 import { Typography } from '@mui/material';
+import { theme } from '../Theme';
 
 export default function Contribute(): React.ReactElement {
   return (
@@ -11,11 +12,9 @@ export default function Contribute(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
           width: '100vw',
-          m: 10,
         }}
       >
         <Typography variant='h4' color='primary' sx={{ fontWeight: 700 }}>
@@ -23,7 +22,7 @@ export default function Contribute(): React.ReactElement {
         </Typography>
         <Box
           sx={{
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             mt: 2,
             p: 2,
             borderRadius: '6px 6px 0px 0px',

--- a/web-app/src/app/screens/FAQ.tsx
+++ b/web-app/src/app/screens/FAQ.tsx
@@ -6,6 +6,7 @@ import '../styles/SignUp.css';
 import '../styles/FAQ.css';
 import { Typography } from '@mui/material';
 import { WEB_VALIDATOR_LINK } from '../constants/Navigation';
+import { theme } from '../Theme';
 
 export default function FAQ(): React.ReactElement {
   return (
@@ -13,7 +14,6 @@ export default function FAQ(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}
@@ -23,7 +23,7 @@ export default function FAQ(): React.ReactElement {
         </Typography>
         <Box
           sx={{
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             mt: 2,
             p: 2,
             borderRadius: '6px 6px 0px 0px',

--- a/web-app/src/app/screens/Feed/AssociatedFeeds.tsx
+++ b/web-app/src/app/screens/Feed/AssociatedFeeds.tsx
@@ -14,6 +14,7 @@ import {
   type AllFeedType,
   type GTFSRTFeedType,
 } from '../../services/feeds/utils';
+import { theme } from '../../Theme';
 
 export interface AssociatedFeedsProps {
   feeds: AllFeedType[] | undefined;
@@ -122,7 +123,7 @@ export default function AssociatedGTFSRTFeeds({
       <ContentBox
         width={{ xs: '100%' }}
         title={'Related Schedule Feeds'}
-        outlineColor={colors.indigo[500]}
+        outlineColor={theme.palette.primary.dark}
         margin={'0 0 8px'}
         padding={2}
       >
@@ -143,7 +144,7 @@ export default function AssociatedGTFSRTFeeds({
       <ContentBox
         width={{ xs: '100%' }}
         title={'Related Realtime Feeds'}
-        outlineColor={colors.indigo[500]}
+        outlineColor={theme.palette.primary.dark}
         padding={2}
       >
         {gtfsRtFeeds === undefined && <Typography>Loading...</Typography>}

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -7,7 +7,6 @@ import {
   Grid,
   type SxProps,
   Typography,
-  colors,
   Snackbar,
   styled,
   IconButton,
@@ -80,7 +79,7 @@ export default function FeedSummary({
     <ContentBox
       width={width}
       title={'Feed Summary'}
-      outlineColor={colors.indigo[500]}
+      outlineColor={theme.palette.primary.dark}
       padding={2}
     >
       <Box sx={boxElementStyle}>

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -10,7 +10,6 @@ import {
   TableContainer,
   TableRow,
   Typography,
-  colors,
 } from '@mui/material';
 import {
   DownloadOutlined,
@@ -21,6 +20,7 @@ import {
 import { type paths } from '../../services/feeds/types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { WEB_VALIDATOR_LINK } from '../../constants/Navigation';
+import { theme } from '../../Theme';
 
 export interface PreviousDatasetsProps {
   datasets:
@@ -54,7 +54,7 @@ export default function PreviousDatasets({
       <ContentBox
         width={{ xs: '100%' }}
         title={''}
-        outlineColor={colors.indigo[500]}
+        outlineColor={theme.palette.primary.dark}
         padding={{ xs: 0, sm: 1 }}
       >
         <TableContainer>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -117,20 +117,16 @@ const wrapComponent = (
       maxWidth='xl'
     >
       <CssBaseline />
-      <Box
-        sx={{ mt: 12, display: 'flex', flexDirection: 'column' }}
-        margin={{ xs: '40px 0px', md: '80px 0px' }}
-      >
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <Box
           sx={{
             width: '100%',
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             borderRadius: '6px 0px 0px 6px',
             p: 3,
             color: 'black',
             fontSize: '18px',
             fontWeight: 700,
-            mt: 4,
           }}
         >
           {feedLoadingStatus === 'error' && <>{t('errorLoadingFeed')}</>}

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -9,7 +9,6 @@ import {
   Typography,
   Button,
   Grid,
-  colors,
 } from '@mui/material';
 import { ChevronLeft } from '@mui/icons-material';
 import '../../styles/SignUp.css';
@@ -49,6 +48,7 @@ import {
 } from '../../services/feeds/utils';
 import { Trans, useTranslation } from 'react-i18next';
 import { type TFunction } from 'i18next';
+import { theme } from '../../Theme';
 
 export function formatProvidersSorted(provider: string): string[] {
   const providers = provider.split(',').filter((n) => n);
@@ -82,7 +82,7 @@ export function getFeedTitleElement(
   return (
     <Typography
       sx={{
-        color: colors.blue.A700,
+        color: theme.palette.primary.main,
         fontWeight: 'bold',
         fontSize: { xs: 24, sm: 36 },
         lineHeight: 'normal',
@@ -119,7 +119,7 @@ const wrapComponent = (
       <CssBaseline />
       <Box
         sx={{ mt: 12, display: 'flex', flexDirection: 'column' }}
-        margin={{ xs: '20px 0px' }}
+        margin={{ xs: '40px 0px', md: '80px 0px' }}
       >
         <Box
           sx={{
@@ -378,7 +378,7 @@ export default function Feed(): React.ReactElement {
               <ContentBox
                 title={t('boundingBoxTitle')}
                 width={{ xs: '100%', md: '42%' }}
-                outlineColor={colors.blue[900]}
+                outlineColor={theme.palette.primary.dark}
                 padding={2}
               >
                 {boundingBox === undefined && (

--- a/web-app/src/app/screens/FeedSubmission/Form/index.tsx
+++ b/web-app/src/app/screens/FeedSubmission/Form/index.tsx
@@ -195,7 +195,6 @@ export default function FeedSubmissionForm(): React.ReactElement {
           display: 'flex',
           justifyContent: 'center',
           flexWrap: 'wrap',
-          mt: 3,
         }}
       >
         <CircularProgress />

--- a/web-app/src/app/screens/FeedSubmission/index.tsx
+++ b/web-app/src/app/screens/FeedSubmission/index.tsx
@@ -31,9 +31,7 @@ function Component(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           mx: 'auto',
-          maxWidth: '85%',
         }}
       >
         {!isAuthenticated && (

--- a/web-app/src/app/screens/FeedSubmission/index.tsx
+++ b/web-app/src/app/screens/FeedSubmission/index.tsx
@@ -16,6 +16,7 @@ import Contribute from '../Contribute';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import FeedSubmissionForm from './Form';
+import { theme } from '../../Theme';
 
 function Component(): React.ReactElement {
   const { t } = useTranslation('feeds');
@@ -96,7 +97,7 @@ function Component(): React.ReactElement {
               <Typography
                 variant='h4'
                 sx={{
-                  color: colors.blue.A700,
+                  color: theme.palette.primary.main,
                   fontWeight: 'bold',
                   my: 3,
                   ml: 0,

--- a/web-app/src/app/screens/FeedSubmissionFAQ.tsx
+++ b/web-app/src/app/screens/FeedSubmissionFAQ.tsx
@@ -5,12 +5,12 @@ import {
   AccordionSummary,
   type SxProps,
   Typography,
-  colors,
   Box,
   Container,
   CssBaseline,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { theme } from '../Theme';
 
 const accordionStyle: SxProps = {
   boxShadow: 'none',
@@ -39,7 +39,7 @@ export default function FeedSubmissionFAQ(): React.ReactElement {
       >
         <Typography
           sx={{
-            color: colors.blue.A700,
+            color: theme.palette.primary.main,
             fontWeight: 'bold',
             fontSize: { xs: 18, sm: 24 },
             mb: 2,

--- a/web-app/src/app/screens/FeedSubmissionFAQ.tsx
+++ b/web-app/src/app/screens/FeedSubmissionFAQ.tsx
@@ -24,29 +24,17 @@ export default function FeedSubmissionFAQ(): React.ReactElement {
   return (
     <Container component='main' sx={{ my: 0, mx: 'auto' }}>
       <CssBaseline />
+      <Typography variant='h4' color='primary' sx={{ fontWeight: 700 }}>
+        Frequently Asked Questions about Adding Feeds
+      </Typography>
       <Box
         sx={{
-          width: '100%',
-          background: '#F8F5F5',
-          borderRadius: '6px 0px 0px 6px',
-          p: 5,
-          color: 'black',
-          fontSize: '18px',
-          fontWeight: 700,
-          mr: 0,
-          mt: 8,
+          background: theme.palette.background.paper,
+          mt: 2,
+          p: 2,
+          borderRadius: '6px 6px 0px 0px',
         }}
       >
-        <Typography
-          sx={{
-            color: theme.palette.primary.main,
-            fontWeight: 'bold',
-            fontSize: { xs: 18, sm: 24 },
-            mb: 2,
-          }}
-        >
-          Frequently Asked Questions about Adding Feeds
-        </Typography>
         <Accordion sx={accordionStyle}>
           <AccordionSummary
             aria-controls='panel1-content'

--- a/web-app/src/app/screens/FeedSubmitted.tsx
+++ b/web-app/src/app/screens/FeedSubmitted.tsx
@@ -1,4 +1,5 @@
-import { Typography, Box, colors, Container, CssBaseline } from '@mui/material';
+import { Typography, Box, Container, CssBaseline } from '@mui/material';
+import { theme } from '../Theme';
 
 export default function FeedSubmitted(): React.ReactElement {
   return (
@@ -11,7 +12,7 @@ export default function FeedSubmitted(): React.ReactElement {
           mt: 10,
           mb: 4,
           mx: 2,
-          color: colors.blue.A700,
+          color: theme.palette.primary.main,
           fontWeight: 'bold',
         }}
       >

--- a/web-app/src/app/screens/Feeds/SearchTable.tsx
+++ b/web-app/src/app/screens/Feeds/SearchTable.tsx
@@ -10,7 +10,6 @@ import {
   TableHead,
   TableRow,
   Typography,
-  colors,
   styled,
 } from '@mui/material';
 import {
@@ -26,6 +25,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import GtfsRtEntities from './GtfsRtEntities';
 import CloseIcon from '@mui/icons-material/Close';
+import { theme } from '../../Theme';
 
 export interface SearchTableProps {
   feedsData: AllFeedsType | undefined;
@@ -102,7 +102,7 @@ export default function SearchTable({
             fontStyle: 'italic',
             fontSize: '14px',
             fontWeight: 'bold',
-            color: colors.blue[900],
+            color: theme.palette.primary.dark,
           }}
           onClick={(event) => {
             event.stopPropagation();

--- a/web-app/src/app/screens/Feeds/SearchTable.tsx
+++ b/web-app/src/app/screens/Feeds/SearchTable.tsx
@@ -192,7 +192,7 @@ export default function SearchTable({
                 borderBottom: '1px solid black',
               },
               '&:hover': {
-                backgroundColor: '#F8F5F5',
+                backgroundColor: theme.palette.background.paper,
                 cursor: 'pointer',
               },
             }}

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TextField,
   Typography,
-  colors,
 } from '@mui/material';
 import { Search } from '@mui/icons-material';
 import '../../styles/SignUp.css';
@@ -30,6 +29,7 @@ import {
 import { useSearchParams } from 'react-router-dom';
 import SearchTable from './SearchTable';
 import { Trans, useTranslation } from 'react-i18next';
+import { theme } from '../../Theme';
 
 const getDataTypeParamFromSelectedFeedTypes = (
   selectedFeedTypes: Record<string, boolean>,
@@ -167,7 +167,7 @@ export default function Feed(): React.ReactElement {
       >
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <Typography variant='h4' color='primary'>
+            <Typography variant='h4' color='primary' sx={{ fontWeight: 700 }}>
               {t('feeds')}
             </Typography>
             <Typography variant='subtitle1'>{t('searchFor')}</Typography>
@@ -354,7 +354,7 @@ export default function Feed(): React.ReactElement {
                                 mt: 2,
                                 button: {
                                   backgroundColor: 'white',
-                                  color: colors.blue[700],
+                                  color: theme.palette.primary.main,
                                 },
                               }}
                               color='primary'

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -158,11 +158,10 @@ export default function Feed(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}
-        margin={{ xs: '80px 0px', m: '80px auto' }}
+        mx={{ xs: 0, m: 'auto' }}
         maxWidth={{ xs: '100%', m: '1600px' }}
       >
         <Grid container spacing={2}>
@@ -227,7 +226,7 @@ export default function Feed(): React.ReactElement {
             <Box
               width={'100%'}
               sx={{
-                background: '#F8F5F5',
+                background: theme.palette.background.paper,
                 borderRadius: '6px 0px 0px 6px',
                 p: {
                   xs: 2,

--- a/web-app/src/app/screens/ForgotPassword.tsx
+++ b/web-app/src/app/screens/ForgotPassword.tsx
@@ -71,7 +71,6 @@ export default function ForgotPassword(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/web-app/src/app/screens/Home.tsx
+++ b/web-app/src/app/screens/Home.tsx
@@ -35,6 +35,9 @@ const ActionBox = ({
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
+      flexGrow: 1,
+      flexBasis: 0,
+      minWidth: 0,
     }}
   >
     <IconComponent sx={{ width: '100%', height: iconHeight }} />
@@ -186,6 +189,9 @@ function Component(): React.ReactElement {
             display: 'flex',
             justifyContent: 'center',
             flexDirection: { xs: 'column', sm: 'row' },
+            width: '700px',
+            maxWidth: '100%',
+            margin: 'auto',
           }}
         >
           <ActionBox

--- a/web-app/src/app/screens/Home.tsx
+++ b/web-app/src/app/screens/Home.tsx
@@ -16,6 +16,7 @@ import LegacyHome from './LegacyHome';
 import { useRemoteConfig } from '../context/RemoteConfigProvider';
 import { WEB_VALIDATOR_LINK } from '../constants/Navigation';
 import '../styles/TextShimmer.css';
+import { theme } from '../Theme';
 
 interface ActionBoxProps {
   IconComponent: React.ElementType;
@@ -70,12 +71,12 @@ function Component(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
+          mt: 6,
           display: 'flex',
           flexDirection: 'column',
         }}
-        margin={{ xs: '80px 20px', m: '80px auto' }}
-        maxWidth={{ xs: '100%', m: '1600px' }}
+        mx={{ xs: '20px', m: 'auto' }}
+        maxWidth={{ xs: '100%', md: '1600px' }}
       >
         <Typography
           sx={{
@@ -215,7 +216,7 @@ function Component(): React.ReactElement {
         </Box>
         <Box
           sx={{
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             borderRadius: '6px 0px 0px 6px',
             p: {
               xs: 2,

--- a/web-app/src/app/screens/Home.tsx
+++ b/web-app/src/app/screens/Home.tsx
@@ -66,7 +66,7 @@ function Component(): React.ReactElement {
   };
 
   return (
-    <Container component='main'>
+    <Container component='main' sx={{ px: { xs: 0, md: 3 } }}>
       <CssBaseline />
       <Box
         sx={{
@@ -217,7 +217,10 @@ function Component(): React.ReactElement {
           sx={{
             background: '#F8F5F5',
             borderRadius: '6px 0px 0px 6px',
-            p: 5,
+            p: {
+              xs: 2,
+              sm: 4,
+            },
             color: 'black',
             fontSize: '18px',
             fontWeight: 700,

--- a/web-app/src/app/screens/LegacyHome.tsx
+++ b/web-app/src/app/screens/LegacyHome.tsx
@@ -6,6 +6,7 @@ import Container from '@mui/material/Container';
 import '../styles/SignUp.css';
 import { Button, Grid } from '@mui/material';
 import { Download, Login } from '@mui/icons-material';
+import { theme } from '../Theme';
 
 export default function Home(): React.ReactElement {
   return (
@@ -13,7 +14,6 @@ export default function Home(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
           width: '100vw',
@@ -44,7 +44,7 @@ export default function Home(): React.ReactElement {
           <Grid item sm={12} md={5}>
             <Box
               sx={{
-                background: '#F8F5F5',
+                background: theme.palette.background.paper,
                 borderRadius: '6px 0px 0px 6px',
                 display: 'flex',
                 alignItems: 'center',
@@ -110,7 +110,7 @@ export default function Home(): React.ReactElement {
         <Box
           sx={{
             width: '90vw',
-            background: '#F8F5F5',
+            background: theme.palette.background.paper,
             borderRadius: '6px 0px 0px 6px',
             p: 5,
             color: 'black',

--- a/web-app/src/app/screens/PostRegistration.tsx
+++ b/web-app/src/app/screens/PostRegistration.tsx
@@ -72,7 +72,6 @@ export default function PostRegistration(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           ml: 2,
           mr: 2,
           display: 'flex',

--- a/web-app/src/app/screens/PrivacyPolicy.tsx
+++ b/web-app/src/app/screens/PrivacyPolicy.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { Box, Container, Typography } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
+import { theme } from '../Theme';
 export default function TermsAndConditions(): React.ReactElement {
   return (
-    <Container component='main' sx={{ width: '100vw', m: 0 }}>
+    <Container component='main' sx={{ width: '100%', m: 'auto' }}>
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           p: 10,
           pt: 2,
           display: 'flex',
           flexDirection: 'column',
-          width: '100vw',
-          background: '#F8F5F5',
+          width: '100%',
+          background: theme.palette.background.paper,
         }}
       >
         <Typography

--- a/web-app/src/app/screens/SignIn.tsx
+++ b/web-app/src/app/screens/SignIn.tsx
@@ -157,7 +157,6 @@ export default function SignIn(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/web-app/src/app/screens/SignUp.tsx
+++ b/web-app/src/app/screens/SignUp.tsx
@@ -188,7 +188,6 @@ export default function SignUp(): React.ReactElement {
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/web-app/src/app/screens/TermsAndConditions.tsx
+++ b/web-app/src/app/screens/TermsAndConditions.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { Box, Container, Typography } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
+import { theme } from '../Theme';
 export default function TermsAndConditions(): React.ReactElement {
   return (
-    <Container component='main' sx={{ width: '100vw', m: 0 }}>
+    <Container component='main' sx={{ width: '100%', m: 'auto' }}>
       <CssBaseline />
       <Box
         sx={{
-          mt: 12,
           p: 10,
           pt: 2,
           display: 'flex',
           flexDirection: 'column',
-          width: '100vw',
-          background: '#F8F5F5',
+          width: '100%',
+          background: theme.palette.background.paper,
         }}
       >
         <Typography

--- a/web-app/src/app/styles/FAQ.css
+++ b/web-app/src/app/styles/FAQ.css
@@ -21,11 +21,6 @@ a:not(.btn-link, .btn-link-component) {
     padding: 2px;
 }
 
-a:hover:not(.btn-link, .btn-link-component) {
-    background-color: #3959fa21 !important;
-    border-radius: 5px;
-}
-
 .btn-link {
     color: inherit !important;
     text-decoration: none;

--- a/web-app/src/app/styles/FAQ.css
+++ b/web-app/src/app/styles/FAQ.css
@@ -1,27 +1,27 @@
 .question {
-    color: #000;
-    font-size: 25px !important;
-    font-style: normal;
-    font-weight: 700 !important;
-    line-height: normal;
-    text-decoration-line: underline;
-    margin-bottom: 5px;
+  color: #000;
+  font-size: 25px !important;
+  font-style: normal;
+  font-weight: 700 !important;
+  line-height: normal;
+  text-decoration-line: underline;
+  margin-bottom: 5px;
 }
 
 .answer {
-    color: #000;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
-    margin-bottom: 40px !important;
+  color: #000;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  margin-bottom: 40px !important;
 }
 
-a:not(.btn-link, .btn-link-component) {
-    color: #000;
-    padding: 2px;
+a:not(.btn-link, .btn-link-component):not(.MuiButtonBase-root) {
+  color: #3959fa;
+  padding: 2px;
 }
 
 .btn-link {
-    color: inherit !important;
-    text-decoration: none;
+  color: inherit !important;
+  text-decoration: none;
 }

--- a/web-app/src/app/styles/Footer.css
+++ b/web-app/src/app/styles/Footer.css
@@ -1,8 +1,9 @@
 .footer {
     width: 100%;
     text-align: center;
-    padding: 10px;
+    padding: 40px 8px;
     font-size: 13px;
+    box-sizing: border-box;
 }
 
 .link-button:hover {

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -14466,11 +14466,6 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typeface-muli@^1.1.13:
-  version "1.1.13"
-  resolved "https://registry.npmjs.org/typeface-muli/-/typeface-muli-1.1.13.tgz"
-  integrity sha512-FrbDCi7OKz6Mg8oK3bwAg3OTy3sGHXqb3ekSnOyHhvVCfSF/aiRTjv/KE5RJ1CfddhYDlBuTCQFNUfOOSlHObw==
-
 typescript-compare@^0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz"


### PR DESCRIPTION
closes: #756 

**Summary:**

Mobility database is a product of MobilityData and as such this PR introduces more styling elements to better align with the MobilityData brand as seen on mobilitydata.org

This PR also consolidates random colors and assures that elements on the web app use colors directly from the theme

Biggest changes
- Buttons now use the MobilityData secondary font
- Header elements have similar hover animations to the mobilitydata.org website (including styling for mobile)

**Expected behavior:** 

The application should work the same, just different styling

**Testing tips:**

Go through the application and try to find visual defects

**What's next**
- Revisit way of implementing styling (instead of always having inline styling)
- Fix the favicon size (to match the mobilitydata.org) and possibly slightly different color
- Get a MobilityDatabase logo image done and implement it
- Remove old components (LegacyHome, Contribute)
- Make reusable styling components (Page Headers + content box)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

Current
![image](https://github.com/user-attachments/assets/1f4a9867-7cc3-46cc-8025-a205d951a923)
![Screenshot 2024-10-24 at 11 54 23](https://github.com/user-attachments/assets/d6c39049-ca39-48da-b576-ededd25f55ca)


After
![image](https://github.com/user-attachments/assets/f32cfe10-0a32-427b-b87d-ce6ed86fa46d)
![Screenshot 2024-10-24 at 11 54 34](https://github.com/user-attachments/assets/63c9af3f-fef6-4cd2-8f02-0b59ff04058c)

Active Tab
![image](https://github.com/user-attachments/assets/2004b60d-af6b-4568-bd91-6570caa7145c)

