### PR TITLE
fix: support redirect as string

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -159,8 +159,10 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                     comment = comments.pop(0)
                 else:
                     comment = ""
-
-                target_stable_id = f"mdb-{int(float(mdb_source_id.strip()))}"
+                try:
+                    target_stable_id = f"mdb-{int(float(mdb_source_id.strip()))}"
+                except ValueError:
+                    target_stable_id = mdb_source_id.strip()
                 target_feed = self.query_feed_by_stable_id(session, target_stable_id, None)
                 if not target_feed:
                     self.logger.warning(f"Could not find redirect target feed {target_stable_id} for feed {stable_id}")


### PR DESCRIPTION
**Summary:**
This pull request includes a change to the `process_redirects` method in the `api/src/scripts/populate_db_gtfs.py` file. A `try-except` block is added to handle `ValueError` exceptions when converting `mdb_source_id` to a float. This ensures that if the conversion fails, the `mdb_source_id` is stripped and used as-is.

Successful run: https://github.com/MobilityData/mobility-feed-api/actions/runs/13142416339
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
