### PR TITLE
test: improved test coverage for gbfs endpoints

### DIFF
--- a/api/tests/test_data/extra_test_data.json
+++ b/api/tests/test_data/extra_test_data.json
@@ -759,5 +759,74 @@
       "severity": "ERROR",
       "total_notices": 2
     }
+  ],
+  "gbfs_versions": [
+    {
+      "feed_id": "gbfs-system_id_1",
+      "id": "gbfs-system_id_1-2.3",
+      "version": "2.3",
+      "url": "https://www.example.com/gbfs_feed_1/2.3/gbfs.json",
+      "latest": false,
+      "endpoints": [
+        {
+          "id": "gbfs-system_id_1-2.3-system_information",
+          "url": "https://www.example.com/gbfs_feed_1/2.3/system_information.json",
+          "language": "en",
+          "name": "system_information",
+          "is_feature": false
+        },
+        {
+          "id": "gbfs-system_id_1-2.3-vehicle_position",
+          "url": "https://www.example.com/gbfs_feed_1/2.3/vehicule_position.json",
+          "language": "en",
+          "name": "vehicle_position",
+          "is_feature": false
+        }
+      ]
+    },
+    {
+      "feed_id": "gbfs-system_id_1",
+      "id": "gbfs-system_id_1-3.0",
+      "version": "3.0",
+      "url": "https://www.example.com/gbfs_feed_1/3.0/gbfs.json",
+      "latest": true,
+      "endpoints": [
+        {
+          "id": "gbfs-system_id_1-3.0-system_information",
+          "url": "https://www.example.com/gbfs_feed_1/3.0/system_information.json",
+          "name": "system_information",
+          "is_feature": false
+        },
+        {
+          "id": "gbfs-system_id_1-3.0-vehicle_position",
+          "url": "https://www.example.com/gbfs_feed_1/3.0/vehicule_position.json",
+          "name": "vehicle_position",
+          "is_feature": false
+        }
+      ]
+    },
+    {
+      "feed_id": "gbfs-system_id_2",
+      "id": "gbfs-system_id_2-2.3",
+      "version": "2.3",
+      "url": "https://www.example.com/gbfs_feed_1/2.3/gbfs.json",
+      "latest": false,
+      "endpoints": [
+        {
+          "id": "gbfs-system_id_2-2.3-system_information",
+          "url": "https://www.example.com/gbfs_feed_2/2.3/system_information.json",
+          "language": "en",
+          "name": "system_information",
+          "is_feature": false
+        },
+        {
+          "id": "gbfs-system_id_2-2.3-vehicle_position",
+          "url": "https://www.example.com/gbfs_feed_2/2.3/vehicule_position.json",
+          "language": "en",
+          "name": "vehicle_position",
+          "is_feature": false
+        }
+      ]
+    }
   ]
 }

