### PR TITLE
feat: added versions filtering to search

### DIFF
--- a/api/src/feeds/impl/models/search_feed_item_result_impl.py
+++ b/api/src/feeds/impl/models/search_feed_item_result_impl.py
@@ -76,6 +76,7 @@ class SearchFeedItemResultImpl(SearchFeedItemResult):
             external_ids=feed_search_row.external_ids,
             provider=feed_search_row.provider,
             feed_contact_email=feed_search_row.feed_contact_email,
+            versions=feed_search_row.versions,
             source_info=SourceInfo(
                 producer_url=feed_search_row.producer_url,
                 authentication_type=int(feed_search_row.authentication_type)

--- a/api/src/feeds/impl/search_api_impl.py
+++ b/api/src/feeds/impl/search_api_impl.py
@@ -31,7 +31,9 @@ class SearchApiImpl(BaseSearchApi):
         return func.plainto_tsquery("english", unaccent(parsed_query))
 
     @staticmethod
-    def add_search_query_filters(query, search_query, data_type, feed_id, status, is_official, features, versions) -> Query:
+    def add_search_query_filters(
+        query, search_query, data_type, feed_id, status, is_official, features, versions
+    ) -> Query:
         """
         Add filters to the search query.
         Filter values are trimmed and converted to lowercase.
@@ -143,7 +145,9 @@ class SearchApiImpl(BaseSearchApi):
         )
         feed_total_count = Database().select(
             session=db_session,
-            query=self.create_count_search_query(status, feed_id, data_type, is_official, feature, versions, search_query),
+            query=self.create_count_search_query(
+                status, feed_id, data_type, is_official, feature, versions, search_query
+            ),
         )
         if feed_rows is None or feed_total_count is None:
             return SearchFeeds200Response(

--- a/api/src/feeds/impl/search_api_impl.py
+++ b/api/src/feeds/impl/search_api_impl.py
@@ -32,7 +32,7 @@ class SearchApiImpl(BaseSearchApi):
 
     @staticmethod
     def add_search_query_filters(
-        query, search_query, data_type, feed_id, status, is_official, features, versions
+        query, search_query, data_type, feed_id, status, is_official, features, version
     ) -> Query:
         """
         Add filters to the search query.
@@ -60,8 +60,8 @@ class SearchApiImpl(BaseSearchApi):
                 query = query.where(t_feedsearch.c.official.is_(True))
             else:
                 query = query.where(or_(t_feedsearch.c.official.is_(False), t_feedsearch.c.official.is_(None)))
-        if versions:
-            versions_list = [v.strip().lower() for v in versions.split(",") if v]
+        if version:
+            versions_list = [v.strip().lower() for v in version.split(",") if v]
             if versions_list:
                 query = query.where(t_feedsearch.c.versions.op("?|")(array(versions_list)))
         if search_query and len(search_query.strip()) > 0:
@@ -84,7 +84,7 @@ class SearchApiImpl(BaseSearchApi):
         data_type: str,
         is_official: bool,
         features,
-        versions: str,
+        version: str,
         search_query: str,
     ) -> Query:
         """
@@ -92,7 +92,7 @@ class SearchApiImpl(BaseSearchApi):
         """
         query = select(func.count(t_feedsearch.c.feed_id))
         return SearchApiImpl.add_search_query_filters(
-            query, search_query, data_type, feed_id, status, is_official, features, versions
+            query, search_query, data_type, feed_id, status, is_official, features, version
         )
 
     @staticmethod
@@ -103,7 +103,7 @@ class SearchApiImpl(BaseSearchApi):
         is_official: bool,
         search_query: str,
         features: List[str],
-        versions: str,
+        version: str,
     ) -> Query:
         """
         Create a search query for the database.
@@ -117,7 +117,7 @@ class SearchApiImpl(BaseSearchApi):
             *feed_search_columns,
         )
         query = SearchApiImpl.add_search_query_filters(
-            query, search_query, data_type, feed_id, status, is_official, features, versions
+            query, search_query, data_type, feed_id, status, is_official, features, version
         )
         return query.order_by(rank_expression.desc())
 
@@ -130,13 +130,13 @@ class SearchApiImpl(BaseSearchApi):
         feed_id: str,
         data_type: str,
         is_official: bool,
-        versions: str,
+        version: str,
         search_query: str,
         feature: List[str],
         db_session: "Session",
     ) -> SearchFeeds200Response:
         """Search feeds using full-text search on feed, location and provider&#39;s information."""
