### PR TITLE
fix: process validation report fails when service date fields are empty

### DIFF
--- a/functions-python/README.md
+++ b/functions-python/README.md
@@ -156,6 +156,13 @@ or
 ```
 scripts/api-tests.sh --folder functions-python
 ```
+
+To run the tests and generate the html coverage report:
+```
+scripts/api-tests.sh --folder functions-python --html_report
+```
+_The coverage reports are located in `{project}/scripts/coverage_reports` as individual folder per function._
+
 This will 
 - run the `function-python-setup.sh` script for the function (ie create the `shared` and `test_shared` folders with symlinks) 
 - Create a python virtual environment in the function folder, e.g.: `functions-python/batch_datasets/venv`

--- a/functions-python/helpers/tests/test_transform.py
+++ b/functions-python/helpers/tests/test_transform.py
@@ -1,4 +1,4 @@
-from transform import to_boolean
+from transform import to_boolean, get_nested_value
 
 
 def test_to_boolean():
@@ -19,3 +19,44 @@ def test_to_boolean():
     assert to_boolean(None) is False
     assert to_boolean([]) is False
     assert to_boolean({}) is False
+
+
+def test_get_nested_value():
+    # Test case 1: Nested dictionary with string value
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "b", "c"]) == "d"
+
+    # Test case 2: Nested dictionary with integer value
+    assert get_nested_value({"a": {"b": {"c": 1}}}, ["a", "b", "c"]) == 1
+
+    # Test case 3: Nested dictionary with float value
+    assert get_nested_value({"a": {"b": {"c": 1.5}}}, ["a", "b", "c"]) == 1.5
+
+    # Test case 4: Nested dictionary with boolean value
+    assert get_nested_value({"a": {"b": {"c": True}}}, ["a", "b", "c"]) is True
+
+    # Test case 5: Nested dictionary with string value that needs trimming
+    assert get_nested_value({"a": {"b": {"c": "  d  "}}}, ["a", "b", "c"]) == "d"
+
+    # Test case 6: Key not found in the dictionary
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "b", "x"]) is None
+    assert (
+        get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "b", "x"], "default")
+        == "default"
+    )
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "b", "x"], []) == []
+
+    # Test case 7: Intermediate key not found in the dictionary
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "x", "c"]) is None
+    assert (
+        get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "x", "c"], "default")
+        == "default"
+    )
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, ["a", "x", "c"], []) == []
+
+    # Test case 8: Empty keys list
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, []) is None
+    assert get_nested_value({"a": {"b": {"c": "d"}}}, [], {}) == {}
+
+    # Test case 9: Non-dictionary data
+    assert get_nested_value("not a dict", ["a", "b", "c"]) is None
+    assert get_nested_value("not a dict", ["a", "b", "c"], []) == []

--- a/functions-python/helpers/transform.py
+++ b/functions-python/helpers/transform.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from typing import List, Optional
 
 
 def to_boolean(value):
@@ -24,3 +25,31 @@ def to_boolean(value):
     if isinstance(value, str):
         return value.lower() in ["true", "1", "yes", "y"]
     return False
+
+
+def get_nested_value(
+    data: dict, keys: List[str], default_value: Optional[any] = None
+) -> Optional[any]:
+    """
+    Retrieve the value from a nested dictionary given a list of keys.
+
+    Args:
+        data (dict): The dictionary to search.
+        keys (List[str]): The list of keys representing the path to the field.
+        default_value: The value to return if the field is not found.
+
+    Returns:
+        Optional[str, int, float, bool, dict]: The value if found and valid, otherwise None. The str values are trimmed.
+    """
+    if not keys:
+        return default_value
+    current_data = data
+    for key in keys:
+        if isinstance(current_data, dict) and key in current_data:
+            current_data = current_data[key]
+        else:
+            return default_value
+    if isinstance(current_data, str):
+        result = current_data.strip()
+        return result if result else default_value
+    return current_data

