### PR TITLE
fix: sqlalchemy sync bugs + batch fill

### DIFF
--- a/functions-python/reverse_geolocation/README.md
+++ b/functions-python/reverse_geolocation/README.md
@@ -16,6 +16,10 @@ This HTTP function initiates reverse geolocation for multiple feeds. It accepts 
 
 - **`country_codes`** (optional): A comma-separated list of country codes specifying which feeds should be processed.  
   - If not provided, the function processes feeds from all available countries.
+- **`include_only_unprocessed`** (optional): A boolean flag indicating whether to include only feeds that have not been processed yet.  
+  - If set to `true`, only unprocessed feeds will be considered for reverse geolocation.
+  - If set to `false`, all feeds will be processed, regardless of their processing status.
+  - Default is `true`.
 
 **Behavior:**  
 The function publishes a message to the `reverse-geolocation` Pub/Sub topic for each non deprecated feed that matches the specified country codes.  

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
@@ -215,6 +215,7 @@ def extract_location_aggregate(
     stop = Feedlocationgrouppoint(feed_id=feed_id, geometry=stop_point)
     stop.group = group
     db_session.add(stop)
+    db_session.flush()
     logging.info(
         f"Point {stop_point} matched to {', '.join([g.name for g in geopolygons])}"
     )
@@ -359,11 +360,13 @@ def extract_location_aggregates(
         )
         for location_group in location_aggregates.values()
     ]
-    gtfs_feed.feedosmlocationgroups = osm_location_groups
+    gtfs_feed.feedosmlocationgroups.clear()
+    gtfs_feed.feedosmlocationgroups.extend(osm_location_groups)
+
     for gtfs_rt_feed in gtfs_feed.gtfs_rt_feeds:
         logging.info(f"Updating GTFS-RT feed with stable ID {gtfs_rt_feed.stable_id}")
         gtfs_rt_feed.feedosmlocationgroups.clear()
-        gtfs_rt_feed.feedosmlocationgroups = osm_location_groups
+        gtfs_rt_feed.feedosmlocationgroups.extend(osm_location_groups)
 
     feed_locations = []
     for location_aggregate in location_aggregates.values():


### PR DESCRIPTION
###  **Summary**
Closes #1072.

This PR addresses an issue where certain feeds (e.g. [mdb-2444](https://mobilitydatabase.org/feeds/gtfs/mdb-2444)) were not processed correctly because their dataset zip file was uploaded to GCS **before** the corresponding database entity was created. Since the reverse geolocation process is triggered by the GCS event, it would attempt to fetch the dataset and fail when the DB record wasn’t available yet.

This behavior is similar to a previously resolved bug that was preventing validation reports from being processed. As the core logic already handles that case, no additional fix was necessary beyond ensuring proper sync timing.

Additionally, minor SQLAlchemy relationship sync issues were identified and resolved as part of this PR to prevent cascade-related errors and duplicate key issues.

A new optional query parameter `include_only_unprocessed` was added to the batch reverse geolocation endpoint. It defaults to `true` and allows targeting only feeds that haven't yet been processed — avoiding unnecessary re-processing of already handled feeds.

### **Expected Behavior**

- Reverse geolocation no longer fails when a feed’s dataset was added to GCS before the DB entity existed.
- The batch fill process can now skip feeds that already have location data.
- The optional query param can be toggled via `include_only_unprocessed=false` if you want to force reprocessing.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
