### PR TITLE
Feat: dataset pagination

### DIFF
--- a/web-app/cypress/e2e/feeds.cy.ts
+++ b/web-app/cypress/e2e/feeds.cy.ts
@@ -10,7 +10,7 @@ describe('Feed page', () => {
     cy.intercept('GET', `${apiBaseUrl}/v1/gtfs_feeds/test-516`, gtfsFeedJson);
     cy.intercept(
       'GET',
-      `${apiBaseUrl}/v1/gtfs_feeds/test-516/datasets`,
+      `${apiBaseUrl}/v1/gtfs_feeds/test-516/datasets?offset=0&limit=10`,
       datasetsFeedJson,
     );
     cy.visit('feeds/test-516');
@@ -25,7 +25,10 @@ describe('Feed page', () => {
   });
 
   it('should render the last updated date', () => {
-    cy.get('[data-testid="last-updated"]').should('contain', 'Quality report updated');
+    cy.get('[data-testid="last-updated"]').should(
+      'contain',
+      'Quality report updated',
+    );
   });
 
   it('should render download button', () => {

--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -131,6 +131,7 @@
   },
   "datasetHistory": "Dataset History",
   "datasetHistoryDescription": "The Mobility Database fetches and stores new datasets once a day at midnight UTC.",
+  "allDatasetsLoaded": "All datasets loaded",
   "datasets": "Datasets",
   "validationReportNotAvailable": "Validation report not available",
   "runValidationReportYourself": "Run Validator Yourself",

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -47,7 +47,9 @@ export default function PreviousDatasets({
 }: PreviousDatasetsProps): React.ReactElement {
   const theme = useTheme();
   const { t } = useTranslation('feeds');
+  const [scrollPosition, setScrollPosition] = React.useState(0);
   const bottomRef = React.useRef<HTMLDivElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     const observer = new IntersectionObserver(
@@ -57,7 +59,10 @@ export default function PreviousDatasets({
           !hasloadedAllDatasets &&
           !isLoadingDatasets
         ) {
-          loadMoreDatasets(datasets?.length ?? 0);
+          const currentNumberOfDatasets = datasets?.length ?? 0;
+          const currentScrollPosition = listRef.current?.scrollTop ?? 0;
+          loadMoreDatasets(currentNumberOfDatasets);
+          setScrollPosition(currentScrollPosition);
         }
       },
       { root: null, threshold: 1.0 },
@@ -66,11 +71,24 @@ export default function PreviousDatasets({
     if (bottomRef.current != null) {
       observer.observe(bottomRef.current);
     }
-
     return () => {
       if (bottomRef.current != null) observer.unobserve(bottomRef.current);
     };
   }, [datasets, hasloadedAllDatasets]);
+
+  /**
+   * When datasets loads, the default behavious is to bring the user to the bottom
+   * This retriggers the loading of datasets infinitely
+   * This effect manually controls the scroll position when data loads
+   */
+  React.useEffect(() => {
+    const list = listRef.current;
+    if (list != null && list.scrollTop != 0) {
+      if (list.scrollTop >= scrollPosition) {
+        list.scrollTop = scrollPosition + 150;
+      }
+    }
+  }, [datasets]);
 
   return (
     <>
@@ -80,235 +98,247 @@ export default function PreviousDatasets({
         {t('datasetHistory')}
       </Typography>
       <Typography sx={{ mb: 2 }}>{t('datasetHistoryDescription')}</Typography>
-
       <ContentBox
         width={{ xs: '100%' }}
         title={''}
         outlineColor={theme.palette.primary.dark}
-        padding={{ xs: 0, sm: 1 }}
+        padding={{ xs: 0 }}
       >
-        <TableContainer>
-          <Table>
-            <TableBody sx={{ width: '100%' }}>
-              {datasets?.map((dataset, index) => (
-                <TableRow data-testid='dataset-item' key={dataset.id}>
-                  {dataset.downloaded_at != null && (
+        <Box
+          sx={{
+            height: '100%',
+            maxHeight: 'min(600px, 60vh)',
+            overflowY: 'scroll',
+            pb: '5px', // for the bottomRef trigger spacing
+          }}
+          ref={listRef}
+        >
+          <TableContainer>
+            <Table>
+              <TableBody sx={{ width: '100%' }}>
+                {datasets?.map((dataset, index) => (
+                  <TableRow data-testid='dataset-item' key={dataset.id}>
+                    {dataset.downloaded_at != null && (
+                      <TableCell>
+                        <Typography variant='body1'>
+                          {index === 0 && <b>Latest: </b>}
+                          {new Date(dataset.downloaded_at).toDateString()}
+                        </Typography>
+                      </TableCell>
+                    )}
                     <TableCell>
-                      <Typography variant='body1'>
-                        {index === 0 && <b>Latest: </b>}
-                        {new Date(dataset.downloaded_at).toDateString()}
-                      </Typography>
+                      {dataset?.service_date_range_start != undefined &&
+                        dataset?.service_date_range_end != undefined && (
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
+                            <Tooltip
+                              title={t(
+                                'datasetHistoryTooltip.serviceDateRange',
+                              )}
+                              placement='top'
+                            >
+                              <DateRangeIcon></DateRangeIcon>
+                            </Tooltip>
+
+                            {formatServiceDateRange(
+                              dataset?.service_date_range_start,
+                              dataset?.service_date_range_end,
+                              dataset.agency_timezone,
+                            )}
+                          </Box>
+                        )}
                     </TableCell>
-                  )}
-                  <TableCell>
-                    {dataset?.service_date_range_start != undefined &&
-                      dataset?.service_date_range_end != undefined && (
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                    <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
+                      {(dataset.validation_report === null ||
+                        dataset.validation_report === undefined) && (
+                        <Typography sx={{ ml: '4px' }}>
+                          {t('validationReportNotAvailable')}
+                        </Typography>
+                      )}
+                      {dataset.validation_report !== null &&
+                        dataset.validation_report !== undefined && (
+                          <>
+                            <Chip
+                              component='a'
+                              clickable
+                              href={`${dataset?.validation_report?.url_html}`}
+                              target='_blank'
+                              rel='noreferrer nofollow'
+                              sx={{ m: '4px' }}
+                              icon={
+                                dataset?.validation_report
+                                  ?.unique_error_count !== undefined &&
+                                dataset?.validation_report?.unique_error_count >
+                                  0 ? (
+                                  <ReportOutlined />
+                                ) : (
+                                  <CheckCircle />
+                                )
+                              }
+                              label={
+                                dataset?.validation_report
+                                  ?.unique_error_count !== undefined &&
+                                dataset?.validation_report?.unique_error_count >
+                                  0
+                                  ? `${dataset?.validation_report
+                                      ?.unique_error_count} ${t(
+                                      'common:feedback.errors',
+                                    )}`
+                                  : t('common:feedback.noErrors')
+                              }
+                              color={
+                                dataset?.validation_report
+                                  ?.unique_error_count !== undefined &&
+                                dataset?.validation_report?.unique_error_count >
+                                  0
+                                  ? 'error'
+                                  : 'success'
+                              }
+                              variant='outlined'
+                            />
+                            <Chip
+                              sx={{ m: '4px' }}
+                              component='a'
+                              clickable
+                              href={`${dataset?.validation_report?.url_html}`}
+                              target='_blank'
+                              rel='noreferrer nofollow'
+                              icon={
+                                dataset?.validation_report
+                                  ?.unique_warning_count !== undefined &&
+                                dataset?.validation_report
+                                  ?.unique_warning_count > 0 ? (
+                                  <ReportOutlined />
+                                ) : (
+                                  <CheckCircle />
+                                )
+                              }
+                              label={
+                                dataset?.validation_report
+                                  ?.unique_warning_count !== undefined &&
+                                dataset?.validation_report
+                                  ?.unique_warning_count > 0
+                                  ? `${dataset?.validation_report
+                                      ?.unique_warning_count} ${t(
+                                      'common:feedback.warnings',
+                                    )}`
+                                  : t('common:feedback.noWarnings')
+                              }
+                              color={
+                                dataset?.validation_report
+                                  ?.unique_warning_count !== undefined &&
+                                dataset?.validation_report
+                                  ?.unique_warning_count > 0
+                                  ? 'warning'
+                                  : 'success'
+                              }
+                              variant='outlined'
+                            />
+                            <Chip
+                              sx={{ m: '4px' }}
+                              component='a'
+                              clickable
+                              href={`${dataset?.validation_report?.url_html}`}
+                              target='_blank'
+                              rel='noreferrer nofollow'
+                              icon={<InfoOutlinedIcon />}
+                              label={`${
+                                dataset?.validation_report?.unique_info_count ??
+                                '0'
+                              } ${t('common:feedback.infoNotices')}`}
+                              color='primary'
+                              variant='outlined'
+                            />
+                          </>
+                        )}
+                    </TableCell>
+                    <TableCell sx={{ textAlign: 'center' }}>
+                      {dataset.validation_report == undefined && (
+                        <Button
+                          variant='contained'
+                          sx={{ mx: 2 }}
+                          disableElevation
+                          endIcon={<LaunchOutlined />}
+                          href={WEB_VALIDATOR_LINK}
+                          target='_blank'
+                          rel='noreferrer'
                         >
+                          {t('runValidationReportYourself')}
+                        </Button>
+                      )}
+                      {dataset.validation_report != null && (
+                        <>
                           <Tooltip
-                            title={t('datasetHistoryTooltip.serviceDateRange')}
+                            title={t('datasetHistoryTooltip.downloadReport')}
                             placement='top'
                           >
-                            <DateRangeIcon></DateRangeIcon>
+                            <Button
+                              variant='text'
+                              aria-label={t(
+                                'datasetHistoryTooltip.downloadReport',
+                              )}
+                              startIcon={<DownloadOutlined />}
+                              size='medium'
+                              href={dataset.hosted_url}
+                              rel='noreferrer nofollow'
+                            >
+                              {t('common:download')}
+                            </Button>
                           </Tooltip>
-
-                          {formatServiceDateRange(
-                            dataset?.service_date_range_start,
-                            dataset?.service_date_range_end,
-                            dataset.agency_timezone,
-                          )}
-                        </Box>
-                      )}
-                  </TableCell>
-                  <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
-                    {(dataset.validation_report === null ||
-                      dataset.validation_report === undefined) && (
-                      <Typography sx={{ ml: '4px' }}>
-                        {t('validationReportNotAvailable')}
-                      </Typography>
-                    )}
-                    {dataset.validation_report !== null &&
-                      dataset.validation_report !== undefined && (
-                        <>
-                          <Chip
-                            component='a'
-                            clickable
-                            href={`${dataset?.validation_report?.url_html}`}
-                            target='_blank'
-                            rel='noreferrer nofollow'
-                            sx={{ m: '4px' }}
-                            icon={
-                              dataset?.validation_report?.unique_error_count !==
-                                undefined &&
-                              dataset?.validation_report?.unique_error_count >
-                                0 ? (
-                                <ReportOutlined />
-                              ) : (
-                                <CheckCircle />
-                              )
-                            }
-                            label={
-                              dataset?.validation_report?.unique_error_count !==
-                                undefined &&
-                              dataset?.validation_report?.unique_error_count > 0
-                                ? `${dataset?.validation_report
-                                    ?.unique_error_count} ${t(
-                                    'common:feedback.errors',
-                                  )}`
-                                : t('common:feedback.noErrors')
-                            }
-                            color={
-                              dataset?.validation_report?.unique_error_count !==
-                                undefined &&
-                              dataset?.validation_report?.unique_error_count > 0
-                                ? 'error'
-                                : 'success'
-                            }
-                            variant='outlined'
-                          />
-                          <Chip
-                            sx={{ m: '4px' }}
-                            component='a'
-                            clickable
-                            href={`${dataset?.validation_report?.url_html}`}
-                            target='_blank'
-                            rel='noreferrer nofollow'
-                            icon={
-                              dataset?.validation_report
-                                ?.unique_warning_count !== undefined &&
-                              dataset?.validation_report?.unique_warning_count >
-                                0 ? (
-                                <ReportOutlined />
-                              ) : (
-                                <CheckCircle />
-                              )
-                            }
-                            label={
-                              dataset?.validation_report
-                                ?.unique_warning_count !== undefined &&
-                              dataset?.validation_report?.unique_warning_count >
-                                0
-                                ? `${dataset?.validation_report
-                                    ?.unique_warning_count} ${t(
-                                    'common:feedback.warnings',
-                                  )}`
-                                : t('common:feedback.noWarnings')
-                            }
-                            color={
-                              dataset?.validation_report
-                                ?.unique_warning_count !== undefined &&
-                              dataset?.validation_report?.unique_warning_count >
-                                0
-                                ? 'warning'
-                                : 'success'
-                            }
-                            variant='outlined'
-                          />
-                          <Chip
-                            sx={{ m: '4px' }}
-                            component='a'
-                            clickable
-                            href={`${dataset?.validation_report?.url_html}`}
-                            target='_blank'
-                            rel='noreferrer nofollow'
-                            icon={<InfoOutlinedIcon />}
-                            label={`${
-                              dataset?.validation_report?.unique_info_count ??
-                              '0'
-                            } ${t('common:feedback.infoNotices')}`}
-                            color='primary'
-                            variant='outlined'
-                          />
+                          |
+                          <Tooltip
+                            title={t('datasetHistoryTooltip.viewReport')}
+                            placement='top'
+                          >
+                            <IconButton
+                              color='primary'
+                              aria-label={t('datasetHistoryTooltip.viewReport')}
+                              size='medium'
+                              href={`${dataset?.validation_report?.url_html}`}
+                              target='_blank'
+                              rel='noreferrer nofollow'
+                              data-testid='validation-report-html'
+                            >
+                              <SummarizeIcon />
+                            </IconButton>
+                          </Tooltip>
+                          |
+                          <Tooltip
+                            title={t('datasetHistoryTooltip.viewJsonReport')}
+                            placement='top'
+                          >
+                            <IconButton
+                              color='primary'
+                              aria-label={t(
+                                'datasetHistoryTooltip.viewJsonReport',
+                              )}
+                              size='medium'
+                              href={`${dataset?.validation_report?.url_json}`}
+                              target='_blank'
+                              rel='noreferrer nofollow'
+                              data-testid='validation-report-json'
+                            >
+                              <CodeIcon />
+                            </IconButton>
+                          </Tooltip>
                         </>
                       )}
-                  </TableCell>
-                  <TableCell sx={{ textAlign: 'center' }}>
-                    {dataset.validation_report == undefined && (
-                      <Button
-                        variant='contained'
-                        sx={{ mx: 2 }}
-                        disableElevation
-                        endIcon={<LaunchOutlined />}
-                        href={WEB_VALIDATOR_LINK}
-                        target='_blank'
-                        rel='noreferrer'
-                      >
-                        {t('runValidationReportYourself')}
-                      </Button>
-                    )}
-                    {dataset.validation_report != null && (
-                      <>
-                        <Tooltip
-                          title={t('datasetHistoryTooltip.downloadReport')}
-                          placement='top'
-                        >
-                          <Button
-                            variant='text'
-                            aria-label={t(
-                              'datasetHistoryTooltip.downloadReport',
-                            )}
-                            startIcon={<DownloadOutlined />}
-                            size='medium'
-                            href={dataset.hosted_url}
-                            rel='noreferrer nofollow'
-                          >
-                            {t('common:download')}
-                          </Button>
-                        </Tooltip>
-                        |
-                        <Tooltip
-                          title={t('datasetHistoryTooltip.viewReport')}
-                          placement='top'
-                        >
-                          <IconButton
-                            color='primary'
-                            aria-label={t('datasetHistoryTooltip.viewReport')}
-                            size='medium'
-                            href={`${dataset?.validation_report?.url_html}`}
-                            target='_blank'
-                            rel='noreferrer nofollow'
-                            data-testid='validation-report-html'
-                          >
-                            <SummarizeIcon />
-                          </IconButton>
-                        </Tooltip>
-                        |
-                        <Tooltip
-                          title={t('datasetHistoryTooltip.viewJsonReport')}
-                          placement='top'
-                        >
-                          <IconButton
-                            color='primary'
-                            aria-label={t(
-                              'datasetHistoryTooltip.viewJsonReport',
-                            )}
-                            size='medium'
-                            href={`${dataset?.validation_report?.url_json}`}
-                            target='_blank'
-                            rel='noreferrer nofollow'
-                            data-testid='validation-report-json'
-                          >
-                            <CodeIcon />
-                          </IconButton>
-                        </Tooltip>
-                      </>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-        <Box
-          ref={bottomRef}
-          style={{ height: '5px', background: 'transparent' }}
-        />
-        {isLoadingDatasets && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
-            <CircularProgress />
-          </Box>
-        )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <Box
+            ref={bottomRef}
+            style={{ height: '5px', background: 'transparent' }}
+          />
+        </Box>
       </ContentBox>
       {hasloadedAllDatasets && (
         <Typography
@@ -319,6 +349,17 @@ export default function PreviousDatasets({
           {t('allDatasetsLoaded')}
         </Typography>
       )}
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          height: '48px',
+          pt: 1,
+        }}
+      >
+        {isLoadingDatasets && <CircularProgress />}
+      </Box>
     </>
   );
 }

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -77,7 +77,7 @@ export default function PreviousDatasets({
   }, [datasets, hasloadedAllDatasets]);
 
   /**
-   * When datasets loads, the default behavious is to bring the user to the bottom
+   * When datasets loads, the default behavior is to bring the user to the bottom
    * This retriggers the loading of datasets infinitely
    * This effect manually controls the scroll position when data loads
    */

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   IconButton,
   Table,
   TableBody,
@@ -33,12 +34,14 @@ export interface PreviousDatasetsProps {
   datasets:
     | paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json']
     | undefined;
+  isLoadingDatasets: boolean;
   hasloadedAllDatasets: boolean;
   loadMoreDatasets: (offset: number) => void;
 }
 
 export default function PreviousDatasets({
   datasets,
+  isLoadingDatasets,
   hasloadedAllDatasets,
   loadMoreDatasets,
 }: PreviousDatasetsProps): React.ReactElement {
@@ -49,7 +52,11 @@ export default function PreviousDatasets({
   React.useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && !hasloadedAllDatasets) {
+        if (
+          entries[0].isIntersecting &&
+          !hasloadedAllDatasets &&
+          !isLoadingDatasets
+        ) {
           loadMoreDatasets(datasets?.length ?? 0);
         }
       },
@@ -297,6 +304,11 @@ export default function PreviousDatasets({
           ref={bottomRef}
           style={{ height: '5px', background: 'transparent' }}
         />
+        {isLoadingDatasets && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+            <CircularProgress />
+          </Box>
+        )}
       </ContentBox>
       {hasloadedAllDatasets && (
         <Typography

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -502,6 +502,7 @@ export default function Feed(): React.ReactElement {
         <Grid item xs={12}>
           <PreviousDatasets
             datasets={datasets}
+            isLoadingDatasets={datasetLoadingStatus === 'loading'}
             hasloadedAllDatasets={
               hasLoadedAllDatasets != undefined && hasLoadedAllDatasets
             }

--- a/web-app/src/app/store/dataset-selectors.ts
+++ b/web-app/src/app/store/dataset-selectors.ts
@@ -21,6 +21,12 @@ export const selectLatestDatasetsData = (
   return state.dataset.data !== undefined ? state.dataset.data[0] : undefined;
 };
 
+export const selectHasLoadedAllDatasets = (
+  state: RootState,
+): boolean | undefined => {
+  return state.dataset.loadedAllData;
+};
+
 export const selectBoundingBoxFromLatestDataset = createSelector(
   [selectLatestDatasetsData],
   (latestDataset): LatLngExpression[] | undefined => {

--- a/web-app/src/app/store/saga/dataset-saga.ts
+++ b/web-app/src/app/store/saga/dataset-saga.ts
@@ -7,20 +7,33 @@ import { getGtfsFeedDatasets } from '../../services/feeds';
 import { type paths } from '../../services/feeds/types';
 import { loadingDatasetSuccess } from '../dataset-reducer';
 import { getUserAccessToken } from '../../services';
+import { areAllDatasetsLoaded } from '../../utils/dataset';
 
 function* getDatasetSaga({
-  payload: { feedId },
-}: PayloadAction<{ feedId: string }>): Generator {
+  payload: { feedId, offset, limit },
+}: PayloadAction<{
+  feedId: string;
+  offset?: number;
+  limit?: number;
+}>): Generator {
   try {
     if (feedId !== undefined) {
       const accessToken = (yield call(getUserAccessToken)) as string;
-      const datasets = (yield call(
-        getGtfsFeedDatasets,
-        feedId,
-        accessToken,
-        {},
-      )) as paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json'];
-      yield put(loadingDatasetSuccess({ data: datasets }));
+      const datasets = (yield call(getGtfsFeedDatasets, feedId, accessToken, {
+        offset,
+        limit,
+      })) as paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json'];
+      const hasLoadedAllData = areAllDatasetsLoaded(
+        datasets.length,
+        limit,
+        offset,
+      );
+      yield put(
+        loadingDatasetSuccess({
+          data: datasets,
+          loadedAllData: hasLoadedAllData,
+        }),
+      );
     }
   } catch (error) {
     yield put(loadingFeedFail(getAppError(error) as FeedError));

--- a/web-app/src/app/utils/dataset.spec.ts
+++ b/web-app/src/app/utils/dataset.spec.ts
@@ -32,9 +32,9 @@ describe('Dataset utils', () => {
     it('should return the merged and sorted datasets when existing datasets are provided', () => {
       const result = mergeAndSortDatasets(newDatasets, existingDatasets);
       expect(result).toEqual([
+        { id: 3, downloaded_at: '2023-01-12T00:00:00Z' },
         { id: 4, downloaded_at: '2023-03-01T00:00:00Z' },
         { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
-        { id: 3, downloaded_at: '2023-01-12T00:00:00Z' },
         { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
       ]);
     });
@@ -42,8 +42,8 @@ describe('Dataset utils', () => {
     it('should filter out duplicates and return the merged and sorted datasets', () => {
       const result = mergeAndSortDatasets(newDatasets, duplicateDatasets);
       expect(result).toEqual([
-        { id: 5, downloaded_at: '2023-05-12T00:00:00Z' },
         { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+        { id: 5, downloaded_at: '2023-05-12T00:00:00Z' },
         { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
       ]);
     });

--- a/web-app/src/app/utils/dataset.spec.ts
+++ b/web-app/src/app/utils/dataset.spec.ts
@@ -1,0 +1,72 @@
+import { type paths } from '../services/feeds/types';
+import { areAllDatasetsLoaded, mergeAndSortDatasets } from './dataset';
+
+type Datasets =
+  paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json'];
+
+const newDatasets = [
+  { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
+  { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+] as unknown as Datasets;
+
+const existingDatasets = [
+  { id: 3, downloaded_at: '2023-01-12T00:00:00Z' },
+  { id: 4, downloaded_at: '2023-03-01T00:00:00Z' },
+] as unknown as Datasets;
+
+const duplicateDatasets = [
+  { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+  { id: 5, downloaded_at: '2023-05-12T00:00:00Z' },
+] as unknown as Datasets;
+
+describe('Dataset utils', () => {
+  describe('mergeAndSortDatasets', () => {
+    it('should return the sorted datasets when no existing datasets are provided', () => {
+      const result = mergeAndSortDatasets(newDatasets, undefined);
+      expect(result).toEqual([
+        { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+        { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
+      ]);
+    });
+
+    it('should return the merged and sorted datasets when existing datasets are provided', () => {
+      const result = mergeAndSortDatasets(newDatasets, existingDatasets);
+      expect(result).toEqual([
+        { id: 4, downloaded_at: '2023-03-01T00:00:00Z' },
+        { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+        { id: 3, downloaded_at: '2023-01-12T00:00:00Z' },
+        { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
+      ]);
+    });
+
+    it('should filter out duplicates and return the merged and sorted datasets', () => {
+      const result = mergeAndSortDatasets(newDatasets, duplicateDatasets);
+      expect(result).toEqual([
+        { id: 5, downloaded_at: '2023-05-12T00:00:00Z' },
+        { id: 2, downloaded_at: '2023-02-01T00:00:00Z' },
+        { id: 1, downloaded_at: '2023-01-02T00:00:00Z' },
+      ]);
+    });
+  });
+  describe('areAllDatasetsLoaded', () => {
+    it('should return true if offset and limit are undefined', () => {
+      const result = areAllDatasetsLoaded(3, undefined, undefined);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the number of datasets returned is less than the limit', () => {
+      const result = areAllDatasetsLoaded(3, 5, undefined);
+      expect(result).toBe(true);
+    });
+
+    it('should return undefined if offset is defined and limit is undefined', () => {
+      const result = areAllDatasetsLoaded(3, undefined, 0);
+      expect(result).toBe(undefined);
+    });
+
+    it('should return false if the number of datasets returned is greater than the limit', () => {
+      const result = areAllDatasetsLoaded(3, 2, 5);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/web-app/src/app/utils/dataset.ts
+++ b/web-app/src/app/utils/dataset.ts
@@ -22,16 +22,15 @@ export function mergeAndSortDatasets(
     const newFilteredData = newDatasets.filter(
       (item) => !existingIds.has(item.id),
     );
-    formattedDatasets = [...existingDatasets, ...newFilteredData].sort(
-      (a, b) => {
-        if (a.downloaded_at !== undefined && b.downloaded_at !== undefined) {
-          const dateB = new Date(b.downloaded_at).getTime();
-          const dateA = new Date(a.downloaded_at).getTime();
-          return dateB - dateA;
-        }
-        return 0;
-      },
-    );
+    const sortedNewFilteredData = newFilteredData.sort((a, b) => {
+      if (a.downloaded_at !== undefined && b.downloaded_at !== undefined) {
+        const dateB = new Date(b.downloaded_at).getTime();
+        const dateA = new Date(a.downloaded_at).getTime();
+        return dateB - dateA;
+      }
+      return 0;
+    });
+    formattedDatasets = [...existingDatasets, ...sortedNewFilteredData];
   }
   return formattedDatasets;
 }

--- a/web-app/src/app/utils/dataset.ts
+++ b/web-app/src/app/utils/dataset.ts
@@ -1,0 +1,59 @@
+import { type paths } from '../services/feeds/types';
+
+type Datasets =
+  paths['/v1/gtfs_feeds/{id}/datasets']['get']['responses'][200]['content']['application/json'];
+
+export function mergeAndSortDatasets(
+  newDatasets: Datasets,
+  existingDatasets: Datasets | undefined,
+): Datasets {
+  let formattedDatasets: Datasets = [];
+  if (existingDatasets === undefined) {
+    formattedDatasets = newDatasets.sort((a, b) => {
+      if (a.downloaded_at !== undefined && b.downloaded_at !== undefined) {
+        const dateB = new Date(b.downloaded_at).getTime();
+        const dateA = new Date(a.downloaded_at).getTime();
+        return dateB - dateA;
+      }
+      return 0;
+    });
+  } else {
+    const existingIds = new Set(existingDatasets.map((item) => item.id));
+    const newFilteredData = newDatasets.filter(
+      (item) => !existingIds.has(item.id),
+    );
+    formattedDatasets = [...existingDatasets, ...newFilteredData].sort(
+      (a, b) => {
+        if (a.downloaded_at !== undefined && b.downloaded_at !== undefined) {
+          const dateB = new Date(b.downloaded_at).getTime();
+          const dateA = new Date(a.downloaded_at).getTime();
+          return dateB - dateA;
+        }
+        return 0;
+      },
+    );
+  }
+  return formattedDatasets;
+}
+
+/*
+ Function to determine if all datasets are loaded given the offset and limit
+ False is if the datasets are not finished loading due to offset / limit
+ True is if the datasets are all loaded for the given feed
+ Undefined is if there is not enough information to determine if the datasets are all loaded
+*/
+export function areAllDatasetsLoaded(
+  numberOfDatasetsLoaded: number,
+  limit?: number,
+  offset?: number,
+): boolean | undefined {
+  let hasLoadedAllData: boolean | undefined = false;
+  if (offset == undefined && limit == undefined) {
+    hasLoadedAllData = true;
+  } else if (limit != undefined && numberOfDatasetsLoaded < limit) {
+    hasLoadedAllData = true;
+  } else if (offset != undefined && limit == undefined) {
+    hasLoadedAllData = undefined;
+  }
+  return hasLoadedAllData;
+}


### PR DESCRIPTION
closes #540 

**Summary:**

There can be 100+ datasets, this PR loads them in batches of 10 at a time

**Expected behavior:** 

When the Feed detail page initially loads, there should be 10 datasets (max) that loads. If the user scrolls to the bottom of the datasets, it will load more and show a loading indicator. Once all of them are loaded, a message saying "all datasets are loaded" will appear and will not make any more calls

**Testing tips:**

Go to any feed detail page and see if the datasets show accordingly.

NOTE: I wasn't able to find any feeds in QA / Dev that had more than 10 datasets. This PR was tested with PROD data. Some PROD feeds with 10+

```
101	"mdb-1896"
101	"mdb-1884"
101	"mdb-761"
101	"mdb-1784"
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

Note: In PROD the datasets are loaded from earliest to latest, and are sorted in the reducer
https://github.com/user-attachments/assets/22093782-1b72-41ae-8d53-b080a4dbad63

