### PR TITLE
fix: gbfs validator scheduler failure

### DIFF
--- a/functions-python/gbfs_validator/src/gbfs_utils.py
+++ b/functions-python/gbfs_validator/src/gbfs_utils.py
@@ -12,7 +12,9 @@ from shared.database_gen.sqlacodegen_models import (
     Gbfsvalidationreport,
     Gbfsnotice,
 )
+from sqlalchemy.orm import Session
 from shared.dataset_service.main import Status
+from shared.helpers.database import with_db_session
 
 
 class GBFSValidator:
@@ -107,8 +109,9 @@ class GBFSValidator:
         }
 
 
+@with_db_session(echo=False)
 def save_snapshot_and_report(
-    session, snapshot: Gbfssnapshot, validation_result: Dict[str, Any]
+    snapshot: Gbfssnapshot, validation_result: Dict[str, Any], db_session: Session
 ):
     """Save the snapshot and validation report to the database."""
     validation_report = Gbfsvalidationreport(
@@ -132,8 +135,8 @@ def save_snapshot_and_report(
         for error in file_summary["groupedErrors"]
     ]
     snapshot.gbfsvalidationreports = [validation_report]
-    session.add(snapshot)
-    session.commit()
+    db_session.add(snapshot)
+    db_session.commit()
 
 
 def fetch_gbfs_files(url: str) -> Dict[str, Any]:

--- a/functions-python/gbfs_validator/tests/test_gbfs_utils.py
+++ b/functions-python/gbfs_validator/tests/test_gbfs_utils.py
@@ -175,7 +175,9 @@ class TestGbfsUtils(unittest.TestCase):
             },
         }
 
-        save_snapshot_and_report(mock_session, mock_snapshot, validation_result)
+        save_snapshot_and_report(
+            mock_snapshot, validation_result, db_session=mock_session
+        )
 
         mock_session.add.assert_called_once_with(mock_snapshot)
         mock_session.commit.assert_called_once()

--- a/functions-python/gbfs_validator/tests/test_gbfs_validator.py
+++ b/functions-python/gbfs_validator/tests/test_gbfs_validator.py
@@ -33,7 +33,6 @@ class TestMainFunctions(unittest.TestCase):
             "VALIDATOR_URL": "https://mock-validator-url.com",
         },
     )
-    @patch("main.Database")
     @patch("main.DatasetTraceService")
     @patch("main.fetch_gbfs_files")
     @patch("main.GBFSValidator.create_gbfs_json_with_bucket_paths")
@@ -52,12 +51,8 @@ class TestMainFunctions(unittest.TestCase):
         mock_create_gbfs_json,
         mock_fetch_gbfs_files,
         mock_dataset_trace_service,
-        mock_database,
     ):
         # Prepare mocks
-        mock_session = MagicMock()
-        mock_database.return_value.start_db_session.return_value = mock_session
-
         mock_trace_service = MagicMock()
         mock_dataset_trace_service.return_value = mock_trace_service
 


### PR DESCRIPTION
**Summary**  
Closes #940  

 **Bug Explanation**  
The issue was caused by **detached SQLAlchemy entities** when fetching GBFS feeds. Since we now manage database sessions more strictly (with automatic session closure in `@with_db_session`), the entities returned from `fetch_all_gbfs_feeds` were detached.  
As a result, when trying to access relationships like `gbfsversions` later in the batch function, we encountered a `DetachedInstanceError`.  

**Fix**  
To fix this issue, I explicitly **detach** the instances from the session right after fetching them. Additionally, we need to ensure that all necessary relationships (like `gbfsversions`) are eagerly loaded, so that all needed data is available even after detaching.  


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
