### PR TITLE
feat: add operational status of "unpublished" to opeartions_api

### DIFF
--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -33,7 +33,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [ wip, published ]
+            enum: [ wip, published, unpublished ]
         - name: data_type
           in: query
           description: Filter feeds by data type.
@@ -179,7 +179,7 @@ components:
           $ref: "#/components/schemas/SourceInfo"
         operational_status:
           type: string
-          enum: [ wip, published ]
+          enum: [ wip, published, unpublished ]
           description: Current operational status of the feed.
         created_at:
           type: string
@@ -319,6 +319,7 @@ components:
             - no_change
             - wip
             - published
+            - unpublished
         official:
           type: boolean
           description: Whether this is an official feed.
@@ -367,6 +368,7 @@ components:
             - no_change
             - wip
             - published
+            - unpublished
         official:
           type: boolean
           description: Whether this is an official feed.

--- a/functions-python/operations_api/src/feeds_operations/impl/feeds_operations_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/feeds_operations_impl.py
@@ -238,6 +238,8 @@ class OperationsApiImpl(BaseOperationsApi):
                 feed.operational_status = "wip"
             elif action.lower() == "published":
                 feed.operational_status = "published"
+            elif action.lower() == "unpublished":
+                feed.operational_status = "unpublished"
         session.add(feed)
 
     @staticmethod