--- a/functions-python/helpers/transform.py
+++ b/functions-python/helpers/transform.py
@@ -39,7 +39,7 @@ def get_nested_value(
         default_value: The value to return if the field is not found.
 
     Returns:
-        Optional[str, int, float, bool, dict]: The value if found and valid, otherwise None. The str values are trimmed.
+        Optional[any]: The value if found and valid, otherwise None. The str values are trimmed.
     """
     if not keys:
         return default_value

--- a/functions-python/process_validation_report/src/main.py
+++ b/functions-python/process_validation_report/src/main.py
@@ -27,6 +27,7 @@ from shared.database_gen.sqlacodegen_models import (
     Gtfsdataset,
 )
 from shared.helpers.logger import Logger
+from src.shared.helpers.transform import get_nested_value
 
 logging.basicConfig(level=logging.INFO)
 
@@ -149,20 +150,9 @@ def generate_report_entities(
     dataset = get_dataset(dataset_stable_id, session)
     dataset.validation_reports.append(validation_report_entity)
 
-    if (
-        "summary" in json_report
-        and "feedInfo" in json_report["summary"]
-        and "feedServiceWindowStart" in json_report["summary"]["feedInfo"]
-        and "feedServiceWindowEnd" in json_report["summary"]["feedInfo"]
-    ):
-        dataset.service_date_range_start = json_report["summary"]["feedInfo"][
-            "feedServiceWindowStart"
-        ]
-        dataset.service_date_range_end = json_report["summary"]["feedInfo"][
-            "feedServiceWindowEnd"
-        ]
+    populate_service_date(dataset, json_report)
 
-    for feature_name in json_report["summary"]["gtfsFeatures"]:
+    for feature_name in get_nested_value(json_report, ["summary", "gtfsFeatures"], []):
         feature = get_feature(feature_name, session)
         feature.validations.append(validation_report_entity)
         entities.append(feature)
@@ -177,6 +167,18 @@ def generate_report_entities(
         dataset.notices.append(notice_entity)
         entities.append(notice_entity)
     return entities
+
+
+def populate_service_date(dataset, json_report):
+    feed_service_window_start = get_nested_value(
+        json_report, ["summary", "feedInfo", "feedServiceWindowStart"]
+    )
+    feed_service_window_end = get_nested_value(
+        json_report, ["summary", "feedInfo", "feedServiceWindowEnd"]
+    )
+    if feed_service_window_start and feed_service_window_end:
+        dataset.service_date_range_start = feed_service_window_start
+        dataset.service_date_range_end = feed_service_window_end
 
 
 def create_validation_report_entities(feed_stable_id, dataset_stable_id, version):

--- a/functions-python/process_validation_report/src/main.py
+++ b/functions-python/process_validation_report/src/main.py
@@ -170,6 +170,11 @@ def generate_report_entities(
 
 
 def populate_service_date(dataset, json_report):
+    """
+    Populates the service date range of the dataset based on the JSON report.
+    The service date range is extracted from the feedServiceWindowStart and feedServiceWindowEnd fields,
+     if both are present and not empty.
+    """
     feed_service_window_start = get_nested_value(
         json_report, ["summary", "feedInfo", "feedServiceWindowStart"]
     )

--- a/functions-python/process_validation_report/src/main.py
+++ b/functions-python/process_validation_report/src/main.py
@@ -27,7 +27,7 @@ from shared.database_gen.sqlacodegen_models import (
     Gtfsdataset,
 )
 from shared.helpers.logger import Logger
-from src.shared.helpers.transform import get_nested_value
+from shared.helpers.transform import get_nested_value
 
 logging.basicConfig(level=logging.INFO)
 

--- a/functions-python/process_validation_report/tests/test_validation_report.py
+++ b/functions-python/process_validation_report/tests/test_validation_report.py
@@ -208,9 +208,8 @@ class TestValidationReportProcessor(unittest.TestCase):
         self.assertEqual(status, 400)
         create_validation_report_entities_mock.assert_not_called()
 
-
     def test_populate_service_date_valid_dates(self):
-        """Test populate_service_date function."""
+        """Test populate_service_date function with valid date values."""
         dataset = Gtfsdataset(
             id=faker.word(), feed_id=faker.word(), stable_id=faker.word(), latest=True
         )
@@ -227,7 +226,6 @@ class TestValidationReportProcessor(unittest.TestCase):
 
         self.assertEqual(dataset.service_date_range_start, "2024-01-01")
         self.assertEqual(dataset.service_date_range_end, "2024-12-31")
-
 
     def test_populate_service_date_valid_empty_dates(self):
         """Test populate_service_date function."""
@@ -251,6 +249,30 @@ class TestValidationReportProcessor(unittest.TestCase):
                 "feedInfo": {
                     "feedServiceWindowStart": "2024-12-31",
                     "feedServiceWindowEnd": "",
+                }
+            }
+        }
+        populate_service_date(dataset, json_report)
+        self.assertEqual(dataset.service_date_range_start, None)
+        self.assertEqual(dataset.service_date_range_end, None)
+
+        json_report = {
+            "summary": {
+                "feedInfo": {
+                    "feedServiceWindowStart": "2024-12-31",
+                    "feedServiceWindowEnd": None,
+                }
+            }
+        }
+        populate_service_date(dataset, json_report)
+        self.assertEqual(dataset.service_date_range_start, None)
+        self.assertEqual(dataset.service_date_range_end, None)
+
+        json_report = {
+            "summary": {
+                "feedInfo": {
+                    "feedServiceWindowStart": None,
+                    "feedServiceWindowEnd": "2024-12-31",
                 }
             }
         }


### PR DESCRIPTION
**Summary:**

The process validation report fails when an empty string(`""`) is found on the JSON value. This PR ignores the empty string values from the fields; it also adds a helper method to be used in similar situations.

**Expected behavior:** 

The process validation report function should account for missing or empty service date fields

### From our AI friend

This pull request includes several changes to add new functionality and improve the codebase for the `functions-python` project. The most important changes include adding a new helper function `get_nested_value`, updating the `README.md` file with instructions for generating HTML coverage reports, and refactoring the `generate_report_entities` function to use the new helper function.

### New functionality:
* [`functions-python/helpers/transform.py`](diffhunk://#diff-54949798e830abf611cca0a807560fce2f8ebde4d567dd3df6ec90a3632fc091R28-R55): Added a new helper function `get_nested_value` to retrieve values from nested dictionaries.
* [`functions-python/helpers/tests/test_transform.py`](diffhunk://#diff-41e385dd46873842b435e51fd6cfe89b12737e5a8780583a9fff0329eb71e18dR22-R62): Added tests for the new `get_nested_value` function.

### Documentation updates:
* [`functions-python/README.md`](diffhunk://#diff-2e0ff130ef27661502c20fa1be7e22d25a89b17557ce2069e76d9702c6251dc3R159-R165): Updated the README file to include instructions for running tests and generating HTML coverage reports.

### Code refactoring:
* [`functions-python/process_validation_report/src/main.py`](diffhunk://#diff-ffccc4e4a82f8edc4ec6403ba2ecf29b826def673452d3c472714a5502eaf834L152-R155): Refactored the `generate_report_entities` function to use the new `get_nested_value` function and moved the service date population logic to a new `populate_service_date` function. [[1]](diffhunk://#diff-ffccc4e4a82f8edc4ec6403ba2ecf29b826def673452d3c472714a5502eaf834L152-R155) [[2]](diffhunk://#diff-ffccc4e4a82f8edc4ec6403ba2ecf29b826def673452d3c472714a5502eaf834R172-R183)
* [`functions-python/process_validation_report/tests/test_validation_report.py`](diffhunk://#diff-7ebd59ca9faee988b6d5d2aa6374d286a2f71d0660bb556abc2d466a13d38fc9R210-R259): Added tests for the new `populate_service_date` function.

**Testing tips:**

Teste in DEV, [link](https://mobility-feeds-dev--pr-979-iznwja3c.web.app/feeds/mdb-417)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
