### PR TITLE
fix: log the status diff

### DIFF
--- a/functions-python/helpers/feed_status.py
+++ b/functions-python/helpers/feed_status.py
@@ -77,6 +77,7 @@ def update_feed_statuses_query(session: "Session", stable_feed_ids: list[str]):
         session.commit()
         refresh_materialized_view(session, t_feedsearch.name)
         logging.info("Feed Database changes for status committed.")
+        logging.info("Status Changes: %s", diff_counts)
         session.close()
         return diff_counts
     except Exception as e:


### PR DESCRIPTION
**Summary:**

In #953 the objective was to log the differences in the feed status updates. We return the difference as a json object but we never log them, and GCP logs do not display the response. The objective of this PR is to log the differences

**Expected behavior:** 

It should log the differences when running update feed status functions

**Testing tips:**

Run update_feed_status and see if it logs out the difference

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
