### PR TITLE
fix: service date range order

### DIFF
--- a/functions-python/backfill_dataset_service_date_range/src/main.py
+++ b/functions-python/backfill_dataset_service_date_range/src/main.py
@@ -136,7 +136,8 @@ def backfill_datasets(session: "Session"):
                 )
                 continue
 
-            # this check is due to an issue in the validation report where the start date could be later than the end date
+            # this check is due to an issue in the validation report
+            # where the start date could be later than the end date
             if extracted_service_start_date > extracted_service_end_date:
                 dataset.service_date_range_start = extracted_service_end_date
                 dataset.service_date_range_end = extracted_service_start_date

--- a/functions-python/backfill_dataset_service_date_range/src/main.py
+++ b/functions-python/backfill_dataset_service_date_range/src/main.py
@@ -136,8 +136,13 @@ def backfill_datasets(session: "Session"):
                 )
                 continue
 
-            dataset.service_date_range_start = extracted_service_start_date
-            dataset.service_date_range_end = extracted_service_end_date
+            # this check is due to an issue in the validation report where the start date could be later than the end date
+            if extracted_service_start_date > extracted_service_end_date:
+                dataset.service_date_range_start = extracted_service_end_date
+                dataset.service_date_range_end = extracted_service_start_date
+            else:
+                dataset.service_date_range_start = extracted_service_start_date
+                dataset.service_date_range_end = extracted_service_end_date
 
             formatted_dates = (
                 extracted_service_start_date + " - " + extracted_service_end_date

--- a/functions-python/backfill_dataset_service_date_range/tests/test_backfill_dataset_service_date_range_main.py
+++ b/functions-python/backfill_dataset_service_date_range/tests/test_backfill_dataset_service_date_range_main.py
@@ -82,6 +82,70 @@ def test_backfill_datasets(mock_get, mock_storage_client):
     )  # latest validation report
     mock_session.commit.assert_called_once()
 
+@patch("google.cloud.storage.Client", autospec=True)
+@patch("requests.get")
+def test_backfill_datasets_service_date_range_swap(mock_get, mock_storage_client):
+    # Mock the storage client and bucket
+    mock_bucket = MagicMock()
+    mock_client_instance = mock_storage_client.return_value
+    mock_client_instance.bucket.return_value = mock_bucket
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = False
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_session = MagicMock()
+    mock_dataset = Mock(spec=Gtfsdataset)
+    mock_dataset.id = 1
+    mock_dataset.stable_id = "mdb-392-202406181921"
+    mock_dataset.service_date_range_end = None
+    mock_dataset.service_date_range_start = None
+    mock_dataset.validation_reports = [
+        MagicMock(
+            validator_version="6.0.0",
+            validated_at="2022-01-01T00:00:00Z",
+            json_report="http://example-2.com/report.json",
+        ),
+        MagicMock(
+            validator_version="5.0.0",
+            validated_at="2023-01-01T00:00:00Z",
+            json_report="http://example-3.com/report.json",
+        ),
+        MagicMock(
+            validator_version="6.0.0",
+            validated_at="2024-01-01T00:00:00Z",
+            json_report="http://example-1.com/report.json",
+        ),
+    ]
+
+    mock_query = MagicMock()
+    mock_query.options.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.all.return_value = [mock_dataset]
+    mock_session.query.return_value = mock_query
+
+    # Mock the requests.get response
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "summary": {
+            "feedInfo": {
+                "feedServiceWindowStart": "2023-12-31",
+                "feedServiceWindowEnd": "2023-01-01",
+            }
+        }
+    }
+    mock_get.return_value = mock_response
+
+    changes_count = backfill_datasets(mock_session)
+
+    assert changes_count == 1
+    assert mock_dataset.service_date_range_start == "2023-01-01"
+    assert mock_dataset.service_date_range_end == "2023-12-31"
+    mock_get.assert_called_once_with(
+        "http://example-1.com/report.json"
+    )  # latest validation report
+    mock_session.commit.assert_called_once()
+
 
 @patch("logging.error", autospec=True)
 @patch("google.cloud.storage.Client", autospec=True)

--- a/functions-python/backfill_dataset_service_date_range/tests/test_backfill_dataset_service_date_range_main.py
+++ b/functions-python/backfill_dataset_service_date_range/tests/test_backfill_dataset_service_date_range_main.py
@@ -82,6 +82,7 @@ def test_backfill_datasets(mock_get, mock_storage_client):
     )  # latest validation report
     mock_session.commit.assert_called_once()
 
+
 @patch("google.cloud.storage.Client", autospec=True)
 @patch("requests.get")
 def test_backfill_datasets_service_date_range_swap(mock_get, mock_storage_client):

--- a/functions-python/process_validation_report/src/main.py
+++ b/functions-python/process_validation_report/src/main.py
@@ -182,8 +182,13 @@ def populate_service_date(dataset, json_report):
         json_report, ["summary", "feedInfo", "feedServiceWindowEnd"]
     )
     if feed_service_window_start and feed_service_window_end:
-        dataset.service_date_range_start = feed_service_window_start
-        dataset.service_date_range_end = feed_service_window_end
+        # this check is due to an issue in the validation report where the start date could be later than the end date
+        if feed_service_window_start > feed_service_window_end:
+            dataset.service_date_range_start = feed_service_window_end
+            dataset.service_date_range_end = feed_service_window_start
+        else:
+            dataset.service_date_range_start = feed_service_window_start
+            dataset.service_date_range_end = feed_service_window_end
 
 
 def create_validation_report_entities(feed_stable_id, dataset_stable_id, version):


### PR DESCRIPTION
**Summary:**

In the validation report it's possible that the service date range start is later than the end. This PR will always use the latest date for the end, and the earlier date in the start. 

Affected functions:
- backfill
- validation report processor

**Expected behavior:** 

The earlier service date range will always be set to start
The latest service date range will always be set to end

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
