### PR TITLE
fix: Corrected the data_type property examples in the OpenApi schemas

### DIFF
--- a/.github/workflows/typescript-generator-check.yml
+++ b/.github/workflows/typescript-generator-check.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: generated_types.ts
-          path: src/app/services/feeds/generated/types.ts
+          path: web-app/src/app/services/feeds/generated/types.ts
 
       - name: Compare TypeScript types with existing types
         working-directory: web-app

--- a/.github/workflows/typescript-generator-check.yml
+++ b/.github/workflows/typescript-generator-check.yml
@@ -2,7 +2,7 @@ name: Verify TypeScript Types Generation
 on:
   pull_request:
     branches: 
-        - main
+      - main
     paths:
       - "docs/DatabaseCatalogAPI.yaml"
 
@@ -44,6 +44,12 @@ jobs:
         run: yarn generate:api-types:output
         env:
           OUTPUT_PATH_TYPES: src/app/services/feeds/generated/types.ts
+
+      - name: Upload generated types
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated_types.ts
+          path: src/app/services/feeds/generated/types.ts
 
       - name: Compare TypeScript types with existing types
         working-directory: web-app

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -433,8 +433,6 @@ components:
                 - development
                 - future
               example: deprecated
-            #           Have to put the enum inline because of a bug in openapi-generator
-            #          $ref: "#/components/schemas/FeedStatus"
             official:
               description: >
                 A boolean value indicating if the feed is official or not. 
@@ -462,6 +460,14 @@ components:
         - $ref: "#/components/schemas/Feed"
         - type: object
           properties:
+            # We reproduce this property here so we can have a specific example.
+            data_type:
+              type: string
+              enum:
+                - gtfs
+                - gtfs_rt
+                - gbfs
+              example: gtfs
             locations:
               $ref: "#/components/schemas/Locations"
             latest_dataset:
@@ -472,6 +478,14 @@ components:
         - $ref: "#/components/schemas/BasicFeed"
         - type: object
           properties:
+            # We reproduce this property here so we can have a specific example.
+            data_type:
+              type: string
+              enum:
+                - gtfs
+                - gtfs_rt
+                - gbfs
+              example: gbfs
             locations:
               $ref: "#/components/schemas/Locations"
             system_id:
@@ -590,6 +604,14 @@ components:
         - $ref: "#/components/schemas/Feed"
         - type: object
           properties:
+            # We reproduce this property here so we can have a specific example.
+            data_type:
+              type: string
+              enum:
+                - gtfs
+                - gtfs_rt
+                - gbfs
+              example: gtfs_rt
             entity_types:
               type: array
               items:

--- a/web-app/src/app/services/feeds/types.ts
+++ b/web-app/src/app/services/feeds/types.ts
@@ -190,10 +190,20 @@ export interface components {
       note?: string;
     };
     GtfsFeed: components['schemas']['Feed'] & {
+      /**
+       * @example gtfs
+       * @enum {string}
+       */
+      data_type?: 'gtfs' | 'gtfs_rt' | 'gbfs';
       locations?: components['schemas']['Locations'];
       latest_dataset?: components['schemas']['LatestDataset'];
     };
     GbfsFeed: components['schemas']['BasicFeed'] & {
+      /**
+       * @example gbfs
+       * @enum {string}
+       */
+      data_type?: 'gtfs' | 'gtfs_rt' | 'gbfs';
       locations?: components['schemas']['Locations'];
       /**
        * @description The system ID of the feed. This is a unique identifier for the system that the feed belongs to.
@@ -296,6 +306,11 @@ export interface components {
     };
     GbfsFeeds: Array<components['schemas']['GbfsFeed']>;
     GtfsRTFeed: components['schemas']['Feed'] & {
+      /**
+       * @example gtfs_rt
+       * @enum {string}
+       */
+      data_type?: 'gtfs' | 'gtfs_rt' | 'gbfs';
       entity_types?: Array<'vp' | 'tu' | 'sa'>;
       /** @description A list of the GTFS feeds that the real time source is associated with, represented by their MDB source IDs. */
       feed_references?: string[];


### PR DESCRIPTION
Closes #1144

Added some duplications of the data_type property used in the feeds, gtfs_feeds, gtfs_rt_feeds and gbfs_feeds.
This resulted in examples being appropriate for the type of feed.
The generated feed code (feed_gen) stayed the same with this change.

![image](https://github.com/user-attachments/assets/7c654af1-ba25-4763-84ce-24be2f1ae9b5)
 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
