### PR TITLE
Feat: feed detail page, timezone + dataset service date range

### DIFF
--- a/web-app/public/locales/en/common.json
+++ b/web-app/public/locales/en/common.json
@@ -16,6 +16,7 @@
         "serviceAlerts": "Service Alerts"
     },
     "loading": "Loading...",
+    "download": "Download",
     "errors": {
         "generic": "We are unable to complete your request at the moment."
     },

--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -101,7 +101,7 @@
   "qualityReportUpdated": "Quality report updated",
   "officialFeedUpdated": "Official verification updated",
   "serviceDateRange": "Service Date Range",
-  "serviceDateRangeTooltip": "Dates are relative to local timezone",
+  "serviceDateRangeTooltip": "Dates are relative to the specified timezone. If no timezone is specified, the dates are in UTC.",
   "heatmapIntensity": "Stop Density",
   "heatmapExplanationTitle": "What does this mean?",
   "heatmapExplanationContent": "This color scale shows the percentage of stops from <code>stops.txt</code> that are located within each geographic area. Darker colors indicate areas where a higher percentage of stops are covered.",
@@ -128,5 +128,16 @@
       "toolTip": "Future Feed",
       "toolTipLong": "This feed is not yet active but will be used in the future."
     }
+  },
+  "datasetHistory": "Dataset History",
+  "datasetHistoryDescription": "The Mobility Database fetches and stores new datasets twice a week, on Mondays and Thursdays at midnight EST.",
+  "datasets": "Datasets",
+  "validationReportNotAvailable": "Validation report not available",
+  "runValidationReportYourself": "Run Validator Yourself",
+  "datasetHistoryTooltip": {
+    "serviceDateRange": "Service date range of when this dataset is active",
+    "downloadReport": "Download the dataset for this feed",
+    "viewReport": "View Validation Report",
+    "viewJsonReport": "View Validation Report in JSON format"
   }
 }

