### PR TITLE
feat: feed status in feed detail page

### DIFF
--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -94,5 +94,29 @@
   "seeDetailPageProviders": "See detail page to view {providersCount} others",
   "openFullQualityReport": "Open Full Quality Report",
   "qualityReportUpdated": "Quality report updated",
-  "officialFeedUpdated": "Official verification updated"
+  "officialFeedUpdated": "Official verification updated",
+  "serviceDateRange": "Service Date Range",
+  "serviceDateRangeTooltip": "Dates are relative to local timezone",
+  "feedStatus": {
+    "active": {
+      "label": "Active",
+      "toolTip": "Active Feed",
+      "toolTipLong": "This feed is currently active and being used."
+    },
+    "inactive": {
+      "label": "Inactive",
+      "toolTip": "Inactive Feed",
+      "toolTipLong": "This feed is currently inactive and not being used."
+    },
+    "deprecated": {
+      "label": "Deprecated",
+      "toolTip": "Deprecated Feed",
+      "toolTipLong": "This feed is deprecated and should not be used."
+    },
+    "future": {
+      "label": "Future",
+      "toolTip": "Future Feed",
+      "toolTipLong": "This feed is not yet active but will be used in the future."
+    }
+  }
 }

--- a/web-app/src/app/components/FeedStatus.tsx
+++ b/web-app/src/app/components/FeedStatus.tsx
@@ -1,0 +1,88 @@
+import { Box, Chip, Tooltip } from '@mui/material';
+import { theme } from '../Theme';
+import { useTranslation } from 'react-i18next';
+import { type TFunction } from 'i18next';
+
+export interface FeedStatusProps {
+  status: string;
+}
+
+interface FeedStatusData {
+  toolTip: string;
+  label: string;
+  themeColor: 'success' | 'info' | 'warning' | 'error';
+  toolTipLong: string;
+}
+
+function getFeedStatusData(
+  status: string,
+  t: TFunction,
+): FeedStatusData | undefined {
+  const data: Record<string, FeedStatusData> = {
+    active: {
+      toolTip: t('feedStatus.active.toolTip'),
+      label: t('feedStatus.active.label'),
+      themeColor: 'success',
+      toolTipLong: t('feedStatus.active.toolTipLong'),
+    },
+    future: {
+      toolTip: t('feedStatus.future.toolTip'),
+      label: t('feedStatus.future.label'),
+      themeColor: 'info',
+      toolTipLong: t('feedStatus.future.toolTipLong'),
+    },
+    inactive: {
+      toolTip: t('feedStatus.inactive.toolTip'),
+      label: t('feedStatus.inactive.label'),
+      themeColor: 'warning',
+      toolTipLong: t('feedStatus.inactive.toolTipLong'),
+    },
+    deprecated: {
+      toolTip: t('feedStatus.deprecated.toolTip'),
+      label: t('feedStatus.deprecated.label'),
+      themeColor: 'error',
+      toolTipLong: t('feedStatus.deprecated.toolTipLong'),
+    },
+  };
+
+  return data[status];
+}
+
+export const FeedStatusIndicator = (
+  props: React.PropsWithChildren<FeedStatusProps>,
+): JSX.Element => {
+  const { t } = useTranslation('feeds');
+  const statusData = getFeedStatusData(props.status, t);
+  return (
+    <>
+      {statusData != undefined && (
+        <Tooltip title={statusData.toolTip} placement='top'>
+          <Box
+            sx={{
+              background: theme.palette[statusData.themeColor].main,
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+            }}
+          ></Box>
+        </Tooltip>
+      )}
+    </>
+  );
+};
+
+export const FeedStatusChip = (
+  props: React.PropsWithChildren<FeedStatusProps>,
+): JSX.Element => {
+  const { t } = useTranslation('feeds');
+  const statusData = getFeedStatusData(props.status, t);
+  return (
+    <>
+      {statusData != undefined && (
+        <Tooltip title={statusData.toolTipLong} placement='top'>
+          <Chip label={statusData.label} color={statusData.themeColor}></Chip>
+        </Tooltip>
+      )}
+    </>
+  );
+};

--- a/web-app/src/app/screens/Feed/DataQualitySummary.tsx
+++ b/web-app/src/app/screens/Feed/DataQualitySummary.tsx
@@ -7,13 +7,16 @@ import { WarningContentBox } from '../../components/WarningContentBox';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { useTranslation } from 'react-i18next';
 import { verificationBadgeStyle } from '../../styles/VerificationBadge.styles';