--- a/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs.py
+++ b/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs.py
@@ -134,6 +134,25 @@ async def test_update_gtfs_feed_set_published(_, update_request_gtfs_feed, db_se
 
 @patch("shared.helpers.logger.Logger")
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("update_request_gtfs_feed", "db_session")
+async def test_update_gtfs_feed_set_unpublished(
+    _, update_request_gtfs_feed, db_session
+):
+    update_request_gtfs_feed.operational_status_action = "unpublished"
+    api = OperationsApiImpl()
+    response: Response = await api.update_gtfs_feed(update_request_gtfs_feed)
+    assert response.status_code == 200
+
+    db_feed = (
+        db_session.query(Gtfsfeed)
+        .filter(Gtfsfeed.stable_id == feed_mdb_40.stable_id)
+        .one()
+    )
+    assert db_feed.operational_status == "unpublished"
+
+
+@patch("shared.helpers.logger.Logger")
+@pytest.mark.asyncio
 async def test_update_gtfs_feed_invalid_feed(_, update_request_gtfs_feed):
     update_request_gtfs_feed.id = "invalid"
     api = OperationsApiImpl()

--- a/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs_rt.py
+++ b/functions-python/operations_api/tests/feeds_operations/impl/test_feeds_operations_impl_gtfs_rt.py
@@ -131,6 +131,25 @@ async def test_update_gtfs_rt_feed_set_published(
 
 @patch("shared.helpers.logger.Logger")
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("update_request_gtfs_rt_feed", "db_session")
+async def test_update_gtfs_rt_feed_set_unpublished(
+    _, update_request_gtfs_rt_feed, db_session
+):
+    update_request_gtfs_rt_feed.operational_status_action = "unpublished"
+    api = OperationsApiImpl()
+    response: Response = await api.update_gtfs_rt_feed(update_request_gtfs_rt_feed)
+    assert response.status_code == 200
+
+    db_feed = (
+        db_session.query(Gtfsrealtimefeed)
+        .filter(Gtfsrealtimefeed.stable_id == feed_mdb_41.stable_id)
+        .one()
+    )
+    assert db_feed.operational_status == "unpublished"
+
+
+@patch("shared.helpers.logger.Logger")
+@pytest.mark.asyncio
 async def test_update_gtfs_rt_feed_official_field(
     _, update_request_gtfs_rt_feed, db_session
 ):

--- a/functions-python/operations_api/tests/feeds_operations/impl/test_get_feeds.py
+++ b/functions-python/operations_api/tests/feeds_operations/impl/test_get_feeds.py
@@ -218,3 +218,60 @@ async def test_get_feeds_gtfs_rt_entity_types():
         assert isinstance(feed.entity_types, list)
         for entity_type in feed.entity_types:
             assert entity_type in ["vp", "tu", "sa"]
+
+
+@pytest.mark.asyncio
+async def test_get_feeds_unpublished_status():
+    """
+    Test get_feeds endpoint with unpublished operational status filter.
+    Should return only feeds with unpublished status.
+    """
+    api = OperationsApiImpl()
+
+    # Test with unpublished status filter
+    response = await api.get_feeds(operation_status="unpublished")
+    assert response is not None
+    for feed in response.feeds:
+        assert feed.operational_status == "unpublished"
+
+
+@pytest.mark.asyncio
+async def test_get_feeds_all_operational_statuses():
+    """
+    Test get_feeds endpoint with all possible operational status values.
+    Verifies that each operational status filter works correctly.
+    """
+    api = OperationsApiImpl()
+
+    # Test each operational status
+    for status in ["wip", "published", "unpublished"]:
+        response = await api.get_feeds(operation_status=status)
+        assert response is not None
+        for feed in response.feeds:
+            assert feed.operational_status == status
+
+
+@pytest.mark.asyncio
+async def test_get_feeds_unpublished_with_data_type():
+    """
+    Test get_feeds endpoint with unpublished status and data type filters combined.
+    """
+    api = OperationsApiImpl()
+
+    gtfs_response = await api.get_feeds(
+        operation_status="unpublished", data_type="gtfs"
+    )
+    assert gtfs_response is not None
+    for feed in gtfs_response.feeds:
+        assert feed.operational_status == "unpublished"
+        assert feed.data_type == "gtfs"
+        assert isinstance(feed, GtfsFeedResponse)
+
+    rt_response = await api.get_feeds(
+        operation_status="unpublished", data_type="gtfs_rt"
+    )
+    assert rt_response is not None
+    for feed in rt_response.feeds:
+        assert feed.operational_status == "unpublished"
+        assert feed.data_type == "gtfs_rt"
+        assert isinstance(feed, GtfsRtFeedResponse)

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -51,5 +51,4 @@
 <!-- Materialized view updated. Added features and totals. -->
     <include file="changes/feat_993.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1132.sql" relativeToChangelogFile="true"/>
-    <include file="changes/feat_1132_2.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -48,4 +48,6 @@
     <include file="changes/feat_1055.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1041.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_997.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_1132.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_1132_2.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_1132.sql
+++ b/liquibase/changes/feat_1132.sql
@@ -1,0 +1,20 @@
+-- Add 'unpublished' to the OperationalStatus enum if it doesn't exist
+DO $$
+BEGIN
+    -- Check if the enum already has the 'unpublished' value
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_enum
+        WHERE enumlabel = 'unpublished'
+        AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'operationalstatus')
+    ) THEN
+        -- Add 'unpublished' to the enum
+        ALTER TYPE OperationalStatus ADD VALUE 'unpublished';
+        RAISE NOTICE 'Added ''unpublished'' value to OperationalStatus enum';
+    ELSE
+        RAISE NOTICE 'The ''unpublished'' value already exists in OperationalStatus enum';
+    END IF;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to add ''unpublished'' to OperationalStatus enum: %', SQLERRM;
+END $$;

--- a/liquibase/changes/feat_1132_2.sql
+++ b/liquibase/changes/feat_1132_2.sql
@@ -1,8 +1,0 @@
-DO $$
-BEGIN
-    REFRESH MATERIALIZED VIEW FeedSearch;
-    RAISE NOTICE 'Refreshed FeedSearch materialized view';
-EXCEPTION
-    WHEN OTHERS THEN
-        RAISE EXCEPTION 'Failed to refresh FeedSearch materialized view: %', SQLERRM;
-END $$;

--- a/liquibase/changes/feat_1132_2.sql
+++ b/liquibase/changes/feat_1132_2.sql
@@ -1,0 +1,8 @@
+DO $$
+BEGIN
+    REFRESH MATERIALIZED VIEW FeedSearch;
+    RAISE NOTICE 'Refreshed FeedSearch materialized view';
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to refresh FeedSearch materialized view: %', SQLERRM;
+END $$;


### PR DESCRIPTION

**Summary:**

This PR adds "unpublished" as an operational_status to the operations_api allowing feeds to be set to unpublished. Feeds set to unpublished can all be searched via the get endpoint.

**Expected behavior:** 

Feed can set to unpublished

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
