### PR TITLE
fix: remove gbfs populate script from mdb catalog trigger

### DIFF
--- a/.github/workflows/db-update.yml
+++ b/.github/workflows/db-update.yml
@@ -192,16 +192,6 @@ jobs:
       id: getpath
       run: echo "PATH=$(realpath sources.csv)" >> $GITHUB_OUTPUT
 
-    - name: Download systems.csv
-      run: wget -O systems.csv https://raw.githubusercontent.com/MobilityData/gbfs/master/systems.csv
-
-    - name: Get full path of systems.csv
-      id: getsyspath
-      run: echo "PATH=$(realpath systems.csv)" >> $GITHUB_OUTPUT
-
-    - name: GBFS - Update Database Content
-      run: scripts/populate-db.sh ${{ steps.getsyspath.outputs.PATH }} gbfs >> populate-gbfs.log
-
     - name: GTFS - Update Database Content
       run: scripts/populate-db.sh ${{ steps.getpath.outputs.PATH }} > populate.log
 
@@ -211,13 +201,6 @@ jobs:
       with:
         name: populate-${{ inputs.ENVIRONMENT }}.log
         path: populate.log
-
-    - name: GBFS - Upload log file for verification
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-          name: populate-gbfs-${{ inputs.ENVIRONMENT }}.log
-          path: populate-gbfs.log
 
   update-gcp-secret:
     name: Update GCP Secrets


### PR DESCRIPTION
**Summary:**

Part of #675 

This pull request includes changes to the `.github/workflows/db-update.yml` file to streamline the database update process by removing the steps related to downloading and processing the `systems.csv` file for GBFS. The most important changes include the removal of steps for downloading `systems.csv`, getting its full path, updating the database content with GBFS data, and uploading the GBFS log file for verification.

Streamlining the database update process:

* Removed steps for downloading `systems.csv`, getting its full path, and updating the database content with GBFS data.
* Removed the step for uploading the GBFS log file for verification.

**Expected behavior:** 

GBFS populate script is not executed when the mobility database catalog merge event is triggered.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