+import { FeedStatusChip } from '../../components/FeedStatus';
 
 export interface DataQualitySummaryProps {
+  feedStatus: components['schemas']['BasicFeed']['status'];
   isOfficialFeed: boolean;
   latestDataset: components['schemas']['GtfsDataset'] | undefined;
 }
 
 export default function DataQualitySummary({
+  feedStatus,
   isOfficialFeed,
   latestDataset,
 }: DataQualitySummaryProps): React.ReactElement {
@@ -24,7 +27,8 @@ export default function DataQualitySummary({
         latestDataset.validation_report === null) && (
         <WarningContentBox>{t('errorLoadingQualityReport')}</WarningContentBox>
       )}
-      <Box sx={{ display: 'flex', gap: 1 }}>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        <FeedStatusChip status={feedStatus ?? ''}></FeedStatusChip>
         {isOfficialFeed && (
           <Tooltip title={t('officialFeedTooltip')} placement='top'>
             <Chip

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -30,6 +30,9 @@ import DatasetIcon from '@mui/icons-material/Dataset';
 import LayersIcon from '@mui/icons-material/Layers';
 import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
+import DateRangeIcon from '@mui/icons-material/DateRange';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { FeedStatusIndicator } from '../../components/FeedStatus';
 
 export interface FeedSummaryProps {
   feed: GTFSFeedType | GTFSRTFeedType | undefined;
@@ -58,7 +61,7 @@ const boxElementStyleProducerURL: SxProps = {
 const StyledTitleContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
   gap: theme.spacing(1),
-  marginBottom: theme.spacing(1),
+  marginBottom: '4px',
   marginTop: theme.spacing(3),
   alignItems: 'center',
 }));
@@ -72,6 +75,35 @@ const ResponsiveListItem = styled('li')(({ theme }) => ({
     width: 'calc(50% - 15px)',
   },
 }));
+
+const formatServiceDateRange = (
+  dateStart: string,
+  dateEnd: string,
+): JSX.Element => {
+  const startDate = new Date(dateStart);
+  const endDate = new Date(dateEnd);
+  const formattedDateStart = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(startDate);
+  const formattedDateEnd = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(endDate);
+  return (
+    <Box>
+      <Typography variant='body1'>
+        {formattedDateStart}{' '}
+        <Typography component={'span'} sx={{ mx: 2, fontSize: '14px' }}>
+          -
+        </Typography>{' '}
+        {formattedDateEnd}
+      </Typography>
+    </Box>
+  );
+};
 
 export default function FeedSummary({
   feed,
@@ -89,7 +121,6 @@ export default function FeedSummary({
   const hasAuthenticationInfo =
     feed?.source_info?.authentication_info_url !== undefined &&
     feed?.source_info.authentication_info_url.trim() !== '';
-
   return (
     <ContentBox
       width={width}
@@ -158,6 +189,34 @@ export default function FeedSummary({
           )}
         </Box>
       </Box>
+      {latestDataset?.service_date_range_start != undefined &&
+        latestDataset.service_date_range_end != undefined && (
+          <Box sx={boxElementStyle}>
+            <StyledTitleContainer>
+              <DateRangeIcon></DateRangeIcon>
+              <Typography variant='subtitle1' sx={{ fontWeight: 'bold' }}>
+                {t('serviceDateRange')}
+                <Tooltip title={t('serviceDateRangeTooltip')} placement='top'>
+                  <IconButton>
+                    <InfoOutlinedIcon />
+                  </IconButton>
+                </Tooltip>
+              </Typography>
+            </StyledTitleContainer>
+            <Typography
+              variant='body1'
+              sx={{ display: 'flex', alignItems: 'center', gap: 3 }}
+            >
+              {formatServiceDateRange(
+                latestDataset?.service_date_range_start,
+                latestDataset?.service_date_range_end,
+              )}
+              <FeedStatusIndicator
+                status={feed?.status ?? ''}
+              ></FeedStatusIndicator>
+            </Typography>
+          </Box>
+        )}
       <Box sx={boxElementStyleProducerURL}>
         <StyledTitleContainer>
           <LinkIcon></LinkIcon>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -417,6 +417,7 @@ export default function Feed(): React.ReactElement {
 
       {feed?.data_type === 'gtfs' && (
         <DataQualitySummary
+          feedStatus={feed?.status}
           isOfficialFeed={feed.official === true}
           latestDataset={latestDataset}
         />


### PR DESCRIPTION
closes #877 

**Summary:**

Display the feed status in the feed detail page as well as the service date range

**Expected behavior:** 

Should display the the status in the feed detail page, and the service date range if it exists

**Testing tips:**

Go to any feed page and you should be able to see the feed status at the top
For more intense testing, run db locally and inject service_date_range_start/end into the dataset db and see the service date values in the UI. (At the moment all service date values are empty)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2025-01-20 at 14 35 05](https://github.com/user-attachments/assets/bff0a9a7-f785-4037-9a9d-34e6eff8a6f8)

![Screenshot 2025-01-20 at 14 35 16](https://github.com/user-attachments/assets/af4e3ff5-678a-43a3-a714-a84d3976eaa1)

![Screenshot 2025-01-20 at 15 14 44](https://github.com/user-attachments/assets/8d414f1b-3a91-4741-8c6a-115502aca5b9)

![Screenshot 2025-01-20 at 15 21 57](https://github.com/user-attachments/assets/37950b3a-95c7-4f57-ba79-aac2d2405b5c)

![Screenshot 2025-01-20 at 15 22 16](https://github.com/user-attachments/assets/5875c794-1db4-4b75-859b-df617e7a3c4c)
