### PR TITLE
fix: update populate script -> feed status only on new feeds

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -211,6 +211,7 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                     created_at=datetime.now(pytz.utc),
                     operational_status="published",
                 )
+                feed.status = self.get_safe_value(row, "status", "active")
                 self.logger.info(f"Creating {feed.__class__.__name__}: {stable_id}")
                 session.add(feed)
                 if data_type == "gtfs":
@@ -237,7 +238,6 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
             feed.authentication_info_url = self.get_safe_value(row, "urls.authentication_info", "")
             feed.api_key_parameter_name = self.get_safe_value(row, "urls.api_key_parameter_name", "")
             feed.license_url = self.get_safe_value(row, "urls.license", "")
-            feed.status = self.get_safe_value(row, "status", "active")
             feed.feed_contact_email = self.get_safe_value(row, "feed_contact_email", "")
             feed.provider = self.get_safe_value(row, "provider", "")
 


### PR DESCRIPTION
**Summary:**

The populate script is setting the status to 'active' for all feeds it processes, which can lead to wrong feed statuses. This PR sets the feed status to active only if it's a new feed. 

**Expected behavior:** 

When the populate script runs, it shouldn't update the feed status for existing feeds

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
