### PR TITLE
fix: gtfs rt associated feed navigation blank

### DIFF
--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -116,16 +116,16 @@ export default function Feed(): React.ReactElement {
   const user = useSelector(selectUserProfile);
   const feedLoadingStatus = useSelector(selectFeedLoadingStatus);
   const datasetLoadingStatus = useSelector(selectDatasetsLoadingStatus);
-  const feedType = feedDataType ?? useSelector(selectFeedData)?.data_type;
+  const dataTypeSelector = useSelector(selectFeedData)?.data_type;
+  const feedType = feedDataType ?? dataTypeSelector;
   const relatedFeeds = useSelector(selectRelatedFeedsData);
   const relatedGtfsRtFeeds = useSelector(selectRelatedGtfsRTFeedsData);
   const datasets = useSelector(selectDatasetsData);
   const latestDataset = useSelector(selectLatestDatasetsData);
   const boundingBox = useSelector(selectBoundingBoxFromLatestDataset);
-  const feed =
-    feedType === 'gtfs'
-      ? useSelector(selectGTFSFeedData)
-      : useSelector(selectGTFSRTFeedData);
+  const gtfsFeedData = useSelector(selectGTFSFeedData);
+  const gtfsRtFeedData = useSelector(selectGTFSRTFeedData);
+  const feed = feedType === 'gtfs' ? gtfsFeedData : gtfsRtFeedData;
   const needsToLoadFeed = feed === undefined || feed?.id !== feedId;
   const isAuthenticatedOrAnonymous =
     useSelector(selectIsAuthenticated) || useSelector(selectIsAnonymous);


### PR DESCRIPTION
closes #1076 

**Summary:**

When going on a gtfs_rt feed without the `gtfs_rt` in the url (ex: https://mobilitydatabase.org/feeds/mdb-2424) and click on an associated feed, it would break with a react hook error leading to a blank page.

**Expected behavior:** 

When going on a gtfs_rt feed page, the user should be able to navigate to the associated feeds (gtfs_rt or not in the url) with nothing breaking.

**Testing tips:**

Go on any gtfs_rt link (and manually to some gtfs_rt links without adding `gtfs_rt` in the url) and click on the associated links, it shouldn't give an error

**The fix**
React didn't like `condition ? useSelector() : useSelector()` due to how it's handled in the state queue. Solution, get both selectors then select the correct one with the condition

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
