### PR TITLE
feat: Feature search UI

### DIFF
--- a/web-app/src/app/components/NestedCheckboxList.tsx
+++ b/web-app/src/app/components/NestedCheckboxList.tsx
@@ -1,0 +1,213 @@
+import {
+  Checkbox,
+  Collapse,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import * as React from 'react';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { theme } from '../Theme';
+
+interface NestedCheckboxListProps {
+  checkboxData: CheckboxStructure[];
+  onCheckboxChange: (checkboxData: CheckboxStructure[]) => void;
+}
+
+// NOTE: Although the data structure allows for multiple levels of nesting, the current implementation only supports two levels.
+// TODO: Implement support for multiple levels of nesting
+export interface CheckboxStructure {
+  title: string;
+  type: 'label' | 'checkbox';
+  checked: boolean;
+  seeChildren?: boolean;
+  children?: CheckboxStructure[];
+}
+
+export default function NestedCheckboxList({
+  checkboxData,
+  onCheckboxChange,
+}: NestedCheckboxListProps): JSX.Element {
+  const [checkboxStructure, setCheckboxStructure] =
+    React.useState<CheckboxStructure[]>(checkboxData);
+  const [hasChange, setHasChange] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    if (hasChange) {
+      setHasChange(false);
+      onCheckboxChange(checkboxStructure);
+    }
+  }, [checkboxStructure]);
+
+  React.useEffect(() => {
+    setCheckboxStructure(checkboxData);
+  }, [checkboxData]);
+
+  return (
+    <List sx={{ width: '100%' }} dense>
+      {checkboxStructure.map((checkboxData, index) => {
+        const labelId = `checkbox-list-label-${checkboxData.title}`;
+        return (
+          <ListItem
+            key={checkboxData.title}
+            disablePadding
+            sx={{
+              display: 'block',
+              borderBottom:
+                checkboxData.children !== undefined
+                  ? `1px solid ${theme.palette.text.primary}`
+                  : 'none',
+              '.MuiListItemSecondaryAction-root': {
+                top: checkboxData.type === 'checkbox' ? '22px' : '11px',
+              },
+            }}
+            secondaryAction={
+              <>
+                {checkboxData.children !== undefined &&
+                  checkboxData.children?.length > 0 && (
+                    <IconButton
+                      edge={'end'}
+                      aria-label='expand'
+                      onClick={() => {
+                        setCheckboxStructure((prev) => {
+                          checkboxData.seeChildren =
+                            checkboxData.seeChildren === undefined
+                              ? true
+                              : !checkboxData.seeChildren;
+                          return [...prev];
+                        });
+                        // NOTE: Expand changes will not output to parent
+                      }}
+                    >
+                      {checkboxData.seeChildren !== undefined &&
+                      checkboxData.seeChildren ? (
+                        <ExpandLess />
+                      ) : (
+                        <ExpandMore />
+                      )}
+                    </IconButton>
+                  )}
+              </>
+            }
+          >
+            {checkboxData.type === 'checkbox' && (
+              <ListItemButton
+                role={undefined}
+                dense={true}
+                sx={{ p: 0 }}
+                onClick={() => {
+                  setCheckboxStructure((prev) => {
+                    checkboxData.checked = !checkboxData.checked;
+                    checkboxData.children?.forEach((child) => {
+                      child.checked = checkboxData.checked;
+                    });
+                    prev[index] = checkboxData;
+                    return [...prev];
+                  });
+                  setHasChange(true);
+                }}
+              >
+                <Checkbox
+                  edge='start'
+                  tabIndex={-1}
+                  disableRipple
+                  inputProps={{ 'aria-labelledby': labelId }}
+                  checked={
+                    checkboxData.checked ||
+                    (checkboxData.children !== undefined &&
+                      checkboxData.children.length > 0 &&
+                      checkboxData.children.every((child) => child.checked))
+                  }
+                  indeterminate={
+                    checkboxData.children !== undefined
+                      ? checkboxData.children.some((child) => child.checked) &&
+                        !checkboxData.children.every((child) => child.checked)
+                      : false
+                  }
+                />
+                <ListItemText
+                  id={labelId}
+                  primary={<b>{checkboxData.title}</b>}
+                  primaryTypographyProps={{
+                    variant: 'body1',
+                  }}
+                />
+              </ListItemButton>
+            )}
+            {checkboxData.type === 'label' && (
+              <ListItemText
+                id={labelId}
+                primary={<b>{checkboxData.title}</b>}
+                primaryTypographyProps={{
+                  variant: 'body1',
+                }}
+              />
+            )}
+            {checkboxData.children !== undefined && (
+              <Collapse
+                in={checkboxData.seeChildren}
+                timeout='auto'
+                unmountOnExit
+              >
+                <List
+                  sx={{
+                    ml: 1,
+                    display: { xs: 'flex', md: 'block' },
+                    flexWrap: 'wrap',
+                  }}
+                  dense
+                >
+                  {checkboxData.children.map((value) => {
+                    const labelId = `checkbox-list-label-${value.title}`;
+
+                    return (
+                      <ListItem
+                        key={value.title}
+                        disablePadding
+                        sx={{ width: { xs: '50%', sm: '33%', md: '100%' } }}
+                        onClick={() => {
+                          setCheckboxStructure((prev) => {
+                            value.checked = !value.checked;
+                            if (!value.checked) {
+                              checkboxData.checked = false;
+                            }
+                            return [...prev];
+                          });
+                          setHasChange(true);
+                        }}
+                      >
+                        <ListItemButton
+                          role={undefined}
+                          dense={true}
+                          sx={{ p: 0, pl: 1 }}
+                        >
+                          <Checkbox
+                            edge='start'
+                            tabIndex={-1}
+                            disableRipple
+                            checked={value.checked || checkboxData.checked}
+                            inputProps={{ 'aria-labelledby': labelId }}
+                          />
+
+                          <ListItemText
+                            id={labelId}
+                            primary={`${value.title}`}
+                            primaryTypographyProps={{
+                              variant: 'body1',
+                            }}
+                          />
+                        </ListItemButton>
+                      </ListItem>
+                    );
+                  })}
+                </List>
+              </Collapse>
+            )}
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}

--- a/web-app/src/app/screens/Feeds/styles.tsx
+++ b/web-app/src/app/screens/Feeds/styles.tsx
@@ -1,0 +1,14 @@
+import { styled, Typography } from '@mui/material';
+
+export const SearchHeader = styled(Typography)(({ theme }) => ({
+  '&:not(:first-of-type)': {
+    marginTop: theme.spacing(2),
+  },
+  '&:after': {
+    content: '""',
+    display: 'block',
+    height: '3px',
+    width: '104px',
+    background: theme.palette.text.primary,
+  },
+}));

--- a/web-app/src/app/screens/Feeds/utility.ts
+++ b/web-app/src/app/screens/Feeds/utility.ts
@@ -1,0 +1,32 @@
+export function getDataTypeParamFromSelectedFeedTypes(
+  selectedFeedTypes: Record<string, boolean>,
+): 'gtfs' | 'gtfs_rt' | undefined {
+  let dataTypeQueryParam: 'gtfs' | 'gtfs_rt' | undefined;
+  if (selectedFeedTypes.gtfs && !selectedFeedTypes.gtfs_rt) {
+    dataTypeQueryParam = 'gtfs';
+  } else if (!selectedFeedTypes.gtfs && selectedFeedTypes.gtfs_rt) {
+    dataTypeQueryParam = 'gtfs_rt';
+  } else if (!selectedFeedTypes.gtfs && !selectedFeedTypes.gtfs_rt) {
+    dataTypeQueryParam = undefined;
+  }
+  return dataTypeQueryParam;
+}
+
+export function getInitialSelectedFeedTypes(
+  searchParams: URLSearchParams,
+): Record<string, boolean> {
+  const gtfsSearch = searchParams.get('gtfs');
+  const gtfsRtSearch = searchParams.get('gtfs_rt');
+
+  if (gtfsSearch === null && gtfsRtSearch === null) {
+    return {
+      gtfs: false,
+      gtfs_rt: false,
+    };
+  } else {
+    return {
+      gtfs: gtfsSearch === 'true',
+      gtfs_rt: gtfsRtSearch === 'true',
+    };
+  }
+}

--- a/web-app/src/app/utils/consts.tsx
+++ b/web-app/src/app/utils/consts.tsx
@@ -32,14 +32,14 @@ export function groupFeaturesByComponent(
   features.forEach((feature) => {
     const featureData = DATASET_FEATURES[feature];
     if (featureData !== undefined) {
-      const component = featureData.component ?? 'Other';
+      const component =
+        featureData.component !== '' ? featureData.component : 'Other';
       if (groupedFeatures[component] === undefined) {
         groupedFeatures[component] = [];
       }
       groupedFeatures[component].push({ ...featureData, feature });
     }
   });
-
   return groupedFeatures;
 }
 


### PR DESCRIPTION
closes: #804 

**Summary:**

- Selecting GTFS / GTFS RT is now put in the url and has selection Chips
- GTFS Features are now selectable in the filter sections and are in the URL
- Implementation of filter chips to see what has been selected
- Styling adjustments

> [!NOTE]  
> The feature search will be commented out before merge

> [!NOTE]  
> The feature filters do not connect to the backend and are just UI ready

**Expected behavior:** 

For gtfs / gtfs_rt selection, functionality should remain the same. You will now be able to refresh the page and have all the data type stay permanent

You should be able to see the selected filters through the chips

**Follow up tickets**
- Unit tests
- [blocked] Implement the feature filters in the endpoint
- Continue on NestedCheckbox component (recursion of checkboxes)
- Add debounce when selecting features so users can select many at a time without waiting for load everytime
- Disable / Hide feature selection when only GTFS_RT is selected
- Refactor the Feeds index.tsx (it's getting large)
   - Filter Chips in new file
   - Continue taking styling out of index and into dedicated style file

**Testing tips:**

Play with the Feeds search page
- Set queries, pagination, filters -> refresh the page, navigate back, etc. Should all work as expected.
Note: It's expected for pagination to reset when selecting a datatype or feature

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

With Feature search
![Screenshot 2024-11-28 at 15 17 32](https://github.com/user-attachments/assets/3edb3037-a09c-46de-9033-acfa400a9a11)

With feature search commented out
![Screenshot 2024-11-28 at 15 17 04](https://github.com/user-attachments/assets/71d382ec-b8d1-412b-9720-8816a387d7ee)

Url parameters
![Screenshot 2024-11-28 at 15 17 44](https://github.com/user-attachments/assets/5e01e09c-23cf-4375-bd3e-2dee35a4bbcb)

