### PR TITLE
fix: override deprecated status from csv

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -202,6 +202,10 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
             feed = self.query_feed_by_stable_id(session, stable_id, data_type)
             if feed:
                 self.logger.debug(f"Updating {feed.__class__.__name__}: {stable_id}")
+                # Always set the deprecated status if found in the csv
+                csv_status = self.get_safe_value(row, "status", "active")
+                if csv_status.lower() == "deprecated":
+                    feed.status = "deprecated"
             else:
                 feed = self.get_model(data_type)(
                     id=generate_unique_id(),
@@ -223,10 +227,6 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                         source="mdb",
                     )
                 ]
-            # Always set the deprecated status if found in the csv
-            csv_status = self.get_safe_value(row, "status", "active")
-            if csv_status.lower() == "deprecated":
-                feed.status = "deprecated"
             # If the is_official field from the CSV is empty, the value here will be None and we don't touch the DB
             if is_official_from_csv is not None:
                 if feed.official != is_official_from_csv:

--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -223,7 +223,10 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                         source="mdb",
                     )
                 ]
-
+            # Always set the deprecated status if found in the csv
+            csv_status = self.get_safe_value(row, "status", "active")
+            if csv_status.lower() == "deprecated":
+                feed.status = "deprecated"
             # If the is_official field from the CSV is empty, the value here will be None and we don't touch the DB
             if is_official_from_csv is not None:
                 if feed.official != is_official_from_csv:


### PR DESCRIPTION
**Summary:**

The change ensures that the `status` field is set to "deprecated" if the corresponding value in the CSV file indicates it. 
Related to: #1143

**Expected behavior:** 

The deprecated status is set to the feed if it's coming from the CSV.

**Testing tips:**

This can be tested locally if the populate script is executed with a non-empty DB.
Tested in DEV with [action](https://github.com/MobilityData/mobility-feed-api/actions/runs/14715398487/job/41297556697)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
