### PR TITLE
fix: avoid exception when country code is not found

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -90,8 +90,9 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                 if location
                 else Location(
                     id=location_id,
-                    # Country code should be short. 
-                    # If too long it might be an error (like it could be the country name instead of code).
+                    # Country code should be short.
+                    # If too long it might be an error
+                    # (like it could be the country name instead of code).
                     country_code=country_code if country_code and len(country_code) <= 3 else None,
                     subdivision_name=subdivision_name,
                     municipality=municipality,

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -90,6 +90,8 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                 if location
                 else Location(
                     id=location_id,
+                    # Country code should be short. 
+                    # If too long it might be an error (like it could be the country name instead of code).
                     country_code=country_code if country_code and len(country_code) <= 3 else None,
                     subdivision_name=subdivision_name,
                     municipality=municipality,

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -61,9 +61,11 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
         return f'mdb-{self.get_safe_value(row, "mdb_source_id", "")}'
 
     def get_country(self, country_code):
+        country = None
         if country_code:
-            return pycountry.countries.get(alpha_2=country_code).name
-        return None
+            country = pycountry.countries.get(alpha_2=country_code)
+            country = country.name if country else None
+        return country
 
     def populate_location(self, session, feed, row, stable_id):
         """

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -1,12 +1,14 @@
 import os
 import traceback
-from typing import TYPE_CHECKING
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import pycountry
 import pytz
 from sqlalchemy import text
 
+from scripts.load_dataset_on_create import publish_all
+from scripts.populate_db import DatabasePopulateHelper, set_up_configs
 from shared.database.database import generate_unique_id, configure_polymorphic_mappers
 from shared.database_gen.sqlacodegen_models import (
     Entitytype,
@@ -16,8 +18,6 @@ from shared.database_gen.sqlacodegen_models import (
     Redirectingid,
     t_feedsearch,
 )
-from scripts.populate_db import DatabasePopulateHelper, set_up_configs
-from scripts.load_dataset_on_create import publish_all
 from utils.data_utils import set_up_defaults
 
 if TYPE_CHECKING:
@@ -90,7 +90,7 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                 if location
                 else Location(
                     id=location_id,
-                    country_code=country_code,
+                    country_code=country_code if country_code and len(country_code) <= 3 else None,
                     subdivision_name=subdivision_name,
                     municipality=municipality,
                     country=country,

--- a/functions-python/reverse_geolocation/src/location_group_utils.py
+++ b/functions-python/reverse_geolocation/src/location_group_utils.py
@@ -75,7 +75,8 @@ class GeopolygonAggregate:
 
     def country(self) -> str:
         """Returns the country name of the LocationGroup."""
-        return pycountry.countries.get(alpha_2=self.iso_3166_1_code).name
+        country = pycountry.countries.get(alpha_2=self.iso_3166_1_code)
+        return country.name if country else None
 
     def location_id(self) -> str:
         """Returns the location ID of the LocationGroup."""

--- a/functions-python/reverse_geolocation/tests/test_location_group_utils.py
+++ b/functions-python/reverse_geolocation/tests/test_location_group_utils.py
@@ -99,6 +99,9 @@ class TestLocationGroupUtils(unittest.TestCase):
     [{"value": "CA", "expected": "Canada"}, {"value": "Canada", "expected": None}],
 )
 def test_location_country(values):
+    """
+    Test the country function with cases with valid and invalid ISO 3166_1 code
+    """
     geopolygon = Geopolygon(
         osm_id=1,
         admin_level=2,


### PR DESCRIPTION
**Summary:**

Add protecting logic to avoid errors while processing an "invalid" country code.

**Expected behavior:** 

Invalid country codes must not raise an exception.

**Testing tips:**

The following script must pass locally:
```
./scripts/docker-localdb-rebuild-data.sh --populate-data
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
