### PR TITLE
Fix/populate uncaught errors

### DIFF
--- a/api/src/scripts/populate_db.py
+++ b/api/src/scripts/populate_db.py
@@ -92,7 +92,7 @@ class DatabasePopulateHelper:
         Only allowed values are "true" and "false" (case insensitive)
         Anything else returns the default.
         """
-        value = row[column_name]
+        value = row.get(column_name)
         if value is None or pandas.isna(value) or f"{value}".strip() == "":
             return default_value
         # I am not sure if pandas will convert "TRUE" and "FALSE" to boolean, so go back to using a string

--- a/api/src/scripts/populate_db.py
+++ b/api/src/scripts/populate_db.py
@@ -80,7 +80,7 @@ class DatabasePopulateHelper:
         """
         Get a safe value from the row
         """
-        value = row[column_name]
+        value = row.get(column_name)
         if not value or pandas.isna(value) or f"{value}".strip() == "":
             return default_value
         return f"{value}".strip()

--- a/api/src/scripts/populate_db.py
+++ b/api/src/scripts/populate_db.py
@@ -80,9 +80,28 @@ class DatabasePopulateHelper:
         """
         Get a safe value from the row
         """
-        if not row[column_name] or pandas.isna(row[column_name]) or f"{row[column_name]}".strip() == "":
-            return default_value if default_value is not None else None
-        return f"{row[column_name]}".strip()
+        value = row[column_name]
+        if not value or pandas.isna(value) or f"{value}".strip() == "":
+            return default_value
+        return f"{value}".strip()
+
+    @staticmethod
+    def get_safe_boolean_value(row, column_name, default_value: bool | None) -> bool | None:
+        """
+        Get a safe boolean value from the row
+        Only allowed values are "true" and "false" (case insensitive)
+        Anything else returns the default.
+        """
+        value = row[column_name]
+        if value is None or pandas.isna(value) or f"{value}".strip() == "":
+            return default_value
+        # I am not sure if pandas will convert "TRUE" and "FALSE" to boolean, so go back to using a string
+        value = f"{value}".strip().lower()
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+        return default_value
 
     @staticmethod
     def get_location_id(country_code, subdivision_name, municipality):

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -192,13 +192,10 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
             # Create or update the GTFS feed
             data_type = self.get_data_type(row)
             stable_id = self.get_stable_id(row)
-            is_official_from_csv = self.get_safe_value(row, "is_official", "false").lower() == "true"
+            is_official_from_csv = self.get_safe_boolean_value(row, "is_official", None)
             feed = self.query_feed_by_stable_id(session, stable_id, data_type)
             if feed:
                 self.logger.debug(f"Updating {feed.__class__.__name__}: {stable_id}")
-                if feed.official != is_official_from_csv:
-                    feed.official = is_official_from_csv
-                    feed.official_updated_at = datetime.now(pytz.utc)
             else:
                 feed = self.get_model(data_type)(
                     id=generate_unique_id(),
@@ -219,8 +216,12 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                         source="mdb",
                     )
                 ]
-                feed.official = is_official_from_csv
-                feed.official_updated_at = datetime.now(pytz.utc)
+
+            # If the is_official field from the CSV is empty, the value here will be None and we don't touch the DB
+            if is_official_from_csv is not None:
+                if feed.official != is_official_from_csv:
+                    feed.official = is_official_from_csv
+                    feed.official_updated_at = datetime.now(pytz.utc)
 
             # Populate common fields from Feed
             feed.feed_name = self.get_safe_value(row, "name", "")

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from typing import TYPE_CHECKING
 from datetime import datetime
 
@@ -131,6 +132,9 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                 except ValueError:
                     gtfs_stable_id = static_reference
                 gtfs_feed = self.query_feed_by_stable_id(session, gtfs_stable_id, "gtfs")
+                if not gtfs_feed:
+                    self.logger.warning(f"Could not find static reference feed {gtfs_stable_id} for feed {stable_id}")
+                    continue
                 already_referenced_ids = {ref.id for ref in gtfs_feed.gtfs_rt_feeds}
                 if gtfs_feed and gtfs_rt_feed.id not in already_referenced_ids:
                     gtfs_feed.gtfs_rt_feeds.append(gtfs_rt_feed)
@@ -294,6 +298,7 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                     self.trigger_downstream_tasks()
         except Exception as e:
             self.logger.error(f"\n------ Failed to populate the database with sources.csv: {e} -----\n")
+            traceback.print_exc()
             exit(1)
 
 

--- a/functions-python/export_csv/src/main.py
+++ b/functions-python/export_csv/src/main.py
@@ -130,6 +130,7 @@ def export_csv(csv_file_path: str):
 
         count = 0
         for feed in fetch_feeds():
+            # We're counting on the writer to leave an empty field in the csv for None values
             writer.writerow(feed)
             count += 1
 


### PR DESCRIPTION
**Summary:**

There were 2 errors that made the populate script exit when running in QA:

- This one:
```
------ Failed to populate the database w***h sources.csv: 'is_official' -----
```

- And this one:
```
2025-03-27 23:26:53,513 ERROR GTFSDatabasePopulateHelper 
------ Failed to populate the database w***h sources.csv: 'NoneType' object has no attribute 'gtfs_rt_feeds' -----
```

The first one is because populate was reading a sources.csv file where the is_official column was absent. We did not protect agains that properly and it's corrected in the current PR. This goes away when we add the column to sources.csv (which is now done), but I thought it would still be good to address this.

The second one is because the sources.csv had a static_reference field that would point to a feed that is not in sources.csv itself, or not already in the DB. The code was changed to issue a warning in that case. This error did not happen in prod because the referred to feed was present in the DB.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
