### PR TITLE
update feed status terraform daily

### DIFF
--- a/infra/functions-python/vars.tf
+++ b/infra/functions-python/vars.tf
@@ -86,3 +86,9 @@ variable "export_csv_schedule" {
     description = "Schedule the export_csv function"
     default = "0 4 * * 2,5" # At 4am every Tuesday and Friday.
 }
+
+variable "update_feed_status_schedule" {
+    type        = string
+    description = "Schedule the update_feed_status function"
+    default     = "0 4 * * *" # At 4am every day.
+}


### PR DESCRIPTION
**Summary:**

Sets up the Google Cloud Scheduler to run the Update_feed_status function once a day at 4am

This is the PR I used as reference: https://github.com/MobilityData/mobility-feed-api/pull/926

**Expected behavior:** 

Every day at 4am the update feed status python function will be called 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
