### PR TITLE
fix: java version comparison fails

### DIFF
--- a/api/src/feeds/impl/models/gtfs_dataset_impl.py
+++ b/api/src/feeds/impl/models/gtfs_dataset_impl.py
@@ -1,12 +1,11 @@
 from functools import reduce
 from typing import List
 
-from packaging.version import Version
-
 from database_gen.sqlacodegen_models import Gtfsdataset, Validationreport
 from feeds.impl.models.bounding_box_impl import BoundingBoxImpl
 from feeds.impl.models.validation_report_impl import ValidationReportImpl
 from feeds_gen.models.gtfs_dataset import GtfsDataset
+from utils.model_utils import compare_java_versions
 
 
 class GtfsDatasetImpl(GtfsDataset):
@@ -30,7 +29,8 @@ class GtfsDatasetImpl(GtfsDataset):
         """
         if validation_reports:
             latest_report = reduce(
-                lambda a, b: a if Version(a.validator_version) > Version(b.validator_version) else b, validation_reports
+                lambda a, b: a if compare_java_versions(a.validator_version, b.validator_version) == 1 else b,
+                validation_reports,
             )
             return ValidationReportImpl.from_orm(latest_report)
         return None

--- a/api/src/feeds/impl/models/latest_dataset_impl.py
+++ b/api/src/feeds/impl/models/latest_dataset_impl.py
@@ -1,12 +1,11 @@
 from functools import reduce
 
-from packaging.version import Version
-
 from database_gen.sqlacodegen_models import Gtfsdataset
 from feeds.impl.models.bounding_box_impl import BoundingBoxImpl
 from feeds.impl.models.validation_report_impl import ValidationReportImpl
 from feeds_gen.models.latest_dataset import LatestDataset
 from feeds_gen.models.latest_dataset_validation_report import LatestDatasetValidationReport
+from utils.model_utils import compare_java_versions
 
 
 class LatestDatasetImpl(LatestDataset):
@@ -28,7 +27,7 @@ class LatestDatasetImpl(LatestDataset):
         validation_report: LatestDatasetValidationReport | None = None
         if dataset.validation_reports:
             latest_report = reduce(
-                lambda a, b: a if Version(a.validator_version) > Version(b.validator_version) else b,
+                lambda a, b: a if compare_java_versions(a.validator_version, b.validator_version) == 1 else b,
                 dataset.validation_reports,
             )
             (

--- a/api/src/utils/model_utils.py
+++ b/api/src/utils/model_utils.py
@@ -1,0 +1,26 @@
+from packaging.version import Version
+
+
+def compare_java_versions(v1: str | None, v2: str | None):
+    """
+    Compare two version strings v1 and v2.
+    Returns 1 if v1 > v2, -1 if v1 < v2,
+    otherwise 0.
+    The version strings are expected to be in the format of
+    major.minor.patch[-SNAPSHOT]
+    """
+    if v1 is None and v2 is None:
+        return 0
+    if v1 is None:
+        return -1
+    if v2 is None:
+        return 1
+    # clean version strings replacing the SNAPSHOT suffix with .dev0
+    v1 = v1.replace("-SNAPSHOT", ".dev0")
+    v2 = v2.replace("-SNAPSHOT", ".dev0")
+    if Version(v1) > Version(v2):
+        return 1
+    elif Version(v1) < Version(v2):
+        return -1
+    else:
+        return 0

--- a/api/tests/utils/test_compare_java_versions.py
+++ b/api/tests/utils/test_compare_java_versions.py
@@ -1,0 +1,27 @@
+import unittest
+from utils.model_utils import compare_java_versions
+
+
+class TestCompareJavaVersions(unittest.TestCase):
+    def test_compare_versions_equal(self):
+        self.assertEqual(compare_java_versions("1.0.0", "1.0.0"), 0)
+        self.assertEqual(compare_java_versions("1.0.0-SNAPSHOT", "1.0.0-SNAPSHOT"), 0)
+
+    def test_compare_versions_v1_greater(self):
+        self.assertEqual(compare_java_versions("1.0.1", "1.0.0"), 1)
+        self.assertEqual(compare_java_versions("1.0.0", "0.9.9"), 1)
+        self.assertEqual(compare_java_versions("1.0.0", "1.0.0-SNAPSHOT"), 1)
+
+    def test_compare_versions_v2_greater(self):
+        self.assertEqual(compare_java_versions("1.0.0", "1.0.1"), -1)
+        self.assertEqual(compare_java_versions("0.9.9", "1.0.0"), -1)
+        self.assertEqual(compare_java_versions("1.0.0-SNAPSHOT", "1.0.0"), -1)
+
+    def test_compare_versions_with_none(self):
+        self.assertEqual(compare_java_versions(None, None), 0)
+        self.assertEqual(compare_java_versions(None, "1.0.0"), -1)
+        self.assertEqual(compare_java_versions("1.0.0", None), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Summary:**
This PR adds a protecting logic to the version comparison. Currently, we are comparing Java versions string with a pip version utility that is not 100% compatible. 

Closes #886

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).

**Testing tips:**

The fastest way to test this PR is using a PR that changes the UI deployed to DEV. 
- Open a UI PR, [example](https://mobility-feeds-dev--pr-885-ab13375j.web.app/)
- Open any feed's screen and expect all feed information to be displayed. 

## From our AI friend
This pull request introduces a new utility function for comparing Java version strings and integrates it into the existing codebase. The most important changes include the creation of the `compare_java_versions` function, its integration into the `GtfsDatasetImpl` and `LatestDatasetImpl` classes, and the addition of unit tests for the new function.

### New Utility Function:
* [`api/src/utils/model_utils.py`](diffhunk://#diff-8c3cf6fb8f0fc5aadf52727bcbd3e8d8dfaf8d64f85a09fe4b47183d5439c314R1-R26): Added the `compare_java_versions` function to compare two Java version strings, including handling of `-SNAPSHOT` suffixes.

### Integration of Utility Function:
* [`api/src/feeds/impl/models/gtfs_dataset_impl.py`](diffhunk://#diff-3bde2b442866b708d36b52c79366669c25f3440b3778f74de00ce09de19c2ffbL4-R8): Replaced the use of `Version` with the new `compare_java_versions` function in the `from_orm_latest_validation_report` method. [[1]](diffhunk://#diff-3bde2b442866b708d36b52c79366669c25f3440b3778f74de00ce09de19c2ffbL4-R8) [[2]](diffhunk://#diff-3bde2b442866b708d36b52c79366669c25f3440b3778f74de00ce09de19c2ffbL33-R33)
* [`api/src/feeds/impl/models/latest_dataset_impl.py`](diffhunk://#diff-4b568c853100ecdc61b16345c5e3c31bd490dfabc8a57e58e90009d1a0c170c1L3-R8): Replaced the use of `Version` with the new `compare_java_versions` function in the `from_orm` method. [[1]](diffhunk://#diff-4b568c853100ecdc61b16345c5e3c31bd490dfabc8a57e58e90009d1a0c170c1L3-R8) [[2]](diffhunk://#diff-4b568c853100ecdc61b16345c5e3c31bd490dfabc8a57e58e90009d1a0c170c1L31-R30)

### Unit Tests:
* [`api/tests/utils/test_compare_java_versions.py`](diffhunk://#diff-8e291440ad1d0baa35764cdff27e7bcf75cab376e091e657497daa7546e35e49R1-R27): Added unit tests for the `compare_java_versions` function to ensure it correctly compares version strings, including cases with `None` values and `-SNAPSHOT` suffixes.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
