### PR TITLE
feat: add official field in the operational API update endpoint

### DIFF
--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -319,6 +319,9 @@ components:
             - no_change
             - wip
             - published
+        official:
+          type: boolean
+          description: Whether this is an official feed.
       required:
         - id
         - status

--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -364,6 +364,9 @@ components:
             - no_change
             - wip
             - published
+        official:
+          type: boolean
+          description: Whether this is an official feed.
       required:
         - id
         - status

--- a/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_feed_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_feed_impl.py
@@ -64,6 +64,7 @@ class UpdateRequestGtfsFeedImpl(UpdateRequestGtfsFeed):
                 [ExternalIdImpl.from_orm(item) for item in obj.externalids],
                 key=lambda x: x.external_id,
             ),
+            official=obj.official,
         )
 
     @classmethod
@@ -118,6 +119,9 @@ class UpdateRequestGtfsFeedImpl(UpdateRequestGtfsFeed):
             )
             else update_request.source_info.license_url
         )
+        
+        if update_request.official is not None:
+            entity.official = update_request.official
 
         redirecting_ids = (
             []

--- a/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_feed_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_feed_impl.py
@@ -14,11 +14,11 @@
 #  limitations under the License.
 #
 
-from shared.database_gen.sqlacodegen_models import Gtfsfeed
 from feeds_operations.impl.models.external_id_impl import ExternalIdImpl
 from feeds_operations.impl.models.redirect_impl import RedirectImpl
 from feeds_operations_gen.models.source_info import SourceInfo
 from feeds_operations_gen.models.update_request_gtfs_feed import UpdateRequestGtfsFeed
+from shared.database_gen.sqlacodegen_models import Gtfsfeed
 
 
 class UpdateRequestGtfsFeedImpl(UpdateRequestGtfsFeed):
@@ -79,6 +79,7 @@ class UpdateRequestGtfsFeedImpl(UpdateRequestGtfsFeed):
         entity.feed_name = update_request.feed_name
         entity.note = update_request.note
         entity.feed_contact_email = update_request.feed_contact_email
+        entity.official = update_request.official
         entity.producer_url = (
             None
             if (
@@ -119,9 +120,6 @@ class UpdateRequestGtfsFeedImpl(UpdateRequestGtfsFeed):
             )
             else update_request.source_info.license_url
         )
-        
-        if update_request.official is not None:
-            entity.official = update_request.official
 
         redirecting_ids = (
             []

--- a/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_rt_feed_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_rt_feed_impl.py
@@ -71,6 +71,7 @@ class UpdateRequestGtfsRtFeedImpl(UpdateRequestGtfsRtFeed):
                 [EntityTypeImpl.from_orm(item) for item in obj.entitytypes]
             ),
             feed_references=sorted([item.stable_id for item in obj.gtfs_feeds]),
+            official=obj.official,
         )
 
     @classmethod
@@ -125,6 +126,9 @@ class UpdateRequestGtfsRtFeedImpl(UpdateRequestGtfsRtFeed):
             )
             else update_request.source_info.license_url
         )
+        
+        if update_request.official is not None:
+            entity.official = update_request.official
 
         redirecting_ids = (
             []

--- a/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_rt_feed_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/models/update_request_gtfs_rt_feed_impl.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 #
 
-from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsrealtimefeed
 from feeds_operations.impl.models.entity_type_impl import EntityTypeImpl
 from feeds_operations.impl.models.external_id_impl import ExternalIdImpl
 from feeds_operations.impl.models.redirect_impl import RedirectImpl
@@ -22,6 +21,7 @@ from feeds_operations_gen.models.source_info import SourceInfo
 from feeds_operations_gen.models.update_request_gtfs_rt_feed import (
     UpdateRequestGtfsRtFeed,
 )
+from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsrealtimefeed
 
 
 class UpdateRequestGtfsRtFeedImpl(UpdateRequestGtfsRtFeed):
@@ -86,6 +86,7 @@ class UpdateRequestGtfsRtFeedImpl(UpdateRequestGtfsRtFeed):
         entity.feed_name = update_request.feed_name
         entity.note = update_request.note
         entity.feed_contact_email = update_request.feed_contact_email
+        entity.official = update_request.official
         entity.producer_url = (
             None
             if (
@@ -126,9 +127,6 @@ class UpdateRequestGtfsRtFeedImpl(UpdateRequestGtfsRtFeed):
             )
             else update_request.source_info.license_url
         )
-        
-        if update_request.official is not None:
-            entity.official = update_request.official
 
         redirecting_ids = (
             []

--- a/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs_rt.py
+++ b/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs_rt.py
@@ -40,6 +40,7 @@ def update_request_gtfs_rt_feed():
         redirects=[],
         operational_status_action="no_change",
         entity_types=[EntityType.VP],
+        official=True,
     )
 
 
@@ -137,3 +138,27 @@ async def test_update_gtfs_rt_feed_set_published(_, update_request_gtfs_rt_feed)
             .one()
         )
         assert db_feed.operational_status == "published"
+
+
+@patch("shared.helpers.logger.Logger")
+@mock.patch.dict(
+    os.environ,
+    {
+        "FEEDS_DATABASE_URL": default_db_url,
+    },
+)
+@pytest.mark.asyncio
+async def test_update_gtfs_rt_feed_official_field(_, update_request_gtfs_rt_feed):
+    """Test updating the official field of a GTFS-RT feed."""
+    update_request_gtfs_rt_feed.official = True
+    with get_testing_session() as session:
+        api = OperationsApiImpl()
+        response: Response = await api.update_gtfs_rt_feed(update_request_gtfs_rt_feed)
+        assert response.status_code == 200
+
+        db_feed = (
+            session.query(Gtfsrealtimefeed)
+            .filter(Gtfsrealtimefeed.stable_id == feed_mdb_41.stable_id)
+            .one()
+        )
+        assert db_feed.official is True


### PR DESCRIPTION
**Summary:**

This PR add official field  as a boolean in the operational API update endpoint.

**Expected behavior:** 
Official status for feed can be added via the operational api updated endpoint

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
