### PR TITLE
Feat: update feed status python function

### DIFF
--- a/functions-python/update_feed_status/.coveragerc
+++ b/functions-python/update_feed_status/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+    */test*/*
+    */database_gen/*
+    */dataset_service/*
+    */helpers/*
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.:

--- a/functions-python/update_feed_status/.env.rename_me
+++ b/functions-python/update_feed_status/.env.rename_me
@@ -1,0 +1,2 @@
+# Environment variables for the validation report information extraction to run locally
+export FEEDS_DATABASE_URL=${{FEEDS_DATABASE_URL}}

--- a/functions-python/update_feed_status/README.md
+++ b/functions-python/update_feed_status/README.md
@@ -1,0 +1,21 @@
+# Update Feed Status
+This directory contains the GCP serverless function that will update all the feed statuses according to their associated latest dataset service date range.
+
+It will exclude Feeds with exisiting status 'deprecated' and 'development'
+
+## Function Workflow
+1. **HTTP Request Trigger**: The function is invoked through an HTTP request that includes identifiers for a dataset and feed.
+2. **Dataset Query**: Retreives all feeds which have latest dataset with exisitng values for the service date range
+3. **Feed Update Query**: Update the feed status based on the service date range values comparing vs current date
+
+## Function Configuration
+The function depends on several environment variables:
+- `FEEDS_DATABASE_URL`: The database URL for connecting to the database containing GTFS datasets and related entities.
+
+## Local Development
+Follow standard practices for local development of GCP serverless functions. Refer to the main [README.md](../README.md) for general setup instructions for the development environment.
+
+## Testing
+To run it locally `./scripts/function-python-run.sh --function_name update_feed_status`
+
+In postman or similar service, with a `POST` call `v1/update_feed_status`

--- a/functions-python/update_feed_status/function_config.json
+++ b/functions-python/update_feed_status/function_config.json
@@ -1,0 +1,20 @@
+{
+  "name": "update-feed-status",
+  "description": "Update the feed status with the corresponding latest dataset service date range",
+  "entry_point": "update_feed_status",
+  "timeout": 3600,
+  "memory": "2Gi",
+  "trigger_http": true,
+  "include_folders": ["helpers"],
+  "include_api_folders": ["database_gen"],
+  "secret_environment_variables": [
+    {
+      "key": "FEEDS_DATABASE_URL"
+    }
+  ],
+  "ingress_settings": "ALLOW_INTERNAL_AND_GCLB",
+  "max_instance_request_concurrency": 1,
+  "max_instance_count": 1,
+  "min_instance_count": 0,
+  "available_cpu": 1
+}

--- a/functions-python/update_feed_status/function_config.json
+++ b/functions-python/update_feed_status/function_config.json
@@ -3,7 +3,7 @@
   "description": "Update the feed status with the corresponding latest dataset service date range",
   "entry_point": "update_feed_status",
   "timeout": 3600,
-  "memory": "2Gi",
+  "memory": "1Gi",
   "trigger_http": true,
   "include_folders": ["helpers"],
   "include_api_folders": ["database_gen"],

--- a/functions-python/update_feed_status/requirements.txt
+++ b/functions-python/update_feed_status/requirements.txt
@@ -1,0 +1,18 @@
+# Common packages
+functions-framework==3.*
+google-cloud-logging
+psycopg2-binary==2.9.6
+aiohttp~=3.10.5
+asyncio~=3.4.3
+urllib3~=2.2.2
+requests~=2.32.3
+attrs~=23.1.0
+pluggy~=1.3.0
+certifi~=2024.7.4
+
+# SQL Alchemy and Geo Alchemy
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages for this function
+cloudevents~=1.10.1

--- a/functions-python/update_feed_status/requirements_dev.txt
+++ b/functions-python/update_feed_status/requirements_dev.txt
@@ -1,0 +1,2 @@
+Faker
+pytest~=7.4.3

--- a/functions-python/update_feed_status/src/main.py
+++ b/functions-python/update_feed_status/src/main.py
@@ -48,15 +48,19 @@ def update_feed_statuses_query(session: "Session"):
         ),
     )
 
-    updated_count = (
-        session.query(Feed)
-        .filter(
-            Feed.status != text("'deprecated'::status"),
-            Feed.status != text("'development'::status"),
-            Feed.id == latest_dataset_subq.c.feed_id,
+    try:
+        updated_count = (
+            session.query(Feed)
+            .filter(
+                Feed.status != text("'deprecated'::status"),
+                Feed.status != text("'development'::status"),
+                Feed.id == latest_dataset_subq.c.feed_id,
+            )
+            .update({Feed.status: new_status}, synchronize_session=False)
         )
-        .update({Feed.status: new_status}, synchronize_session=False)
-    )
+    except Exception as e:
+        logging.error(f"Error updating feed statuses: {e}")
+        raise Exception(f"Error updating feed statuses: {e}")
 
     try:
         session.commit()

--- a/functions-python/update_feed_status/src/main.py
+++ b/functions-python/update_feed_status/src/main.py
@@ -1,0 +1,88 @@
+import logging
+import os
+import functions_framework
+from datetime import date
+from shared.helpers.logger import Logger
+from shared.helpers.database import Database
+from typing import TYPE_CHECKING
+from sqlalchemy import case, text
+from shared.database_gen.sqlacodegen_models import Gtfsdataset, Feed
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logging.basicConfig(level=logging.INFO)
+
+
+#  query to update the status of the feeds based on the service date range of the latest dataset
+def update_feed_statuses_query(session: "Session"):
+    today = date.today()
+
+    latest_dataset_subq = (
+        session.query(
+            Gtfsdataset.feed_id,
+            Gtfsdataset.service_date_range_start,
+            Gtfsdataset.service_date_range_end,
+        )
+        .filter(
+            Gtfsdataset.latest.is_(True),
+            Gtfsdataset.service_date_range_start.isnot(None),
+            Gtfsdataset.service_date_range_end.isnot(None)
+        )
+        .subquery()
+    )
+
+    new_status = case(
+        (
+            latest_dataset_subq.c.service_date_range_end < today,
+            text("'inactive'::status"),
+        ),
+        (
+            latest_dataset_subq.c.service_date_range_start > today,
+            text("'future'::status"),
+        ),
+        (
+            (latest_dataset_subq.c.service_date_range_start <= today)
+            & (latest_dataset_subq.c.service_date_range_end >= today),
+            text("'active'::status"),
+        ),
+    )
+
+    updated_count = (
+        session.query(Feed)
+        .filter(
+            Feed.status != text("'deprecated'::status"),
+            Feed.status != text("'development'::status"),
+            Feed.id == latest_dataset_subq.c.feed_id
+        )
+        .update({Feed.status: new_status}, synchronize_session=False)
+    )
+
+    try:
+        session.commit()
+        logging.info("Feed Database changes committed.")
+        session.close()
+        return updated_count
+    except Exception as e:
+        logging.error("Error committing changes:", e)
+        session.rollback()
+        session.close()
+        raise Exception(f"Error creating dataset: {e}")
+
+
+@functions_framework.http
+def update_feed_status(_):
+    """Updates the Feed status based on the latets dataset service date range."""
+    Logger.init_logger()
+    db = Database(database_url=os.getenv("FEEDS_DATABASE_URL"))
+    update_count = 0
+    try:
+        with db.start_db_session() as session:
+            logging.info("Database session started.")
+            update_count = update_feed_statuses_query(session)
+
+    except Exception as error:
+        logging.error(f"Error updating the feed statuses: {error}")
+        return f"Error updating the feed statuses: {error}", 500
+
+    return f"Script executed successfully. {update_count} feeds updated", 200

--- a/functions-python/update_feed_status/src/main.py
+++ b/functions-python/update_feed_status/src/main.py
@@ -27,7 +27,7 @@ def update_feed_statuses_query(session: "Session"):
         .filter(
             Gtfsdataset.latest.is_(True),
             Gtfsdataset.service_date_range_start.isnot(None),
-            Gtfsdataset.service_date_range_end.isnot(None)
+            Gtfsdataset.service_date_range_end.isnot(None),
         )
         .subquery()
     )
@@ -53,7 +53,7 @@ def update_feed_statuses_query(session: "Session"):
         .filter(
             Feed.status != text("'deprecated'::status"),
             Feed.status != text("'development'::status"),
-            Feed.id == latest_dataset_subq.c.feed_id
+            Feed.id == latest_dataset_subq.c.feed_id,
         )
         .update({Feed.status: new_status}, synchronize_session=False)
     )

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -2,7 +2,6 @@ from unittest.mock import patch, MagicMock
 from test_shared.test_utils.database_utils import default_db_url
 from main import update_feed_status, update_feed_statuses_query
 from datetime import date, timedelta
-import pytest
 
 import os
 

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, MagicMock
 from test_shared.test_utils.database_utils import default_db_url
 from main import update_feed_status, update_feed_statuses_query
 from datetime import date, timedelta
+import pytest
 
 import os
 
@@ -26,6 +27,28 @@ def test_update_feed_status_return():
 
     assert updated_count == 3
     mock_session.commit.assert_called_once()
+
+
+def test_update_feed_status_failed_query():
+    mock_session = MagicMock()
+
+    today = date(2025, 3, 1)
+
+    mock_subquery = MagicMock()
+    mock_subquery.c.feed_id = 1
+    mock_subquery.c.service_date_range_start = today - timedelta(days=10)
+    mock_subquery.c.service_date_range_end = today + timedelta(days=10)
+
+    mock_query = mock_session.query.return_value
+    mock_query.filter.return_value.subquery.return_value = mock_subquery
+
+    mock_update_query = mock_session.query.return_value.filter.return_value
+    mock_update_query.update.side_effect = Exception("Mocked exception")
+
+    try:
+        update_feed_statuses_query(mock_session)
+    except Exception as e:
+        assert str(e) == "Error updating feed statuses: Mocked exception"
 
 
 @patch("main.Logger", autospec=True)

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -1,0 +1,59 @@
+# from unittest.mock import patch, Mock, MagicMock
+# from main import backfill_datasets, backfill_dataset_service_date_range, is_version_gte
+# from shared.database_gen.sqlacodegen_models import Gtfsdataset
+# from test_shared.test_utils.database_utils import default_db_url
+
+from unittest.mock import patch, MagicMock
+from test_shared.test_utils.database_utils import default_db_url
+from main import update_feed_status, update_feed_statuses_query
+from datetime import date, timedelta
+
+import os
+
+
+def test_update_feed_status_return():
+    mock_session = MagicMock()
+
+    today = date(2025, 3, 1)
+
+    mock_subquery = MagicMock()
+    mock_subquery.c.feed_id = 1
+    mock_subquery.c.service_date_range_start = today - timedelta(days=10)
+    mock_subquery.c.service_date_range_end = today + timedelta(days=10)
+
+    mock_query = mock_session.query.return_value
+    mock_query.filter.return_value.subquery.return_value = mock_subquery
+
+    mock_update_query = mock_session.query.return_value.filter.return_value
+    mock_update_query.update.return_value = 3
+
+    updated_count = update_feed_statuses_query(mock_session)
+
+    assert updated_count == 3
+    mock_session.commit.assert_called_once()
+
+
+@patch("main.Logger", autospec=True)
+@patch("main.update_feed_statuses_query")
+def test_updated_feed_status(mock_update_query, mock_logger):
+    mock_update_query.return_value = 5
+
+    with patch.dict(os.environ, {"FEEDS_DATABASE_URL": default_db_url}):
+        response_body, status_code = update_feed_status(None)
+
+    mock_update_query.asser_called_once()
+    assert response_body == "Script executed successfully. 5 feeds updated"
+    assert status_code == 200
+
+
+@patch("main.Logger", autospec=True)
+@patch("main.update_feed_statuses_query")
+def test_updated_feed_status_error_raised(mock_update_query, mock_logger):
+    mock_update_query.side_effect = Exception("Mocked exception")
+
+    with patch.dict(os.environ, {"FEEDS_DATABASE_URL": default_db_url}):
+        response_body, status_code = update_feed_status(None)
+
+    mock_update_query.asser_called_once()
+    assert response_body == "Error updating the feed statuses: Mocked exception"
+    assert status_code == 500

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -1,8 +1,3 @@
-# from unittest.mock import patch, Mock, MagicMock
-# from main import backfill_datasets, backfill_dataset_service_date_range, is_version_gte
-# from shared.database_gen.sqlacodegen_models import Gtfsdataset
-# from test_shared.test_utils.database_utils import default_db_url
-
 from unittest.mock import patch, MagicMock
 from test_shared.test_utils.database_utils import default_db_url
 from main import update_feed_status, update_feed_statuses_query

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -36,4 +36,5 @@
     <include file="changes/feat_871.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_880.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_880_2.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_879.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_879.sql
+++ b/liquibase/changes/feat_879.sql
@@ -1,0 +1,1 @@
+ALTER TYPE Status ADD VALUE 'future';


### PR DESCRIPTION
#879 
**Summary:**

- Python function to update the feed status based on the latest dataset service date range
- Updated the schema so that `Feed.status` enum includes 'future'

**Expected behavior:** 

When the `/update_feed_status` function is run, it should update all Feeds (excluding status: 'deprecated' and 'development') based on the Feeds latest dataset service date range

**Follow up tickets**
Because timezone tickets are coming up, I figured it would be better to wait until that code goes in and manually test the python function before setting up the google cloud scheduler. The ticket to set up the scheduler has been created

**Testing tips:**

Locally you can run the function
```
./scripts/function-python-run.sh --function_name update_feed_status --build
```
and modify values in the database to assure the logic is working as expected

Picture when the function was run against the DEV databse. NOTE: I had to modify the 'future' status during the test since the DEV db doesn't have the schema changes done in this ticket
![Screenshot 2025-03-06 at 09 13 43](https://github.com/user-attachments/assets/56e73981-7f01-42cb-9b6d-cda70db30f86)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [X] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
