### PR TITLE
fix: download datasets when no validation report

### DIFF
--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -297,9 +297,7 @@ export default function PreviousDatasets({
 
                         {dataset.validation_report != null && (
                           <>
-                          {dataset.hosted_url != null && (
-                            <>|</>
-                          )}
+                            {dataset.hosted_url != null && <>|</>}
                             <Tooltip
                               title={t('datasetHistoryTooltip.viewReport')}
                               placement='top'

--- a/web-app/src/app/screens/Feed/PreviousDatasets.tsx
+++ b/web-app/src/app/screens/Feed/PreviousDatasets.tsx
@@ -154,125 +154,115 @@ export default function PreviousDatasets({
                         )}
                     </TableCell>
                     <TableCell sx={{ textAlign: { xs: 'left', xl: 'center' } }}>
-                      {(dataset.validation_report === null ||
-                        dataset.validation_report === undefined) && (
+                      {dataset.validation_report == null && (
                         <Typography sx={{ ml: '4px' }}>
                           {t('validationReportNotAvailable')}
                         </Typography>
                       )}
-                      {dataset.validation_report !== null &&
-                        dataset.validation_report !== undefined && (
-                          <>
-                            <Chip
-                              component='a'
-                              clickable
-                              href={`${dataset?.validation_report?.url_html}`}
-                              target='_blank'
-                              rel='noreferrer nofollow'
-                              sx={{ m: '4px' }}
-                              icon={
-                                dataset?.validation_report
-                                  ?.unique_error_count !== undefined &&
-                                dataset?.validation_report?.unique_error_count >
-                                  0 ? (
-                                  <ReportOutlined />
-                                ) : (
-                                  <CheckCircle />
-                                )
-                              }
-                              label={
-                                dataset?.validation_report
-                                  ?.unique_error_count !== undefined &&
-                                dataset?.validation_report?.unique_error_count >
-                                  0
-                                  ? `${dataset?.validation_report
-                                      ?.unique_error_count} ${t(
-                                      'common:feedback.errors',
-                                    )}`
-                                  : t('common:feedback.noErrors')
-                              }
-                              color={
-                                dataset?.validation_report
-                                  ?.unique_error_count !== undefined &&
-                                dataset?.validation_report?.unique_error_count >
-                                  0
-                                  ? 'error'
-                                  : 'success'
-                              }
-                              variant='outlined'
-                            />
-                            <Chip
-                              sx={{ m: '4px' }}
-                              component='a'
-                              clickable
-                              href={`${dataset?.validation_report?.url_html}`}
-                              target='_blank'
-                              rel='noreferrer nofollow'
-                              icon={
-                                dataset?.validation_report
-                                  ?.unique_warning_count !== undefined &&
-                                dataset?.validation_report
-                                  ?.unique_warning_count > 0 ? (
-                                  <ReportOutlined />
-                                ) : (
-                                  <CheckCircle />
-                                )
-                              }
-                              label={
-                                dataset?.validation_report
-                                  ?.unique_warning_count !== undefined &&
-                                dataset?.validation_report
-                                  ?.unique_warning_count > 0
-                                  ? `${dataset?.validation_report
-                                      ?.unique_warning_count} ${t(
-                                      'common:feedback.warnings',
-                                    )}`
-                                  : t('common:feedback.noWarnings')
-                              }
-                              color={
-                                dataset?.validation_report
-                                  ?.unique_warning_count !== undefined &&
-                                dataset?.validation_report
-                                  ?.unique_warning_count > 0
-                                  ? 'warning'
-                                  : 'success'
-                              }
-                              variant='outlined'
-                            />
-                            <Chip
-                              sx={{ m: '4px' }}
-                              component='a'
-                              clickable
-                              href={`${dataset?.validation_report?.url_html}`}
-                              target='_blank'
-                              rel='noreferrer nofollow'
-                              icon={<InfoOutlinedIcon />}
-                              label={`${
-                                dataset?.validation_report?.unique_info_count ??
-                                '0'
-                              } ${t('common:feedback.infoNotices')}`}
-                              color='primary'
-                              variant='outlined'
-                            />
-                          </>
-                        )}
-                    </TableCell>
-                    <TableCell sx={{ textAlign: 'center' }}>
-                      {dataset.validation_report == undefined && (
-                        <Button
-                          variant='contained'
-                          sx={{ mx: 2 }}
-                          disableElevation
-                          endIcon={<LaunchOutlined />}
-                          href={WEB_VALIDATOR_LINK}
-                          target='_blank'
-                          rel='noreferrer'
-                        >
-                          {t('runValidationReportYourself')}
-                        </Button>
-                      )}
                       {dataset.validation_report != null && (
                         <>
+                          <Chip
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
+                            sx={{ m: '4px' }}
+                            icon={
+                              dataset?.validation_report?.unique_error_count !=
+                                undefined &&
+                              dataset?.validation_report?.unique_error_count >
+                                0 ? (
+                                <ReportOutlined />
+                              ) : (
+                                <CheckCircle />
+                              )
+                            }
+                            label={
+                              dataset?.validation_report?.unique_error_count !=
+                                undefined &&
+                              dataset?.validation_report?.unique_error_count > 0
+                                ? `${dataset?.validation_report
+                                    ?.unique_error_count} ${t(
+                                    'common:feedback.errors',
+                                  )}`
+                                : t('common:feedback.noErrors')
+                            }
+                            color={
+                              dataset?.validation_report?.unique_error_count !=
+                                undefined &&
+                              dataset?.validation_report?.unique_error_count > 0
+                                ? 'error'
+                                : 'success'
+                            }
+                            variant='outlined'
+                          />
+                          <Chip
+                            sx={{ m: '4px' }}
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
+                            icon={
+                              dataset?.validation_report
+                                ?.unique_warning_count != undefined &&
+                              dataset?.validation_report?.unique_warning_count >
+                                0 ? (
+                                <ReportOutlined />
+                              ) : (
+                                <CheckCircle />
+                              )
+                            }
+                            label={
+                              dataset?.validation_report
+                                ?.unique_warning_count != undefined &&
+                              dataset?.validation_report?.unique_warning_count >
+                                0
+                                ? `${dataset?.validation_report
+                                    ?.unique_warning_count} ${t(
+                                    'common:feedback.warnings',
+                                  )}`
+                                : t('common:feedback.noWarnings')
+                            }
+                            color={
+                              dataset?.validation_report
+                                ?.unique_warning_count != undefined &&
+                              dataset?.validation_report?.unique_warning_count >
+                                0
+                                ? 'warning'
+                                : 'success'
+                            }
+                            variant='outlined'
+                          />
+                          <Chip
+                            sx={{ m: '4px' }}
+                            component='a'
+                            clickable
+                            href={`${dataset?.validation_report?.url_html}`}
+                            target='_blank'
+                            rel='noreferrer nofollow'
+                            icon={<InfoOutlinedIcon />}
+                            label={`${
+                              dataset?.validation_report?.unique_info_count ??
+                              '0'
+                            } ${t('common:feedback.infoNotices')}`}
+                            color='primary'
+                            variant='outlined'
+                          />
+                        </>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          gap: 1,
+                          justifyContent: 'center',
+                          alignItems: 'center',
+                        }}
+                      >
+                        {dataset.hosted_url != null && (
                           <Tooltip
                             title={t('datasetHistoryTooltip.downloadReport')}
                             placement='top'
@@ -290,44 +280,66 @@ export default function PreviousDatasets({
                               {t('common:download')}
                             </Button>
                           </Tooltip>
-                          |
-                          <Tooltip
-                            title={t('datasetHistoryTooltip.viewReport')}
-                            placement='top'
+                        )}
+                        {dataset.validation_report == undefined && (
+                          <Button
+                            variant='contained'
+                            sx={{ mx: 2 }}
+                            disableElevation
+                            endIcon={<LaunchOutlined />}
+                            href={WEB_VALIDATOR_LINK}
+                            target='_blank'
+                            rel='noreferrer'
                           >
-                            <IconButton
-                              color='primary'
-                              aria-label={t('datasetHistoryTooltip.viewReport')}
-                              size='medium'
-                              href={`${dataset?.validation_report?.url_html}`}
-                              target='_blank'
-                              rel='noreferrer nofollow'
-                              data-testid='validation-report-html'
+                            {t('runValidationReportYourself')}
+                          </Button>
+                        )}
+
+                        {dataset.validation_report != null && (
+                          <>
+                          {dataset.hosted_url != null && (
+                            <>|</>
+                          )}
+                            <Tooltip
+                              title={t('datasetHistoryTooltip.viewReport')}
+                              placement='top'
                             >
-                              <SummarizeIcon />
-                            </IconButton>
-                          </Tooltip>
-                          |
-                          <Tooltip
-                            title={t('datasetHistoryTooltip.viewJsonReport')}
-                            placement='top'
-                          >
-                            <IconButton
-                              color='primary'
-                              aria-label={t(
-                                'datasetHistoryTooltip.viewJsonReport',
-                              )}
-                              size='medium'
-                              href={`${dataset?.validation_report?.url_json}`}
-                              target='_blank'
-                              rel='noreferrer nofollow'
-                              data-testid='validation-report-json'
+                              <IconButton
+                                color='primary'
+                                aria-label={t(
+                                  'datasetHistoryTooltip.viewReport',
+                                )}
+                                size='medium'
+                                href={`${dataset?.validation_report?.url_html}`}
+                                target='_blank'
+                                rel='noreferrer nofollow'
+                                data-testid='validation-report-html'
+                              >
+                                <SummarizeIcon />
+                              </IconButton>
+                            </Tooltip>
+                            |
+                            <Tooltip
+                              title={t('datasetHistoryTooltip.viewJsonReport')}
+                              placement='top'
                             >
-                              <CodeIcon />
-                            </IconButton>
-                          </Tooltip>
-                        </>
-                      )}
+                              <IconButton
+                                color='primary'
+                                aria-label={t(
+                                  'datasetHistoryTooltip.viewJsonReport',
+                                )}
+                                size='medium'
+                                href={`${dataset?.validation_report?.url_json}`}
+                                target='_blank'
+                                rel='noreferrer nofollow'
+                                data-testid='validation-report-json'
+                              >
+                                <CodeIcon />
+                              </IconButton>
+                            </Tooltip>
+                          </>
+                        )}
+                      </Box>
                     </TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
closes #1067 
**Summary:**

In the feed detail page, in the dataset history section, when there isn't a validation report, the user wasn't able to download the dataset (even though the dataset url existed). This PR allows users to download datasets even if the validation report isn't present

**Expected behavior:** 

You should be able to download a dataset even if there are no validation report for it

**Testing tips:**

Go to feed: `mdb-100` and see that you have the ability to download the dataset even if the validation report isn't there. You can test this on any feed

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2025-04-03 at 09 51 11](https://github.com/user-attachments/assets/c4fda223-13e8-48f1-aa25-b15df98ace24)