-        query = self.create_search_query(status, feed_id, data_type, is_official, search_query, feature, versions)
+        query = self.create_search_query(status, feed_id, data_type, is_official, search_query, feature, version)
         feed_rows = Database().select(
             session=db_session,
             query=query,
@@ -146,7 +146,7 @@ class SearchApiImpl(BaseSearchApi):
         feed_total_count = Database().select(
             session=db_session,
             query=self.create_count_search_query(
-                status, feed_id, data_type, is_official, feature, versions, search_query
+                status, feed_id, data_type, is_official, feature, version, search_query
             ),
         )
         if feed_rows is None or feed_total_count is None:

--- a/api/tests/integration/test_search_api.py
+++ b/api/tests/integration/test_search_api.py
@@ -450,7 +450,7 @@ def test_search_filter_by_versions(client: TestClient, values: dict):
     params = None
     if values["versions"] is not None:
         params = [
-            ("versions", values["versions"]),
+            ("version", values["versions"]),
         ]
 
     headers = {

--- a/api/tests/integration/test_search_api.py
+++ b/api/tests/integration/test_search_api.py
@@ -424,3 +424,47 @@ def test_search_filter_by_official_status(client: TestClient, values: dict):
     assert (
         response_body.total == expected_count
     ), f"There should be {expected_count} feeds for official={values['official']}"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"versions": "1.0", "expected_count": 0},
+        {"versions": "2.3,3.0", "expected_count": 2},
+        {"versions": "3.0", "expected_count": 1},
+        {"versions": "2.3", "expected_count": 2},
+        {"versions": None, "expected_count": 16},
+    ],
+    ids=[
+        "Version 1.0",
+        "Versions 2.3 and 3.0",
+        "Version 3.0",
+        "Version 2.3",
+        "No version specified",
+    ],
+)
+def test_search_filter_by_versions(client: TestClient, values: dict):
+    """
+    Retrieve feeds with the version.
+    """
+    params = None
+    if values["versions"] is not None:
+        params = [
+            ("versions", values["versions"]),
+        ]
+
+    headers = {
+        "Authentication": "special-key",
+    }
+    response = client.request(
+        "GET",
+        "/v1/search",
+        headers=headers,
+        params=params,
+    )
+    # Parse the response body into a Python object
+    response_body = SearchFeeds200Response.parse_obj(response.json())
+    expected_count = values["expected_count"]
+    assert (
+        response_body.total == expected_count
+    ), f"There should be {expected_count} feeds for versions={values['versions']}"

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -334,7 +334,7 @@ paths:
         - $ref: "#/components/parameters/feed_id_query_param"
         - $ref: "#/components/parameters/data_type_query_param"
         - $ref: "#/components/parameters/is_official_query_param"
-        - $ref: "#/components/parameters/versions_query_param"
+        - $ref: "#/components/parameters/version_query_param"
         - $ref: "#/components/parameters/search_text_query_param"
         - $ref: "#/components/parameters/feature"
       security:
@@ -1342,8 +1342,8 @@ components:
       schema:
         type: string
 
-    versions_query_param:
-      name: versions
+    version_query_param:
+      name: version
       in: query
       description: Comma separated list of GBFS versions to filter by.
       required: False

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -334,6 +334,7 @@ paths:
         - $ref: "#/components/parameters/feed_id_query_param"
         - $ref: "#/components/parameters/data_type_query_param"
         - $ref: "#/components/parameters/is_official_query_param"
+        - $ref: "#/components/parameters/versions_query_param"
         - $ref: "#/components/parameters/search_text_query_param"
       security:
         - Authentication: []
@@ -712,6 +713,12 @@ components:
                 * sa - service alerts
 #              Have to put the enum inline because of a bug in openapi-generator
 #              $ref: "#/components/schemas/EntityTypes"
