### PR TITLE
feat: gbfs error message for no versions

### DIFF
--- a/web-app/public/locales/en/gbfs.json
+++ b/web-app/public/locales/en/gbfs.json
@@ -20,5 +20,6 @@
         "system_alerts": "System Alerts",
         "free_bike_status": "Free Bike Status",
         "nearby_stations": "Nearby Stations"
-    }
+    },
+    "unableToDetectVersions": "Unable to detect versions within this feed."
 }

--- a/web-app/src/app/screens/Feed/components/GbfsVersions.tsx
+++ b/web-app/src/app/screens/Feed/components/GbfsVersions.tsx
@@ -22,6 +22,7 @@ import {
 import { displayFormattedDate } from '../../../utils/date';
 import { featureChipsStyle } from '../Feed.styles';
 import { sortGbfsVersions } from '../Feed.functions';
+import { WarningContentBox } from '../../../components/WarningContentBox';
 
 export interface GbfsVersionsProps {
   feed: GBFSFeedType;
@@ -80,10 +81,6 @@ export default function GbfsVersions({
     return `https://github.com/MobilityData/gbfs/blob/v${version}/gbfs.md#${feature}json`;
   };
 
-  if (feed?.versions == null || feed?.versions?.length === 0) {
-    return <></>;
-  }
-
   return (
     <>
       <Typography
@@ -100,6 +97,10 @@ export default function GbfsVersions({
           justifyContent: 'flex-end',
         }}
       >
+        {feed?.versions == null ||
+          (feed.versions.length === 0 && (
+            <WarningContentBox>{t('unableToDetectVersions')}</WarningContentBox>
+          ))}
         {[...(feed?.versions ?? [])]
           .sort((a, b) => sortGbfsVersions(a, b))
           .map((item, index) => {


### PR DESCRIPTION
**Summary:**
closes #1104 
In gbfs feed detail if there are no versions, it will display an error message

**Expected behavior:** 

In gbfs feed detail if there are no versions, it will display an error message

**Testing tips:**

Go to `feeds/gbfs/gbfs-maribor` and see that there are no versions

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![image](https://github.com/user-attachments/assets/83d10fa7-7d65-49b4-acab-5b16691e706e)

