### PR TITLE
feat: Add gbfs endpoint to the GBFSVersion entity

### DIFF
--- a/functions-python/gbfs_validator/src/gbfs_data_processor.py
+++ b/functions-python/gbfs_validator/src/gbfs_data_processor.py
@@ -114,6 +114,13 @@ class GBFSDataProcessor:
                 language = None
             print(language)
             endpoints += GBFSEndpoint.from_dict(feed_match.value, language)
+
+        # If the autodiscovery endpoint is not listed then add it
+        if not any(endpoint.name == "gbfs" for endpoint in endpoints):
+            endpoints += GBFSEndpoint.from_dict(
+                [{"name": "gbfs", "url": gbfs_json_url}], None
+            )
+
         unique_endpoints = list(
             {
                 f"{endpoint.name}, {endpoint.language or ''}": endpoint

--- a/functions-python/gbfs_validator/src/gbfs_data_processor.py
+++ b/functions-python/gbfs_validator/src/gbfs_data_processor.py
@@ -284,9 +284,9 @@ class GBFSDataProcessor:
         features: List[str],
     ) -> Gbfsendpoint:
         """Update or create a GBFS endpoint entity."""
-        formatted_id = (
-            f"{self.stable_id}_{version}_{endpoint.name}_{endpoint.language or ''}"
-        )
+        formatted_id = f"{self.stable_id}_{version}_{endpoint.name}"
+        if endpoint.language:
+            formatted_id += f"_{endpoint.language}"
         gbfs_endpoint_orm = (
             db_session.query(Gbfsendpoint)
             .filter(Gbfsendpoint.id == formatted_id)

--- a/functions-python/gbfs_validator/tests/test_gbfs_data_processor.py
+++ b/functions-python/gbfs_validator/tests/test_gbfs_data_processor.py
@@ -235,5 +235,10 @@ class TestGbfsDataProcessor(unittest.TestCase):
             # Validate versions
             self.assertEqual(len(gbfs_feed.gbfsversions), 2)
             versions = [version.version for version in gbfs_feed.gbfsversions]
+            # Validate that autodiscovery url endpoint is added to all versions
+            for gbfs_version in gbfs_feed.gbfsversions:
+                assert any(
+                    endpoint.name == "gbfs" for endpoint in gbfs_version.gbfsendpoints
+                )
             self.assertIn("2.2", versions)
             self.assertIn("2.1", versions)

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -53,4 +53,5 @@
     <!-- Materialized view updated. Used Feed.official field as official status. -->
     <include file="changes/feat_1083.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1132.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_1124.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_1124.sql
+++ b/liquibase/changes/feat_1124.sql
@@ -1,0 +1,17 @@
+-- Insert a GbfsEndpoint row to GbfsVersions that miss the gbfs(autodiscovery) endpoint
+INSERT INTO GbfsEndpoint (id, gbfs_version_id, url, name, is_feature)
+SELECT 
+    Feed.stable_id || '_' || GbfsVersion.version AS id,
+    GbfsVersion.id AS gbfs_version_id,
+    GbfsVersion.url AS url,
+    'gbfs' AS name,
+    false AS is_feature -- gbfs file is not a feature, see https://github.com/MobilityData/mobility-feed-api/issues/1125
+FROM GbfsVersion
+JOIN GbfsFeed ON GbfsVersion.feed_id = GbfsFeed.id
+JOIN Feed ON GbfsFeed.id = Feed.id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM GbfsEndpoint
+    WHERE GbfsEndpoint.gbfs_version_id = GbfsVersion.id
+      AND GbfsEndpoint.name = 'gbfs'
+);


### PR DESCRIPTION
**Summary:**
Closes #1124 
This PR adds the autodiscovery URL to the list of endpoints when it's not explicitly defined in the GBFS response per version. Also, populate the current data in PROD. 


**Expected behavior:** 

The autodiscovery URL is always persisted in the DB as a GBFS endpoint.

**Testing tips:**
SQL update executed in DEV and executed the gbfs-batch function in DEV, the following query verified that there are no gbfs versions without the `gbfs` endpoint:
```
SELECT feed.stable_id, gbfsversion.*
FROM gbfsversion
inner join feed on gbfsversion.feed_id = feed.id
WHERE NOT EXISTS (
    SELECT 1
    FROM gbfsendpoint ge
    WHERE ge.gbfs_version_id = gbfsversion.id
      AND ge.name = 'gbfs'
);
```
GBFS endpoint added to a feed that don't have GBFS endpoint listed in version 1.1:

![Screenshot 2025-05-01 at 4 05 02 PM](https://github.com/user-attachments/assets/30bdf9ed-c2d9-4019-b49f-b645c3177187)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