--- a/web-app/src/app/screens/Feed/Feed.functions.tsx
+++ b/web-app/src/app/screens/Feed/Feed.functions.tsx
@@ -1,3 +1,4 @@
+import { Box, Typography } from '@mui/material';
 import { type TFunction } from 'i18next';
 
 export function formatProvidersSorted(provider: string): string[] {
@@ -62,3 +63,37 @@ export function generatePageTitle(
   newDocTitle += 'Mobility Database';
   return newDocTitle;
 }
+
+export const formatServiceDateRange = (
+  dateStart: string,
+  dateEnd: string,
+  timeZone?: string,
+): JSX.Element => {
+  const startDate = new Date(dateStart);
+  const endDate = new Date(dateEnd);
+  const usedTimezone = timeZone ?? 'UTC';
+  // Note: If the timezone isn't set, it will default to UTC
+  // If the timezone is set, but has an invalid value, it will default to the user's local timezone
+  const formattedDateStart = new Intl.DateTimeFormat('en-US', {
+    timeZone: usedTimezone,
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(startDate);
+  const formattedDateEnd = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(endDate);
+  return (
+    <Box>
+      <Typography variant='body1'>
+        {formattedDateStart}{' '}
+        <Typography component={'span'} sx={{ mx: 1, fontSize: '14px' }}>
+          -
+        </Typography>{' '}
+        {formattedDateEnd}
+      </Typography>
+    </Box>
+  );
+};

--- a/web-app/src/app/screens/Feed/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/FeedSummary.tsx
@@ -31,8 +31,10 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import DateRangeIcon from '@mui/icons-material/DateRange';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { FeedStatusIndicator } from '../../components/FeedStatus';
 import Locations from '../../components/Locations';
+import { formatServiceDateRange } from './Feed.functions';
 
 export interface FeedSummaryProps {
   feed: GTFSFeedType | GTFSRTFeedType | undefined;
@@ -75,35 +77,6 @@ const ResponsiveListItem = styled('li')(({ theme }) => ({
     width: 'calc(50% - 15px)',
   },
 }));
-
-const formatServiceDateRange = (
-  dateStart: string,
-  dateEnd: string,
-): JSX.Element => {
-  const startDate = new Date(dateStart);
-  const endDate = new Date(dateEnd);
-  const formattedDateStart = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(startDate);
-  const formattedDateEnd = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(endDate);
-  return (
-    <Box>
-      <Typography variant='body1'>
-        {formattedDateStart}{' '}
-        <Typography component={'span'} sx={{ mx: 2, fontSize: '14px' }}>
-          -
-        </Typography>{' '}
-        {formattedDateEnd}
-      </Typography>
-    </Box>
-  );
-};
 
 export default function FeedSummary({
   feed,
@@ -190,6 +163,19 @@ export default function FeedSummary({
           )}
         </Box>
       </Box>
+      {latestDataset?.agency_timezone != undefined && (
+        <Box sx={boxElementStyle}>
+          <StyledTitleContainer>
+            <AccessTimeIcon></AccessTimeIcon>
+            <Typography variant='subtitle1' sx={{ fontWeight: 'bold' }}>
+              Agency Timezone
+            </Typography>
+          </StyledTitleContainer>
+          <Typography variant='body1'>
+            {latestDataset.agency_timezone}
+          </Typography>
+        </Box>
+      )}
       {latestDataset?.service_date_range_start != undefined &&
         latestDataset.service_date_range_end != undefined && (
           <Box sx={boxElementStyle}>
@@ -208,6 +194,7 @@ export default function FeedSummary({
               {formatServiceDateRange(
                 latestDataset?.service_date_range_start,
                 latestDataset?.service_date_range_end,
+                latestDataset.agency_timezone,
               )}
               <FeedStatusIndicator
                 status={feed?.status ?? ''}

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -4,11 +4,13 @@ import {
   Box,
   Button,
   Chip,
+  IconButton,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableRow,
+  Tooltip,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -20,7 +22,12 @@ import {
 } from '@mui/icons-material';
 import { type paths } from '../../services/feeds/types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import SummarizeIcon from '@mui/icons-material/Summarize';
+import CodeIcon from '@mui/icons-material/Code';
+import DateRangeIcon from '@mui/icons-material/DateRange';
 import { WEB_VALIDATOR_LINK } from '../../constants/Navigation';
+import { formatServiceDateRange } from './Feed.functions';
+import { useTranslation } from 'react-i18next';
 
 export interface PreviousDatasetsProps {
   datasets:
@@ -32,22 +39,20 @@ export default function PreviousDatasets({
   datasets,
 }: PreviousDatasetsProps): React.ReactElement {
   const theme = useTheme();
+  const { t } = useTranslation('feeds');
   return (
     <>
       <Typography
         sx={{ fontSize: { xs: 18, sm: 24 }, fontWeight: 'bold', mb: 1 }}
       >
-        Dataset History
+        {t('datasetHistory')}
       </Typography>
-      <Typography>
-        The Mobility Database fetches and stores new datasets twice a week, on
-        Mondays and Thursdays at midnight EST.{' '}
-      </Typography>
+      <Typography>{t('datasetHistoryDescription')}</Typography>
 
       {datasets !== undefined && datasets.length > 0 && (
         <Box sx={{ mt: 2, mb: 2, display: 'flex' }}>
           <Typography sx={{ fontWeight: 'bold' }}>
-            {datasets.length} Datasets
+            {datasets.length} {t('datasets')}
           </Typography>
         </Box>
       )}
@@ -72,26 +77,42 @@ export default function PreviousDatasets({
                     </TableCell>
                   )}
                   <TableCell>
-                    <Button
-                      variant='text'
-                      disableElevation
-                      endIcon={<DownloadOutlined />}
-                      href={dataset.hosted_url}
-                    >
-                      Download
-                    </Button>
+                    {dataset?.service_date_range_start != undefined &&
+                      dataset?.service_date_range_end != undefined && (
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
+                          <Tooltip
+                            title={t('datasetHistoryTooltip.serviceDateRange')}
+                            placement='top'
+                          >
+                            <DateRangeIcon></DateRangeIcon>
+                          </Tooltip>
+
+                          {formatServiceDateRange(
+                            dataset?.service_date_range_start,
+                            dataset?.service_date_range_end,
+                            dataset.agency_timezone,
+                          )}
+                        </Box>
+                      )}
                   </TableCell>
                   <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
                     {(dataset.validation_report === null ||
                       dataset.validation_report === undefined) && (
                       <Typography sx={{ ml: '4px' }}>
-                        Validation report not available
+                        {t('validationReportNotAvailable')}
                       </Typography>
                     )}
                     {dataset.validation_report !== null &&
                       dataset.validation_report !== undefined && (
                         <>
                           <Chip
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
                             sx={{ m: '4px' }}
                             icon={
                               dataset?.validation_report?.unique_error_count !==
@@ -107,8 +128,11 @@ export default function PreviousDatasets({
                               dataset?.validation_report?.unique_error_count !==
                                 undefined &&
                               dataset?.validation_report?.unique_error_count > 0
-                                ? `${dataset?.validation_report?.unique_error_count} errors`
-                                : `No errors`
+                                ? `${dataset?.validation_report
+                                    ?.unique_error_count} ${t(
+                                    'common:feedback.errors',
+                                  )}`
+                                : t('common:feedback.noErrors')
                             }
                             color={
                               dataset?.validation_report?.unique_error_count !==
@@ -121,6 +145,11 @@ export default function PreviousDatasets({
                           />
                           <Chip
                             sx={{ m: '4px' }}
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
                             icon={
                               dataset?.validation_report
                                 ?.unique_warning_count !== undefined &&
@@ -136,8 +165,11 @@ export default function PreviousDatasets({
                                 ?.unique_warning_count !== undefined &&
                               dataset?.validation_report?.unique_warning_count >
                                 0
-                                ? `${dataset?.validation_report?.unique_warning_count} warnings`
-                                : `No warnings`
+                                ? `${dataset?.validation_report
+                                    ?.unique_warning_count} ${t(
+                                    'common:feedback.warnings',
+                                  )}`
+                                : t('common:feedback.noWarnings')
                             }
                             color={
                               dataset?.validation_report
@@ -151,20 +183,24 @@ export default function PreviousDatasets({
                           />
                           <Chip
                             sx={{ m: '4px' }}
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
                             icon={<InfoOutlinedIcon />}
                             label={`${
                               dataset?.validation_report?.unique_info_count ??
                               '0'
-                            } info notices`}
+                            } ${t('common:feedback.infoNotices')}`}
                             color='primary'
                             variant='outlined'
                           />
                         </>
                       )}
                   </TableCell>
-                  <TableCell>
-                    {(dataset.validation_report === null ||
-                      dataset.validation_report === undefined) && (
+                  <TableCell sx={{ textAlign: 'center' }}>
+                    {dataset.validation_report == undefined && (
                       <Button
                         variant='contained'
                         sx={{ mx: 2 }}
@@ -174,35 +210,64 @@ export default function PreviousDatasets({
                         target='_blank'
                         rel='noreferrer'
                       >
-                        Run Validator Yourself
+                        {t('runValidationReportYourself')}
                       </Button>
                     )}
                     {dataset.validation_report != null && (
                       <>
-                        <Button
-                          variant='contained'
-                          sx={{ mx: 2 }}
-                          disableElevation
-                          endIcon={<LaunchOutlined />}
-                          href={`${dataset?.validation_report?.url_html}`}
-                          target='_blank'
-                          rel='noreferrer nofollow'
-                          data-testid='validation-report-html'
+                        <Tooltip
+                          title={t('datasetHistoryTooltip.downloadReport')}
+                          placement='top'
                         >
-                          View Report
-                        </Button>
-                        <Button
-                          variant='contained'
-                          sx={{ mx: 2, my: { xs: 1, xl: 0 } }}
-                          endIcon={<LaunchOutlined />}
-                          disableElevation
-                          href={`${dataset?.validation_report?.url_json}`}
-                          target='_blank'
-                          rel='noreferrer nofollow'
-                          data-testid='validation-report-json'
+                          <Button
+                            variant='text'
+                            aria-label={t(
+                              'datasetHistoryTooltip.downloadReport',
+                            )}
+                            startIcon={<DownloadOutlined />}
+                            size='medium'
+                            href={dataset.hosted_url}
+                            rel='noreferrer nofollow'
+                          >
+                            {t('common:download')}
+                          </Button>
+                        </Tooltip>
+                        |
+                        <Tooltip
+                          title={t('datasetHistoryTooltip.viewReport')}
+                          placement='top'
                         >
-                          JSON Version
-                        </Button>
+                          <IconButton
+                            color='primary'
+                            aria-label={t('datasetHistoryTooltip.viewReport')}
+                            size='medium'
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
+                            data-testid='validation-report-html'
+                          >
+                            <SummarizeIcon />
+                          </IconButton>
+                        </Tooltip>
+                        |
+                        <Tooltip
+                          title={t('datasetHistoryTooltip.viewJsonReport')}
+                          placement='top'
+                        >
+                          <IconButton
+                            color='primary'
+                            aria-label={t(
+                              'datasetHistoryTooltip.viewJsonReport',
+                            )}
+                            size='medium'
+                            href={`${dataset?.validation_report?.url_json}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
+                            data-testid='validation-report-json'
+                          >
+                            <CodeIcon />
+                          </IconButton>
+                        </Tooltip>
                       </>
                     )}
                   </TableCell>


### PR DESCRIPTION
closes #949 
**Summary:**

Includes the agency timezone in the Feed Detail page and adjusts the time according to the timezone provided (defaults to UTC if no timezone)

Redesign of the Dataset history table to include service date ranges

**Expected behavior:** 

It should display the agency timezone in the feed detail page if it exists. It should also format the service date range in accordance with the timezone (defaults to UTC)

The datasets history table should also inlcude the service date range, and you can now click on the validation report which will bring you to the html report

**Testing tips:**

Feed with timezone: feeds/gtfs/mdb-2360
Feed with many datasets: feeds/gtfs/mdb-853

otherwise go on many feeds and see if there are any errors or discrepancies 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2025-03-25 at 14 11 18](https://github.com/user-attachments/assets/807b22ee-4309-441b-9eb5-25287d845e8f)

![Screenshot 2025-03-25 at 14 11 10](https://github.com/user-attachments/assets/30ee433f-1b97-4add-a43f-9430a0f01bd5)

![Screenshot 2025-03-25 at 14 11 00](https://github.com/user-attachments/assets/b7d36abe-4035-4330-85ae-9991457a3b19)


