### PR TITLE
Feat: add "future" status to feed types in Operations API

### DIFF
--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -444,12 +444,14 @@ components:
           * `deprecated` Feed is explicitly deprecated and should not be used in public trip planners.
           * `inactive` Feed hasn't been recently updated and should be used at risk of providing outdated information.
           * `development` Feed is being used for development purposes and should not be used in public trip planners.
+          * `future` Feed is not yet active but will be in the future.
       type: string
       enum:
         - active
         - deprecated
         - inactive
         - development
+        - future
       example: active
 
     DataType:


### PR DESCRIPTION
**Summary:**

This PR adds "future" status to feed types in Operations API

**Expected behavior:** 
"future" is now a feed status ypes in Operations API

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
