### PR TITLE
feat: fix task queue trigger for updating reports post release

### DIFF
--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -36,3 +36,4 @@ jobs:
             --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
             --schedule-time=$(date -u -d "+24 hours" +%Y-%m-%dT%H:%M:%SZ) \
             --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT}
+            -location=northamerica-northeast1

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -35,5 +35,5 @@ jobs:
             --queue=update_validation_report_task_queue \
             --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
             --schedule-time=$(date -u -d "+24 hours" +%Y-%m-%dT%H:%M:%SZ) \
-            --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT}
-            -location=northamerica-northeast1
+            --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT} \
+            --location=${{ vars.MOBILITY_FEEDS_REGION }}

--- a/.github/workflows/validator-update.yml
+++ b/.github/workflows/validator-update.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create task to run cloud function
         run: |
           gcloud tasks create-http-task \
-            --queue=update_validation_report_task_queue \
+            --queue=update-validation-report-task-queue \
             --url=https://${ENVIRONMENT}-${PROJECT_ID}.cloudfunctions.net/update-validation-report \
             --schedule-time=$(date -u -d "+24 hours" +%Y-%m-%dT%H:%M:%SZ) \
             --oidc-service-account-email=${DEPLOYER_SERVICE_ACCOUNT} \


### PR DESCRIPTION
**Summary:**
Closes #785 
This pull request includes a small change to the `.github/workflows/validator-update.yml` file. The change corrects the queue name format and adds a location variable to the `gcloud tasks create-http-task` command.

* Corrected queue name format from `update_validation_report_task_queue` to `update-validation-report-task-queue`.
* Added `--location` parameter to the `gcloud tasks create-http-task` command.

**Expected behavior:** 
The task queue is successfully created.
Example for [this action run](https://github.com/MobilityData/mobility-feed-api/actions/runs/11709898669/job/32614935602): [update-validation-report-task-queue](https://console.cloud.google.com/cloudtasks/queue/northamerica-northeast1/update-validation-report-task-queue?project=mobility-feeds-prod)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
