### PR TITLE
bug: fix bug making operations feeds endpoint fail when called without data_type filtering

### DIFF
--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -109,6 +109,10 @@ def get_feeds_query(
 
         conditions = []
 
+        if data_type is None:
+            conditions.append(model.data_type.in_(["gtfs", "gtfs_rt"]))
+            logging.info("Added filter to exclude gbfs feeds")
+
         if operation_status:
             conditions.append(model.operational_status == operation_status)
             logging.info("Added operational_status filter: %s", operation_status)

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -2,6 +2,10 @@ import logging
 from datetime import datetime
 from typing import Type
 
+from sqlalchemy import and_
+from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm.query import Query
+
 from shared.database_gen.sqlacodegen_models import (
     Feed,
     Gtfsrealtimefeed,
@@ -10,9 +14,6 @@ from shared.database_gen.sqlacodegen_models import (
     Gtfsdataset,
     Validationreport,
 )
-from sqlalchemy import and_
-from sqlalchemy.orm import Session, joinedload
-from sqlalchemy.orm.query import Query
 
 feed_mapping = {"gtfs_rt": Gtfsrealtimefeed, "gtfs": Gtfsfeed, "gbfs": Gbfsfeed}
 


### PR DESCRIPTION
**Summary:**

This PR fixes the bug that makes operations feeds endpoint fail when called without data_type filtering. Added a filter to filter out gbfs feeds from the get endpoint

**Expected behavior:** 

Get feeds endpoint can be call without data_type filtering.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