+        versions:
+          type: array
+          items:
+            type: string
+            example: 2.3
+          description: The supported versions of the GBFS feed.
         feed_references:
           description:
             A list of the GTFS feeds that the real time source is associated with, represented by their MDB source IDs.
@@ -1322,6 +1329,15 @@ components:
       required: False
       schema:
         type: string
+
+    versions_query_param:
+      name: versions
+      in: query
+      description: Comma separated list of GBFS versions to filter by.
+      required: False
+      schema:
+        type: string
+        example: 2.0,2.1
 
     data_type_query_param:
       name: data_type

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -48,9 +48,11 @@
     <include file="changes/feat_1055.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1041.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_997.sql" relativeToChangelogFile="true"/>
-<!-- Materialized view updated. Added features and totals. -->
+    <!-- Materialized view updated. Added features and totals. -->
     <include file="changes/feat_993.sql" relativeToChangelogFile="true"/>
     <!-- Materialized view updated. Used Feed.official field as official status. -->
     <include file="changes/feat_1083.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1132.sql" relativeToChangelogFile="true"/>
+    <!-- Materialized view updated. Added versions of GBFS feeds-->
+    <include file="changes/feat_1118.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_1118.sql
+++ b/liquibase/changes/feat_1118.sql
@@ -1,0 +1,248 @@
+-- Updating the FeedSearch materialized view to include versions of GBFS feeds
+
+DROP MATERIALIZED VIEW IF EXISTS FeedSearch;
+CREATE MATERIALIZED VIEW FeedSearch AS
+SELECT
+    -- feed
+    Feed.stable_id AS feed_stable_id,
+    Feed.id AS feed_id,
+    Feed.data_type,
+    Feed.status,
+    Feed.feed_name,
+    Feed.note,
+    Feed.feed_contact_email,
+    -- source
+    Feed.producer_url,
+    Feed.authentication_info_url,
+    Feed.authentication_type,
+    Feed.api_key_parameter_name,
+    Feed.license_url,
+    Feed.provider,
+    Feed.operational_status,
+    -- official status
+    Feed.official AS official,
+    -- latest_dataset
+    Latest_dataset.id AS latest_dataset_id,
+    Latest_dataset.hosted_url AS latest_dataset_hosted_url,
+    Latest_dataset.downloaded_at AS latest_dataset_downloaded_at,
+    Latest_dataset.bounding_box AS latest_dataset_bounding_box,
+    Latest_dataset.hash AS latest_dataset_hash,
+    Latest_dataset.agency_timezone AS latest_dataset_agency_timezone,
+    Latest_dataset.service_date_range_start AS latest_dataset_service_date_range_start,
+    Latest_dataset.service_date_range_end AS latest_dataset_service_date_range_end,
+    -- Latest dataset features
+    LatestDatasetFeatures AS latest_dataset_features,
+    -- Latest dataset validation totals
+    COALESCE(LatestDatasetValidationReportJoin.total_error, 0) as latest_total_error,
+    COALESCE(LatestDatasetValidationReportJoin.total_warning, 0) as latest_total_warning,
+    COALESCE(LatestDatasetValidationReportJoin.total_info, 0) as latest_total_info,
+    COALESCE(LatestDatasetValidationReportJoin.unique_error_count, 0) as latest_unique_error_count,
+    COALESCE(LatestDatasetValidationReportJoin.unique_warning_count, 0) as latest_unique_warning_count,
+    COALESCE(LatestDatasetValidationReportJoin.unique_info_count, 0) as latest_unique_info_count,
+    -- external_ids
+    ExternalIdJoin.external_ids,
+    -- redirect_ids
+    RedirectingIdJoin.redirect_ids,
+    -- feed gtfs_rt references
+    FeedReferenceJoin.feed_reference_ids,
+    -- feed gtfs_rt entities
+    EntityTypeFeedJoin.entities,
+    -- locations
+    FeedLocationJoin.locations,
+    -- osm locations grouped
+    OsmLocationJoin.osm_locations,
+     -- gbfs versions
+    COALESCE(GbfsVersionsJoin.versions, '[]'::jsonb) AS versions,
+
+    -- full-text searchable document
+    setweight(to_tsvector('english', coalesce(unaccent(Feed.feed_name), '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(unaccent(Feed.provider), '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(unaccent((
+        SELECT string_agg(
+            coalesce(location->>'country_code', '') || ' ' ||
+            coalesce(location->>'country', '') || ' ' ||
+            coalesce(location->>'subdivision_name', '') || ' ' ||
+            coalesce(location->>'municipality', ''),
+            ' '
+        )
+        FROM json_array_elements(FeedLocationJoin.locations) AS location
+    )), '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(unaccent(OsmLocationNamesJoin.osm_location_names), '')), 'A')
+        AS document
+FROM Feed
+
+-- Latest dataset
+LEFT JOIN (
+    SELECT *
+    FROM gtfsdataset
+    WHERE latest = true
+) AS Latest_dataset ON Latest_dataset.feed_id = Feed.id AND Feed.data_type = 'gtfs'
+
+-- Latest dataset features
+LEFT JOIN (
+    SELECT
+        GtfsDataset.id AS FeatureGtfsDatasetId,
+        array_agg(DISTINCT FeatureValidationReport.feature) AS LatestDatasetFeatures
+    FROM GtfsDataset
+    JOIN ValidationReportGtfsDataset
+      ON ValidationReportGtfsDataset.dataset_id = GtfsDataset.id
+    JOIN (
+        -- Pick latest ValidationReport per dataset based on validated_at
+        SELECT DISTINCT ON (ValidationReportGtfsDataset.dataset_id)
+            ValidationReportGtfsDataset.dataset_id,
+            ValidationReport.id AS latest_validation_report_id
+        FROM ValidationReportGtfsDataset
+        JOIN ValidationReport
+          ON ValidationReport.id = ValidationReportGtfsDataset.validation_report_id
+        ORDER BY
+            ValidationReportGtfsDataset.dataset_id,
+            ValidationReport.validated_at DESC
+    ) AS LatestReports
+      ON LatestReports.latest_validation_report_id = ValidationReportGtfsDataset.validation_report_id
+    JOIN FeatureValidationReport
+      ON FeatureValidationReport.validation_id = ValidationReportGtfsDataset.validation_report_id
+    GROUP BY FeatureGtfsDatasetId
+) AS LatestDatasetFeaturesJoin ON Latest_dataset.id = FeatureGtfsDatasetId
+
+-- Latest dataset validation report
+LEFT JOIN (
+    SELECT
+        GtfsDataset.id AS ValidationReportGtfsDatasetId,
+        ValidationReport.total_error,
+        ValidationReport.total_warning,
+        ValidationReport.total_info,
+        ValidationReport.unique_error_count,
+        ValidationReport.unique_warning_count,
+        ValidationReport.unique_info_count
+    FROM GtfsDataset
+    JOIN ValidationReportGtfsDataset
+      ON ValidationReportGtfsDataset.dataset_id = GtfsDataset.id
+    JOIN (
+        -- Pick latest ValidationReport per dataset based on validated_at
+        SELECT DISTINCT ON (ValidationReportGtfsDataset.dataset_id)
+            ValidationReportGtfsDataset.dataset_id,
+            ValidationReport.id AS latest_validation_report_id
+        FROM ValidationReportGtfsDataset
+        JOIN ValidationReport
+          ON ValidationReport.id = ValidationReportGtfsDataset.validation_report_id
+        ORDER BY
+            ValidationReportGtfsDataset.dataset_id,
+            ValidationReport.validated_at DESC
+    ) AS LatestReports
+      ON LatestReports.latest_validation_report_id = ValidationReportGtfsDataset.validation_report_id
+    JOIN ValidationReport
+      ON ValidationReport.id = ValidationReportGtfsDataset.validation_report_id
+) AS LatestDatasetValidationReportJoin ON Latest_dataset.id = ValidationReportGtfsDatasetId
+
+-- External ids
+LEFT JOIN (
+    SELECT
+        feed_id,
+        json_agg(json_build_object('external_id', associated_id, 'source', source)) AS external_ids
+    FROM externalid
+    GROUP BY feed_id
+) AS ExternalIdJoin ON ExternalIdJoin.feed_id = Feed.id
+
+-- feed reference ids
+LEFT JOIN (
+    SELECT
+        gtfs_rt_feed_id,
+        array_agg(FeedReferenceJoinInnerQuery.stable_id) AS feed_reference_ids
+    FROM FeedReference
+    LEFT JOIN Feed AS FeedReferenceJoinInnerQuery ON FeedReferenceJoinInnerQuery.id = FeedReference.gtfs_feed_id
+    GROUP BY gtfs_rt_feed_id
+) AS FeedReferenceJoin ON FeedReferenceJoin.gtfs_rt_feed_id = Feed.id AND Feed.data_type = 'gtfs_rt'
+
+-- Redirect ids
+LEFT JOIN (
+    SELECT
+        target_id,
+        json_agg(json_build_object('target_id', target_id, 'comment', redirect_comment)) AS redirect_ids
+    FROM RedirectingId
+    GROUP BY target_id
+) AS RedirectingIdJoin ON RedirectingIdJoin.target_id = Feed.id
+
+-- Feed locations
+LEFT JOIN (
+    SELECT
+        LocationFeed.feed_id,
+        json_agg(json_build_object('country', country, 'country_code', country_code, 'subdivision_name',
+                                   subdivision_name, 'municipality', municipality)) AS locations
+    FROM Location
+    LEFT JOIN LocationFeed ON LocationFeed.location_id = Location.id
+    GROUP BY LocationFeed.feed_id
+) AS FeedLocationJoin ON FeedLocationJoin.feed_id = Feed.id
+
+-- Entity types
+LEFT JOIN (
+    SELECT
+        feed_id,
+        array_agg(entity_name) AS entities
+    FROM EntityTypeFeed
+    GROUP BY feed_id
+) AS EntityTypeFeedJoin ON EntityTypeFeedJoin.feed_id = Feed.id AND Feed.data_type = 'gtfs_rt'
+
+-- OSM locations
+LEFT JOIN (
+    WITH locations_per_group AS (
+        SELECT
+            fog.feed_id,
+            olg.group_name,
+            jsonb_agg(
+                DISTINCT jsonb_build_object(
+                    'admin_level', gp.admin_level,
+                    'name', gp.name
+                )
+            ) AS locations
+        FROM FeedOsmLocationGroup fog
+        JOIN OsmLocationGroup olg ON olg.group_id = fog.group_id
+        JOIN OsmLocationGroupGeopolygon olgg ON olgg.group_id = olg.group_id
+        JOIN Geopolygon gp ON gp.osm_id = olgg.osm_id
+        GROUP BY fog.feed_id, olg.group_name
+    )
+    SELECT
+        feed_id,
+        jsonb_agg(
+            jsonb_build_object(
+                'group_name', group_name,
+                'locations', locations
+            )
+        )::json AS osm_locations
+    FROM locations_per_group
+    GROUP BY feed_id
+) AS OsmLocationJoin ON OsmLocationJoin.feed_id = Feed.id
+
+-- OSM location names
+LEFT JOIN (
+    SELECT
+        fog.feed_id,
+        string_agg(DISTINCT gp.name, ' ') AS osm_location_names
+    FROM FeedOsmLocationGroup fog
+    JOIN OsmLocationGroup olg ON olg.group_id = fog.group_id
+    JOIN OsmLocationGroupGeopolygon olgg ON olgg.group_id = olg.group_id
+    JOIN Geopolygon gp ON gp.osm_id = olgg.osm_id
+    WHERE gp.name IS NOT NULL
+    GROUP BY fog.feed_id
+) AS OsmLocationNamesJoin ON OsmLocationNamesJoin.feed_id = Feed.id
+
+-- GBFS versions
+LEFT JOIN (
+    SELECT
+        Feed.id AS feed_id,
+        to_jsonb(array_agg(DISTINCT GbfsVersion.version ORDER BY GbfsVersion.version)) AS versions
+    FROM Feed
+    JOIN GbfsFeed ON GbfsFeed.id = Feed.id
+    JOIN GbfsVersion ON GbfsVersion.feed_id = GbfsFeed.id
+    WHERE Feed.data_type = 'gbfs'
+    GROUP BY Feed.id
+) AS GbfsVersionsJoin ON GbfsVersionsJoin.feed_id = Feed.id;
+
+
+-- This index allows concurrent refresh on the materialized view avoiding table locks
+CREATE UNIQUE INDEX idx_unique_feed_id ON FeedSearch(feed_id);
+
+-- Indices for feedsearch view optimization
+CREATE INDEX feedsearch_document_idx ON FeedSearch USING GIN(document);
+CREATE INDEX feedsearch_feed_stable_id ON FeedSearch(feed_stable_id);
+CREATE INDEX feedsearch_data_type ON FeedSearch(data_type);
+CREATE INDEX feedsearch_status ON FeedSearch(status);

--- a/web-app/src/app/services/feeds/types.ts
+++ b/web-app/src/app/services/feeds/types.ts
@@ -360,6 +360,8 @@ export interface components {
       locations?: components['schemas']['Locations'];
       latest_dataset?: components['schemas']['LatestDataset'];
       entity_types?: Array<'vp' | 'tu' | 'sa'>;
+      /** @description The supported versions of the GBFS feed. */
+      versions?: string[];
       /** @description A list of the GTFS feeds that the real time source is associated with, represented by their MDB source IDs. */
       feed_references?: string[];
     };
@@ -699,6 +701,8 @@ export interface components {
     offset?: number;
     /** @description General search query to match against transit provider, location, and feed name. */
     search_text_query_param?: string;
+    /** @description Comma separated list of GBFS versions to filter by. */
+    versions_query_param?: string;
     /** @description Comma separated list of data types to filter by. Valid values are gtfs, gtfs_rt and gbfs. */
     data_type_query_param?: string;
     /** @description The feed ID of the requested feed. */
@@ -992,6 +996,7 @@ export interface operations {
         feed_id?: components['parameters']['feed_id_query_param'];
         data_type?: components['parameters']['data_type_query_param'];
         is_official?: components['parameters']['is_official_query_param'];
+        versions?: components['parameters']['versions_query_param'];
         search_query?: components['parameters']['search_text_query_param'];
         feature?: components['parameters']['feature'];
       };

--- a/web-app/src/app/services/feeds/types.ts
+++ b/web-app/src/app/services/feeds/types.ts
@@ -702,7 +702,7 @@ export interface components {
     /** @description General search query to match against transit provider, location, and feed name. */
     search_text_query_param?: string;
     /** @description Comma separated list of GBFS versions to filter by. */
-    versions_query_param?: string;
+    version_query_param?: string;
     /** @description Comma separated list of data types to filter by. Valid values are gtfs, gtfs_rt and gbfs. */
     data_type_query_param?: string;
     /** @description The feed ID of the requested feed. */
@@ -996,7 +996,7 @@ export interface operations {
         feed_id?: components['parameters']['feed_id_query_param'];
         data_type?: components['parameters']['data_type_query_param'];
         is_official?: components['parameters']['is_official_query_param'];
-        versions?: components['parameters']['versions_query_param'];
+        version?: components['parameters']['version_query_param'];
         search_query?: components['parameters']['search_text_query_param'];
         feature?: components['parameters']['feature'];
       };


### PR DESCRIPTION
**Summary:**
- Added `versions` field to the `FeedSearch` materialized view and exposed it in the search API response for GBFS feeds
- Introduced a new optional `versions` query parameter to the `/search` endpoint  
  → Accepts a comma-separated list (e.g. `?versions=2.2,3.0`)  
  → Filters feeds that support **any** of the specified versions (logical OR)

**Notes:**
- Version filtering is only applied when the `versions` parameter is provided and non-empty
- Supports exact matches on version strings as returned by the backend (e.g. `"2.2"`, `"3.0"`)

**Testing tips:**
Run API locally.
```http
GET /v1/search?data_type=gbfs&versions=2.2,3.0
``` 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
