### PR TITLE
fix: official tag to gtfs_rt detail page

### DIFF
--- a/web-app/src/app/components/OfficialChip.tsx
+++ b/web-app/src/app/components/OfficialChip.tsx
@@ -1,0 +1,19 @@
+import { Chip, Tooltip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { verificationBadgeStyle } from '../styles/VerificationBadge.styles';
+import VerifiedIcon from '@mui/icons-material/Verified';
+
+export default function OfficialChip(): React.ReactElement {
+  const { t } = useTranslation('feeds');
+  return (
+    <>
+      <Tooltip title={t('officialFeedTooltip')} placement='top'>
+        <Chip
+          sx={verificationBadgeStyle}
+          icon={<VerifiedIcon sx={{ fill: 'white' }}></VerifiedIcon>}
+          label={t('officialFeed')}
+        ></Chip>
+      </Tooltip>
+    </>
+  );
+}

--- a/web-app/src/app/screens/Feed/DataQualitySummary.tsx
+++ b/web-app/src/app/screens/Feed/DataQualitySummary.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { Box, Chip, Tooltip } from '@mui/material';
+import { Box, Chip } from '@mui/material';
 import { CheckCircle, ReportOutlined } from '@mui/icons-material';
 import { type components } from '../../services/feeds/types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { WarningContentBox } from '../../components/WarningContentBox';
-import VerifiedIcon from '@mui/icons-material/Verified';
 import { useTranslation } from 'react-i18next';
-import { verificationBadgeStyle } from '../../styles/VerificationBadge.styles';
 import { FeedStatusChip } from '../../components/FeedStatus';
 import { useRemoteConfig } from '../../context/RemoteConfigProvider';
+import OfficialChip from '../../components/OfficialChip';
 
 export interface DataQualitySummaryProps {
   feedStatus: components['schemas']['BasicFeed']['status'];
@@ -25,23 +24,14 @@ export default function DataQualitySummary({
   const { config } = useRemoteConfig();
   return (
     <Box data-testid='data-quality-summary' sx={{ my: 2 }}>
-      {(latestDataset?.validation_report === undefined ||
-        latestDataset.validation_report === null) && (
+      {latestDataset?.validation_report == undefined && (
         <WarningContentBox>{t('errorLoadingQualityReport')}</WarningContentBox>
       )}
       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
         {config.enableFeedStatusBadge && (
           <FeedStatusChip status={feedStatus ?? ''}></FeedStatusChip>
         )}
-        {isOfficialFeed && (
-          <Tooltip title={t('officialFeedTooltip')} placement='top'>
-            <Chip
-              sx={verificationBadgeStyle}
-              icon={<VerifiedIcon sx={{ fill: 'white' }}></VerifiedIcon>}
-              label={t('officialFeed')}
-            ></Chip>
-          </Tooltip>
-        )}
+        {isOfficialFeed && <OfficialChip></OfficialChip>}
         {latestDataset?.validation_report !== undefined &&
           latestDataset.validation_report !== null && (
             <>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -58,6 +58,7 @@ import {
   generateDescriptionMetaTag,
 } from './Feed.functions';
 import FeedTitle from './FeedTitle';
+import OfficialChip from '../../components/OfficialChip';
 
 const wrapComponent = (
   feedLoadingStatus: string,
@@ -354,6 +355,11 @@ export default function Feed(): React.ReactElement {
           isOfficialFeed={feed.official === true}
           latestDataset={latestDataset}
         />
+      )}
+      {feed?.data_type === 'gtfs_rt' && feed.official === true && (
+        <Box sx={{ my: 1 }}>
+          <OfficialChip></OfficialChip>
+        </Box>
       )}
       <Box>
         {latestDataset?.validation_report?.validated_at != undefined && (


### PR DESCRIPTION
closes #1070 
**Summary:**

Display Official Tag on gtfs rt page when applicable

**Expected behavior:** 

When a gtfs rt feed has the official tag property, it should display the tag

**Testing tips:**

Go to any gtfs rt feed on dev and see if the tag is there.

These are the official feeds in dev
```
"mdb-1911"
"mdb-1912"
"mdb-2401"
"mdb-2402"
"mdb-2403"
"mdb-2405"
"mdb-2406"
"mdb-2409"
"mdb-2410"
"mdb-2422"
"mdb-2423"
"mdb-2424"
"mdb-2427"
"mdb-2428"
"mdb-2429"
"mdb-1910"
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)


![image](https://github.com/user-attachments/assets/3414fe9b-5b03-4810-93e8-d97f73fe4dd3)
