### PR TITLE
fix: text to speech feature filter

### DIFF
--- a/web-app/src/app/utils/consts.tsx
+++ b/web-app/src/app/utils/consts.tsx
@@ -96,7 +96,7 @@ export const DATASET_FEATURES: DatasetFeatures = {
     fileName: '',
     linkToInfo: 'https://gtfs.org/getting-started/features/overview/',
   },
-  'Text-To-Speech': {
+  'Text-to-Speech': {
     component: 'Accessibility',
     fileName: 'stops.txt',
     linkToInfo:
@@ -292,8 +292,8 @@ export const DATASET_FEATURES: DatasetFeatures = {
   },
 };
 // SPELLING CORRECTIONS
-DATASET_FEATURES['Text-to-Speech'] = {
-  ...DATASET_FEATURES['Text-To-Speech'],
+DATASET_FEATURES['Text-To-Speech'] = {
+  ...DATASET_FEATURES['Text-to-Speech'],
   deprecated: true,
 };
 


### PR DESCRIPTION
**Summary:**
closes #1169 

The wrong text-to-speech feature was deprecated, this corrects that so that the feature filter works

**Expected behavior:** 

When filtering by text-to-speech, it should show results

**Testing tips:**

On feeds search, filter by text to speech and see results

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
<img width="1566" alt="Screenshot 2025-05-02 at 09 05 19" src="https://github.com/user-attachments/assets/4f45a0dd-db50-49fe-a9b4-9f03fce8ee5e" />


