### PR TITLE
Added hard limits to API

### DIFF
--- a/api/tests/integration/test_feeds_api.py
+++ b/api/tests/integration/test_feeds_api.py
@@ -815,3 +815,26 @@ def test_gtfs_redirect(client):
     assert feed["redirects"][0]["comment"] == ""
     # spreadsheet contains '10'
     assert feed["redirects"][0]["target_id"] == "mdb-10"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"endpoint": "/v1/feeds", "hard_limit": 3500},
+        {"endpoint": "/v1/gtfs_feeds", "hard_limit": 2500},
+        {"endpoint": "/v1/gtfs_rt_feeds", "hard_limit": 1000},
+        {"endpoint": "/v1/gtfs_feeds/mdb-1/datasets", "hard_limit": 500},
+        {"endpoint": "/v1/search", "hard_limit": 3500},
+    ],
+)
+def test_hard_limits(client, monkeypatch, values):
+    """Test that an error is returned if we request more than the hard limit for each endpoint"""
+    hard_limit = values["hard_limit"]
+
+    response = client.request(
+        "GET",
+        values["endpoint"],
+        headers=authHeaders,
+        params={"limit": hard_limit + 1},
+    )
+    assert response.status_code != 200

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -42,7 +42,7 @@ paths:
         - "feeds"
       operationId: getFeeds
       parameters:
-        - $ref: "#/components/parameters/limit_query_param"
+        - $ref: "#/components/parameters/limit_query_param_feeds_endpoint"
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/status"
         - $ref: "#/components/parameters/provider"
@@ -88,7 +88,7 @@ paths:
         - "feeds"
       operationId: getGtfsFeeds
       parameters:
-        - $ref: "#/components/parameters/limit_query_param"
+        - $ref: "#/components/parameters/limit_query_param_gtfs_feeds_endpoint"
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/provider"
         - $ref: "#/components/parameters/producer_url"
@@ -117,7 +117,7 @@ paths:
         - "feeds"
       operationId: getGtfsRtFeeds
       parameters:
-        - $ref: "#/components/parameters/limit_query_param"
+        - $ref: "#/components/parameters/limit_query_param_gtfs_rt_feeds_endpoint"
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/provider"
         - $ref: "#/components/parameters/producer_url"
@@ -184,7 +184,7 @@ paths:
       operationId: getGtfsFeedDatasets
       parameters:
         - $ref: "#/components/parameters/latest_query_param"
-        - $ref: "#/components/parameters/limit_query_param"
+        - $ref: "#/components/parameters/limit_query_param_datasets_endpoint"
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/downloaded_after"
         - $ref: "#/components/parameters/downloaded_before"
@@ -277,7 +277,7 @@ paths:
       tags:
         - "search"
       parameters:
-        - $ref: "#/components/parameters/limit_query_param"
+        - $ref: "#/components/parameters/limit_query_param_search_endpoint"
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/statuses"
         - $ref: "#/components/parameters/feed_id_query_param"
@@ -1060,7 +1060,7 @@ components:
         type: boolean
         default: null
 
-    limit_query_param:
+    limit_query_param_feeds_endpoint:
       name: limit
       in: query
       description: The number of items to be returned.
@@ -1068,6 +1068,56 @@ components:
       schema:
         type: integer
         minimum: 0
+        maximum: 3500
+        default: 3500
+        example: 10
+
+    limit_query_param_gtfs_feeds_endpoint:
+      name: limit
+      in: query
+      description: The number of items to be returned.
+      required: False
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 2500
+        default: 2500
+        example: 10
+
+    limit_query_param_gtfs_rt_feeds_endpoint:
+      name: limit
+      in: query
+      description: The number of items to be returned.
+      required: False
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 1000
+        default: 1000
+        example: 10
+
+    limit_query_param_datasets_endpoint:
+      name: limit
+      in: query
+      description: The number of items to be returned.
+      required: False
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 500
+        default: 500
+        example: 10
+
+    limit_query_param_search_endpoint:
+      name: limit
+      in: query
+      description: The number of items to be returned.
+      required: False
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 3500
+        default: 3500
         example: 10
         
     offset:


### PR DESCRIPTION
**Summary:**

Added hard limit to the API endpoints, according to this table:
Endpoint | Returned entities count
-- | --
feeds | 3500
gtfs_feeds | 2500
gtfs_rt_feeds | 1000
search | 3500
datasets | 500

**Expected behavior:** 

- Requesting more than the limit will result in a 422 error:
```
curl -X 'GET' \
  'http://localhost:8080/v1/gtfs_feeds?limit=2501' \
  -H 'accept: application/json'
{"detail":[{"type":"less_than_equal","loc":["query","limit"],"msg":"Input should be less than or equal to 2500","input":"2501","ctx":{"le":2500}}]}
```

- If the limit is not specified, the hard limit is used. 

The net effect is that we will never return more entities than the hard limit.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
