### PR TITLE
fix: remove deprecated features from search filters

### DIFF
--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -29,7 +29,7 @@ import {
 import { useSearchParams } from 'react-router-dom';
 import SearchTable from './SearchTable';
 import { Trans, useTranslation } from 'react-i18next';
-import { groupFeaturesByComponent } from '../../utils/consts';
+import { DATASET_FEATURES, groupFeaturesByComponent } from '../../utils/consts';
 import NestedCheckboxList, {
   type CheckboxStructure,
 } from '../../components/NestedCheckboxList';
@@ -240,14 +240,19 @@ export default function Feed(): React.ReactElement {
 
   function setInitialExpandGroup(): Record<string, boolean> {
     const expandGroup: Record<string, boolean> = {};
-    Object.keys(groupFeaturesByComponent()).forEach((featureGroup) => {
+    Object.keys(
+      groupFeaturesByComponent(Object.keys(DATASET_FEATURES), true),
+    ).forEach((featureGroup) => {
       expandGroup[featureGroup] = false;
     });
     return expandGroup;
   }
 
   function generateCheckboxStructure(): CheckboxStructure[] {
-    const groupedFeatures = groupFeaturesByComponent();
+    const groupedFeatures = groupFeaturesByComponent(
+      Object.keys(DATASET_FEATURES),
+      true,
+    );
     return Object.entries(groupedFeatures)
       .filter(([parent]) => parent !== 'Other')
       .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))

--- a/web-app/src/app/utils/consts.tsx
+++ b/web-app/src/app/utils/consts.tsx
@@ -39,7 +39,7 @@ export function groupFeaturesByComponent(
   features.forEach((feature) => {
     const featureData = DATASET_FEATURES[feature];
     if (featureData !== undefined) {
-      if (removeDeprecated && featureData.deprecated) {
+      if (removeDeprecated && featureData.deprecated === true) {
         return;
       }
       const component =

--- a/web-app/src/app/utils/consts.tsx
+++ b/web-app/src/app/utils/consts.tsx
@@ -9,6 +9,7 @@ interface DatasetFeature {
   componentSubgroup?: string;
   fileName: string;
   linkToInfo: string;
+  deprecated?: boolean;
 }
 
 type DatasetFeatures = Record<string, DatasetFeature>;
@@ -31,12 +32,16 @@ interface ComprehensiveDatasetFeature extends DatasetFeature {
 
 export function groupFeaturesByComponent(
   features: string[] = Object.keys(DATASET_FEATURES),
+  removeDeprecated = false,
 ): Record<string, DatasetComponentFeature[]> {
   const groupedFeatures: Record<string, DatasetComponentFeature[]> = {};
 
   features.forEach((feature) => {
     const featureData = DATASET_FEATURES[feature];
     if (featureData !== undefined) {
+      if (removeDeprecated && featureData.deprecated) {
+        return;
+      }
       const component =
         featureData.component !== '' ? featureData.component : 'Other';
       if (groupedFeatures[component] === undefined) {
@@ -287,7 +292,10 @@ export const DATASET_FEATURES: DatasetFeatures = {
   },
 };
 // SPELLING CORRECTIONS
-DATASET_FEATURES['Text-to-Speech'] = DATASET_FEATURES['Text-To-Speech'];
+DATASET_FEATURES['Text-to-Speech'] = {
+  ...DATASET_FEATURES['Text-To-Speech'],
+  deprecated: true,
+};
 
 // DEPRECATED FEATURES
 DATASET_FEATURES['Wheelchair Accessibility'] = {
@@ -295,16 +303,32 @@ DATASET_FEATURES['Wheelchair Accessibility'] = {
   component: 'Accessibility',
   fileName: 'trips.txt',
   linkToInfo: 'https://gtfs.org/getting-started/features/accessibility',
+  deprecated: true,
 };
-DATASET_FEATURES['Bikes Allowance'] = DATASET_FEATURES['Bike Allowed'];
-DATASET_FEATURES['Transfer Fares'] = DATASET_FEATURES['Fare Transfers']; // as of 6.0
-DATASET_FEATURES['Pathways (basic)'] = DATASET_FEATURES['Pathway Connections']; // as of 6.0
-DATASET_FEATURES['Pathways (extra)'] = DATASET_FEATURES['Pathway Details']; // as of 6.0
-DATASET_FEATURES['Traversal Time'] =
-  DATASET_FEATURES['In-station Traversal Time'];
+DATASET_FEATURES['Bikes Allowance'] = {
+  ...DATASET_FEATURES['Bike Allowed'],
+  deprecated: true,
+};
+DATASET_FEATURES['Transfer Fares'] = {
+  ...DATASET_FEATURES['Fare Transfers'],
+  deprecated: true,
+}; // as of 6.0
+DATASET_FEATURES['Pathways (basic)'] = {
+  ...DATASET_FEATURES['Pathway Connections'],
+  deprecated: true,
+}; // as of 6.0
+DATASET_FEATURES['Pathways (extra)'] = {
+  ...DATASET_FEATURES['Pathway Details'],
+  deprecated: true,
+}; // as of 6.0
+DATASET_FEATURES['Traversal Time'] = {
+  ...DATASET_FEATURES['In-station Traversal Time'],
+  deprecated: true,
+};
 DATASET_FEATURES['Pathways Directions'] = {
   // as of 6.0
   component: 'Pathways',
   fileName: 'pathways.txt',
   linkToInfo: 'https://gtfs.org/schedule/reference/#pathwaystxt',
+  deprecated: true,
 };


### PR DESCRIPTION
**Summary:**

With feature filtering, we do not want the user to filter through deprecated feature names

**Expected behavior:** 

deprecated features should not appear in the search

**Testing tips:**

Go on the search page and look for deprecated features

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![image](https://github.com/user-attachments/assets/51188566-442a-434f-b37b-b8f41b7de80a)
