### PR TITLE
fix: feature url changes

### DIFF
--- a/web-app/src/app/utils/consts.ts
+++ b/web-app/src/app/utils/consts.ts
@@ -17,184 +17,184 @@ export const DATASET_FEATURES: DatasetFeatures = {
   overview: {
     component: '',
     fileName: '',
-    linkToInfo: 'https://gtfs.org/getting_started/features/overview/',
+    linkToInfo: 'https://gtfs.org/getting-started/features/overview/',
   },
   'Text-To-Speech': {
     component: 'Accessibility',
     fileName: 'stops.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/accessibility/#text-to-speech',
+      'https://gtfs.org/getting-started/features/accessibility/#text-to-speech',
   },
   'Stops Wheelchair Accessibility': {
     component: 'Accessibility',
     fileName: 'trips.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/accessibility/#stops-wheelchair-accessibility',
+      'https://gtfs.org/getting-started/features/accessibility/#stops-wheelchair-accessibility',
   },
   'Trips Wheelchair Accessibility': {
     component: 'Accessibility',
     fileName: 'trips.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/accessibility/#trips-wheelchair-accessibility',
+      'https://gtfs.org/getting-started/features/accessibility/#trips-wheelchair-accessibility',
   },
   'Route Colors': {
     component: 'Base add-ons',
     fileName: 'routes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#route-colors',
+      'https://gtfs.org/getting-started/features/base-add-ons/#route-colors',
   },
   'Bike Allowed': {
     component: 'Base add-ons',
     fileName: 'trips.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#bike-allowed',
+      'https://gtfs.org/getting-started/features/base-add-ons/#bike-allowed',
   },
   Translations: {
     component: 'Base add-ons',
     fileName: 'translations.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#translations',
+      'https://gtfs.org/getting-started/features/base-add-ons/#translations',
   },
   Headsigns: {
     component: 'Base add-ons',
     fileName: 'trips.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#headsigns',
+      'https://gtfs.org/getting-started/features/base-add-ons/#headsigns',
   },
   'Fare Products': {
     component: 'Fares',
     fileName: 'fare_products.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/fares/#fare-products',
+      'https://gtfs.org/getting-started/features/fares/#fare-products',
   },
   'Fare Media': {
     component: 'Fares',
     fileName: 'fare_media.txt',
-    linkToInfo: 'https://gtfs.org/getting_started/features/fares/#fare-media',
+    linkToInfo: 'https://gtfs.org/getting-started/features/fares/#fare-media',
   },
   'Route-Based Fares': {
     component: 'Fares',
     fileName: 'routes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/fares/#route-based-fares',
+      'https://gtfs.org/getting-started/features/fares/#route-based-fares',
   },
   'Time-Based Fares': {
     component: 'Fares',
     fileName: 'timeframes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/fares/#time-based-fares',
+      'https://gtfs.org/getting-started/features/fares/#time-based-fares',
   },
   'Zone-Based Fares': {
     component: 'Fares',
     fileName: 'areas.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/fares/#zone-based-fares',
+      'https://gtfs.org/getting-started/features/fares/#zone-based-fares',
   },
   'Fare Transfers': {
     component: 'Fares',
     fileName: 'fare_transfer_rules.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/fares/#fare-transfers',
+      'https://gtfs.org/getting-started/features/fares/#fare-transfers',
   },
   'Fares V1': {
     component: 'Fares',
     fileName: 'fare_attributes.txt',
-    linkToInfo: 'https://gtfs.org/getting_started/features/fares/#fares-v1',
+    linkToInfo: 'https://gtfs.org/getting-started/features/fares/#fares-v1',
   },
   'Pathway Connections': {
     component: 'Pathways',
     fileName: 'pathways.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/pathways/#pathway-connections',
+      'https://gtfs.org/getting-started/features/pathways/#pathway-connections',
   },
   'Pathway Details': {
     component: 'Pathways',
     fileName: 'pathways.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/pathways/#pathway-details',
+      'https://gtfs.org/getting-started/features/pathways/#pathway-details',
   },
   Levels: {
     component: 'Pathways',
     fileName: 'levels.txt',
-    linkToInfo: 'https://gtfs.org/getting_started/features/pathways/#levels',
+    linkToInfo: 'https://gtfs.org/getting-started/features/pathways/#levels',
   },
-  'In-station traversal time': {
+  'In-station Traversal Time': {
     component: 'Pathways',
     fileName: 'pathways.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/pathways/#in-station-traversal-time',
+      'https://gtfs.org/getting-started/features/pathways/#in-station-traversal-time',
   },
   'Pathway Signs': {
     component: 'Pathways',
     fileName: 'pathways.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/pathways/#pathway-signs',
+      'https://gtfs.org/getting-started/features/pathways/#pathway-signs',
   },
   'Location Types': {
     component: 'Base add-ons',
     fileName: 'stops.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#location-types',
+      'https://gtfs.org/getting-started/features/base-add-ons/#location-types',
   },
   'Feed Information': {
     component: 'Base add-ons',
     fileName: 'feed_info.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#feed-information',
+      'https://gtfs.org/getting-started/features/base-add-ons/#feed-information',
   },
   Attributions: {
     component: 'Base add-ons',
     fileName: 'attributions.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#attributions',
+      'https://gtfs.org/getting-started/features/base-add-ons/#attributions',
   },
   'Continuous Stops': {
     component: 'Flexible Services',
     fileName: 'routes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/flexible_services/#continuous-stops',
+      'https://gtfs.org/getting-started/features/flexible-services/#continuous-stops',
   },
   'Booking Rules': {
     component: 'Flexible Services',
     fileName: 'routes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/flexible_services/#booking-rules',
+      'https://gtfs.org/getting-started/features/flexible-services/#booking-rules',
   },
   'Fixed-Stops Demand Responsive Services': {
     component: 'Flexible Services',
     fileName: 'location_groups.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/flexible_services/#fixed-stops-demand-responsive-services',
+      'https://gtfs.org/getting-started/features/flexible-services/#fixed-stops-demand-responsive-services',
   },
   'Zone-Based Demand Responsive Services': {
     component: 'Flexible Services',
     fileName: 'stop_times.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/flexible_services/#zone-based-demand-responsive-services',
+      'https://gtfs.org/getting-started/features/flexible-services/#zone-based-demand-responsive-services',
   },
   'Predefined Routes with Deviation': {
     component: 'Flexible Services',
     fileName: 'stop_times.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/flexible_services/#predefined-routes-with-deviation',
+      'https://gtfs.org/getting-started/features/flexible-services/#predefined-routes-with-deviation',
   },
   Shapes: {
     component: 'Base add-ons',
     fileName: 'shapes.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#shapes ',
+      'https://gtfs.org/getting-started/features/base-add-ons/#shapes ',
   },
   Transfers: {
     component: 'Base add-ons',
     fileName: 'transfers.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#transfers',
+      'https://gtfs.org/getting-started/features/base-add-ons/#transfers',
   },
   Frequencies: {
     component: 'Base add-ons',
     fileName: 'frequencies.txt',
     linkToInfo:
-      'https://gtfs.org/getting_started/features/base_add-ons/#frequency-based-service ',
+      'https://gtfs.org/getting-started/features/base-add-ons/#frequency-based-service ',
   },
 };
 
@@ -203,7 +203,7 @@ DATASET_FEATURES['Wheelchair Accessibility'] = {
   // as of 6.0
   component: 'Accessibility',
   fileName: 'trips.txt',
-  linkToInfo: 'https://gtfs.org/getting_started/features/accessibility',
+  linkToInfo: 'https://gtfs.org/getting-started/features/accessibility',
 };
 DATASET_FEATURES['Bikes Allowance'] = DATASET_FEATURES['Bike Allowed'];
 DATASET_FEATURES['Transfer Fares'] = DATASET_FEATURES['Fare Transfers']; // as of 6.0


### PR DESCRIPTION
**Summary:**

The feature urls changed to no longer have `_` and being replaced with `-`. Also fixed the spelling of `In-station Traversal Time`

**Expected behavior:** 

All features on the feed detail page should go to the correct gtfs.org page

**Testing tips:**

Go to any feed detail page and test if the features navigate correctly

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