--- a/integration-tests/src/endpoints/gbfs_feeds.py
+++ b/integration-tests/src/endpoints/gbfs_feeds.py
@@ -1,0 +1,77 @@
+from endpoints.integration_tests import IntegrationTests
+
+
+class GBFSFeedsEndpointTests(IntegrationTests):
+    def __init__(self, file_path, access_token, url, progress):
+        super().__init__(file_path, access_token, url, progress=progress)
+
+    def test_gbfs_feeds_filter_by_provider(self):
+        """Test retrieval of GBFS feeds filtered by provider"""
+        providers = ["BIXI Montréal", "Bird Laval", "Lime Ottawa"]
+        task_id = self.progress.add_task(
+            "[yellow]Validating GTFS feeds by provider...[/yellow]",
+            total=len(providers),
+        )
+        for i, provider_id in enumerate(providers):
+            self._test_filter_by_provider(
+                provider_id,
+                "v1/gbfs_feeds",
+                task_id=task_id,
+                index=f"{i + 1}/{len(providers)}",
+            )
+
+    def test_gbfs_feeds_filter_by_version(self):
+        """Test retrieval of GBFS feeds filtered by version"""
+        versions = ["1.0", "2.3", "3.0"]
+        task_id = self.progress.add_task(
+            "[yellow]Validating GTFS feeds by version...[/yellow]",
+            total=len(versions),
+        )
+        total_returned = 0
+        for i, version in enumerate(versions):
+            response = self.get_response(
+                "v1/gbfs_feeds",
+                params={"version": version},
+            )
+            assert (
+                response.status_code == 200
+            ), f"Expected 200 status code for version '{version}', got {response.status_code}."
+            gbfs_feeds = response.json()
+            total_returned += len(gbfs_feeds)
+            self.console.log(
+                ""
+                f"Number of feeds returned for version '{version}': {len(gbfs_feeds)}"
+            )
+            self._update_progression(
+                task_id,
+                f"Retrieved feeds version {version}",
+                f"{(i + 1)} / {len(versions)}",
+            )
+        assert (
+            total_returned > 0
+        ), f"No feeds returned for the specified versions: {versions}."
+
+    def test_gbfs_feeds_filter_by_system_id(self):
+        """Test retrieval of GBFS feeds filtered by system_id"""
+        system_ids = ["bird-edmonton", "Bixi_MTL", "lime_ottawa"]
+        task_id = self.progress.add_task(
+            "[yellow]Validating GTFS feeds by system_id...[/yellow]",
+            total=len(system_ids),
+        )
+        for i, system_id in enumerate(system_ids):
+            response = self.get_response(
+                "v1/gbfs_feeds",
+                params={"system_id": system_id},
+            )
+            assert (
+                response.status_code == 200
+            ), f"Expected 200 status code for system_id '{system_id}', got {response.status_code}."
+            gbfs_feeds = response.json()
+            assert (
+                len(gbfs_feeds) > 0
+            ), f"No feeds returned for system_id '{system_id}'."
+            self._update_progression(
+                task_id,
+                f"Retrieved feeds system_id {system_id}",
+                f"{(i + 1)} / {len(system_ids)}",
+            )

--- a/integration-tests/src/endpoints/gbfs_feeds.py
+++ b/integration-tests/src/endpoints/gbfs_feeds.py
@@ -9,7 +9,7 @@ class GBFSFeedsEndpointTests(IntegrationTests):
         """Test retrieval of GBFS feeds filtered by provider"""
         providers = ["BIXI Montréal", "Bird Laval", "Lime Ottawa"]
         task_id = self.progress.add_task(
-            "[yellow]Validating GTFS feeds by provider...[/yellow]",
+            "[yellow]Validating GBFS feeds by provider...[/yellow]",
             total=len(providers),
         )
         for i, provider_id in enumerate(providers):
@@ -24,7 +24,7 @@ class GBFSFeedsEndpointTests(IntegrationTests):
         """Test retrieval of GBFS feeds filtered by version"""
         versions = ["1.0", "2.3", "3.0"]
         task_id = self.progress.add_task(
-            "[yellow]Validating GTFS feeds by version...[/yellow]",
+            "[yellow]Validating GBFS feeds by version...[/yellow]",
             total=len(versions),
         )
         total_returned = 0
@@ -55,7 +55,7 @@ class GBFSFeedsEndpointTests(IntegrationTests):
         """Test retrieval of GBFS feeds filtered by system_id"""
         system_ids = ["bird-edmonton", "Bixi_MTL", "lime_ottawa"]
         task_id = self.progress.add_task(
-            "[yellow]Validating GTFS feeds by system_id...[/yellow]",
+            "[yellow]Validating GBFS feeds by system_id...[/yellow]",
             total=len(system_ids),
         )
         for i, system_id in enumerate(system_ids):


### PR DESCRIPTION
**Summary:**

- Added integration test cases to validate filtering by provider, version, and system_id on the GBFS endpoint.
- Expanded integration tests in the feeds API to cover various filter parameters and expected outcomes.
- Updated the database test population script to support GBFS versions and endpoints.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
