### PR TITLE
fix: home page flickering bug

### DIFF
--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -388,7 +388,7 @@ export default function Feed(): React.ReactElement {
             onSubmit={(event) => {
               event.preventDefault();
               setActivePagination(1);
-              setActiveSearch(searchQuery);
+              setActiveSearch(searchQuery.trim());
             }}
             sx={searchBarStyles}
           >
@@ -409,7 +409,7 @@ export default function Feed(): React.ReactElement {
                     }}
                     onClick={() => {
                       setActivePagination(1);
-                      setActiveSearch(searchQuery);
+                      setActiveSearch(searchQuery.trim());
                     }}
                     position='start'
                   >

--- a/web-app/src/app/screens/Home.tsx
+++ b/web-app/src/app/screens/Home.tsx
@@ -57,7 +57,12 @@ function Component(): React.ReactElement {
   const theme = useTheme();
 
   const handleSearch = (): void => {
-    navigate(`/feeds?q=${encodeURIComponent(searchInputValue)}`);
+    const encodedURI = encodeURIComponent(searchInputValue.trim())
+    if(encodedURI.length === 0) {
+      navigate('/feeds');
+    } else {
+      navigate(`/feeds?q=${encodedURI}`);
+    }
   };
 
   const handleKeyDown = (

--- a/web-app/src/app/screens/Home.tsx
+++ b/web-app/src/app/screens/Home.tsx
@@ -57,8 +57,8 @@ function Component(): React.ReactElement {
   const theme = useTheme();
 
   const handleSearch = (): void => {
-    const encodedURI = encodeURIComponent(searchInputValue.trim())
-    if(encodedURI.length === 0) {
+    const encodedURI = encodeURIComponent(searchInputValue.trim());
+    if (encodedURI.length === 0) {
       navigate('/feeds');
     } else {
       navigate(`/feeds?q=${encodedURI}`);


### PR DESCRIPTION
**Summary:**

Issue describing: https://github.com/MobilityData/mobility-feed-api/issues/1184

closes: #1184 

When clicking on the home search input (empty), it would trigger a flicker in the search page. This PR fixes that

**Expected behavior:** 

When clicking on the home search input, it should not create a flicker effect in the search page

**Testing tips:**

From the home page, click on the 'search' button, it should go to the search page with no issues

** KNOWN BUG **

The issue underlying is that going to the URL `feeds/q=` will cause that flicker to occur. It's a deeper issue about updating the url to remove the invalid search and the data types at the same time. I will create a different ticket to tackle this as it's quite a complex bug to fix, and now can only be re-produced by going directly to that url

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
