### PR TITLE
Feat: checkbox filter enhancements

### DIFF
--- a/web-app/src/app/components/NestedCheckboxList.spec.tsx
+++ b/web-app/src/app/components/NestedCheckboxList.spec.tsx
@@ -1,0 +1,135 @@
+import {
+  checkboxCheckValue,
+  checkboxIndeterminateValue,
+  CheckboxStructure,
+} from './NestedCheckboxList';
+
+const baseCheckbox = (
+  overrides: Partial<CheckboxStructure> = {},
+): CheckboxStructure => ({
+  title: 'Test Checkbox',
+  type: 'checkbox',
+  checked: false,
+  disabled: false,
+  children: [],
+  ...overrides,
+});
+
+describe('checkboxCheckValue', () => {
+  it('returns false if checkbox is disabled', () => {
+    const checkbox = {
+      checked: true,
+      disabled: true,
+      children: [],
+    } as unknown as CheckboxStructure;
+    expect(checkboxCheckValue(checkbox, false)).toBe(false);
+  });
+
+  it('returns false if disableAll is true', () => {
+    const checkbox = {
+      checked: true,
+      disabled: false,
+      children: [],
+    } as unknown as CheckboxStructure;
+    expect(checkboxCheckValue(checkbox, true)).toBe(false);
+  });
+
+  it('returns true if checked is true and not disabled', () => {
+    const checkbox = {
+      checked: true,
+      disabled: false,
+      children: [],
+    } as unknown as CheckboxStructure;
+    expect(checkboxCheckValue(checkbox, false)).toBe(true);
+  });
+
+  it('returns true if all children are checked', () => {
+    const checkbox = {
+      checked: false,
+      disabled: false,
+      children: [
+        { checked: true, disabled: false },
+        { checked: true, disabled: false },
+      ],
+    } as unknown as CheckboxStructure;
+    expect(checkboxCheckValue(checkbox, false)).toBe(true);
+  });
+
+  it('returns false if any child is not checked', () => {
+    const checkbox = {
+      checked: false,
+      disabled: false,
+      children: [
+        { checked: true, disabled: false },
+        { checked: false, disabled: false },
+      ],
+    } as unknown as CheckboxStructure;
+    expect(checkboxCheckValue(checkbox, false)).toBe(false);
+  });
+});
+
+describe('checkboxIndeterminateValue', () => {
+  it('returns false if disableAll is true', () => {
+    const checkbox = baseCheckbox({
+      children: [baseCheckbox({ checked: true, disabled: false })],
+    });
+    expect(checkboxIndeterminateValue(checkbox, true)).toBe(false);
+  });
+
+  it('returns false if children is undefined', () => {
+    const checkbox = baseCheckbox({
+      children: undefined,
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(false);
+  });
+
+  it('returns false if all children are checked', () => {
+    const checkbox = baseCheckbox({
+      children: [
+        baseCheckbox({ checked: true, disabled: false }),
+        baseCheckbox({ checked: true, disabled: false }),
+      ],
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(false);
+  });
+
+  it('returns false if no children are checked', () => {
+    const checkbox = baseCheckbox({
+      children: [
+        baseCheckbox({ checked: false, disabled: false }),
+        baseCheckbox({ checked: false, disabled: false }),
+      ],
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(false);
+  });
+
+  it('returns true if some children are checked and some are not', () => {
+    const checkbox = baseCheckbox({
+      children: [
+        baseCheckbox({ checked: true, disabled: false }),
+        baseCheckbox({ checked: false, disabled: false }),
+      ],
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(true);
+  });
+
+  it('returns false if all children are disabled', () => {
+    const checkbox = baseCheckbox({
+      children: [
+        baseCheckbox({ checked: true, disabled: true }),
+        baseCheckbox({ checked: false, disabled: true }),
+      ],
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(false);
+  });
+
+  it('returns true if some children are checked and some are not, and not all children are disabled', () => {
+    const checkbox = baseCheckbox({
+      children: [
+        baseCheckbox({ checked: true, disabled: false }),
+        baseCheckbox({ checked: false, disabled: true }),
+      ],
+    });
+    expect(checkboxIndeterminateValue(checkbox, false)).toBe(true);
+  });
+});

--- a/web-app/src/app/components/NestedCheckboxList.spec.tsx
+++ b/web-app/src/app/components/NestedCheckboxList.spec.tsx
@@ -1,7 +1,7 @@
 import {
   checkboxCheckValue,
   checkboxIndeterminateValue,
-  CheckboxStructure,
+  type CheckboxStructure,
 } from './NestedCheckboxList';
 
 const baseCheckbox = (

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -401,7 +401,7 @@ export default function Feed(): React.ReactElement {
                 </>
               )}
 
-              {(config.enableFeatureFilterSearch) && (
+              {config.enableFeatureFilterSearch && (
                 <>
                   <SearchHeader
                     variant='h6'

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -77,6 +77,10 @@ export default function Feed(): React.ReactElement {
   const feedsData = useSelector(selectFeedsData);
   const feedStatus = useSelector(selectFeedsStatus);
 
+  // features i/o
+  const areFeatureFiltersEnabled =
+    selectedFeedTypes.gtfs_rt === false || selectedFeedTypes.gtfs === true;
+
   const getPaginationOffset = (activePagination?: number): number => {
     const paginationParam =
       searchParams.get('o') !== null ? Number(searchParams.get('o')) : 1;
@@ -397,10 +401,17 @@ export default function Feed(): React.ReactElement {
                 </>
               )}
 
-              {config.enableFeatureFilterSearch && (
+              {(config.enableFeatureFilterSearch || 3 > 2) && (
                 <>
-                  <SearchHeader variant='h6'>Features</SearchHeader>
+                  <SearchHeader
+                    variant='h6'
+                    sx={areFeatureFiltersEnabled ? {} : { opacity: 0.5 }}
+                  >
+                    Features
+                  </SearchHeader>
                   <NestedCheckboxList
+                    disableAll={!areFeatureFiltersEnabled}
+                    debounceTime={500}
                     checkboxData={featureCheckboxData}
                     onExpandGroupChange={(checkboxData) => {
                       const newExpandGroup: Record<string, boolean> = {};
@@ -474,19 +485,20 @@ export default function Feed(): React.ReactElement {
                     }}
                   />
                 )}
-                {selectedFeatures.map((feature) => (
-                  <Chip
-                    color='secondary'
-                    size='small'
-                    label={feature}
-                    key={feature}
-                    onDelete={() => {
-                      setSelectedFeatures([
-                        ...selectedFeatures.filter((sf) => sf !== feature),
-                      ]);
-                    }}
-                  />
-                ))}
+                {areFeatureFiltersEnabled &&
+                  selectedFeatures.map((feature) => (
+                    <Chip
+                      color='secondary'
+                      size='small'
+                      label={feature}
+                      key={feature}
+                      onDelete={() => {
+                        setSelectedFeatures([
+                          ...selectedFeatures.filter((sf) => sf !== feature),
+                        ]);
+                      }}
+                    />
+                  ))}
                 {(selectedFeatures.length > 0 ||
                   isOfficialFeedSearch ||
                   selectedFeedTypes.gtfs_rt ||

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -79,7 +79,7 @@ export default function Feed(): React.ReactElement {
 
   // features i/o
   const areFeatureFiltersEnabled =
-    selectedFeedTypes.gtfs_rt === false || selectedFeedTypes.gtfs === true;
+    !selectedFeedTypes.gtfs_rt || selectedFeedTypes.gtfs;
 
   const getPaginationOffset = (activePagination?: number): number => {
     const paginationParam =

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -401,7 +401,7 @@ export default function Feed(): React.ReactElement {
                 </>
               )}
 
-              {(config.enableFeatureFilterSearch || 3 > 2) && (
+              {(config.enableFeatureFilterSearch) && (
                 <>
                   <SearchHeader
                     variant='h6'


### PR DESCRIPTION
**Summary:**

closes: #842 

Enhancements to the checkbox filter found on the feeds search page
- Disabled state
- Debounce when multi select
- Refactor code to use recursive component

**Expected behavior:** 

1. When selecting 'GTFS Realtime' and 'GTFS Schedule' is not selected. The Features filter will be disabled. If the user has already selected features, they will be de-selected and all the expanding elements closed. Once the Feature filter is no longer disabled, the state will return back to what it was
2. When selecting features in rapid succession, the app will wait 500ms before triggering a search call

**Testing tips:**

Go to the Feeds Search page and play around with the filters and keep an eye on the chips. UX feedback is also appreciated. 

NOTE: Feature filter does not work with the backend yet, do not verify if the feeds displayed are correct

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![Screenshot 2025-04-14 at 15 44 15](https://github.com/user-attachments/assets/955dc3d9-2dcf-4304-86b1-0837e917618c)
