### PR TITLE
fix: GTFS validator GCP workflow takes too much time to complete

### DIFF
--- a/workflows/gtfs_validator_execution.yml
+++ b/workflows/gtfs_validator_execution.yml
@@ -116,7 +116,7 @@ main:
                         result: executionResultResponse
                     - validateStatus:
                         next: logExecutionResult
-                # Retrying 120 times with a delay of 10 seconds each time gives 60 minutes wait time.
+                # Retrying 120 times with a delay of 30 seconds each time gives 60 minutes wait time.
                 retry:
                   predicate: ${retry_predicate}
                   max_retries: 120

--- a/workflows/gtfs_validator_execution.yml
+++ b/workflows/gtfs_validator_execution.yml
@@ -116,13 +116,13 @@ main:
                         result: executionResultResponse
                     - validateStatus:
                         next: logExecutionResult
-                # Retrying 120 times with a delay of 10 seconds each time gives 20 minutes wait time.
+                # Retrying 120 times with a delay of 10 seconds each time gives 60 minutes wait time.
                 retry:
                   predicate: ${retry_predicate}
                   max_retries: 120
                   backoff:
-                    initial_delay: 10
-                    max_delay: 10
+                    initial_delay: 30
+                    max_delay: 30
                     multiplier: 1
       - logExecutionResult:
           steps:
@@ -253,56 +253,6 @@ main:
           args:
             text: ${"Created task for feed " + feedID + " Task ID:" + taskResponse.name}
             severity: INFO
-      # The waitForTaskCompletion will wait for HTTP error status 404 from google API.
-      # The cloud tasks API doesn't return a status field and when the task success it HTTP returns 404(tasks not found).
-      - waitForTaskCompletion:
-          try:
-            steps:
-              - getTaskStatus:
-                  call: googleapis.cloudtasks.v2beta3.projects.locations.queues.tasks.get
-                  args:
-                    name: ${taskResponse.name}
-                  result: taskStatus
-              - printTaskStatus:
-                  call: sys.log
-                  args:
-                    text: ${taskStatus}
-                    severity: INFO
-                  next: retryTaskStatus
-          except:
-            as: error
-            steps:
-              - printExceptTaskStatus:
-                  call: sys.log
-                  args:
-                    text: ${"HTTP error raised while calling get tasks endpoint:" + error.message}
-                    severity: INFO
-              - handle404:
-                  switch:
-                    - condition: ${error.code == 404}
-                      next: logTaskCompletion
-                    - condition: ${error.code != 404}
-                      raise: ${error}
-      - retryTaskStatus:
-          call: sys.sleep
-          args:
-            seconds: 30
-          next: waitForTaskCompletion
-      - logTaskCompletion:
-          call: sys.log
-          args:
-            text: ${"Completed task for feed " + feedID + " Task ID:" + taskResponse.name}
-            severity: INFO
-          next: successfulExecution
-      - fileExistenceTimeout:
-          steps:
-            - logFileExistenceTimeout:
-                call: sys.log
-                args:
-                    text: ${"File not found after 20 minutes for datasetID " + datasetID }
-                    severity: ERROR
-            - returnFileNotFound:
-                return:  ${"File not found after 20 minutes for datasetID " + datasetID }
       - successfulExecution:
           steps:
             - logSuccessfulExecution:


### PR DESCRIPTION
**Summary:**

This PR deletes the waitForTaskCompletion step in the  GTFS validator's workflow. This is the strep causing the cost to skyrocket. This RP reduces the ability to know when the GTFS validator process fails for a particular feed. However, this will be addressed as part of #1029  
As a secondary fix, this PR increases the interval time from 10s to 30s for expecting a response from the validator and increases the waiting time to 60 minutes.

Part of #1089 
**Expected behavior:** 
The workflow spending time is reduced.

**Testing tips:**

Go to DEV environment and run a workflow with the proposed structure from this PR.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
