### PR TITLE
fix: db query and memory limit

### DIFF
--- a/infra/feed-api/main.tf
+++ b/infra/feed-api/main.tf
@@ -76,7 +76,7 @@ resource "google_cloud_run_v2_service" "mobility-feed-api" {
       resources {
         limits = {
           cpu    = "1"
-          memory = "1Gi"
+          memory = "2Gi"
         }
       }
     }


### PR DESCRIPTION
**Summary:**
- ✅ Changed database query to load only the latest dataset in `gtfs_feeds` endpoint. The query now takes less than 10 seconds to run and consumes less than 1GB memory when pointing the local api to the prod database.
- ✅ Increased API memory limit
Please make sure these boxes are checked before submitting your pull request - thanks!
Closes #548 

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
