### PR TITLE
feat: removed default search selection

### DIFF
--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -292,20 +292,6 @@ export default function Feed(): React.ReactElement {
 
   const containerRef = React.useRef(null);
   useEffect(() => {
-    if (!config.enableGbfsInSearchPage) {
-      if (!selectedFeedTypes.gtfs_rt && !selectedFeedTypes.gtfs) {
-        setSelectedFeedTypes({ gtfs: true, gtfs_rt: true });
-      }
-    } else {
-      if (
-        !selectedFeedTypes.gtfs_rt &&
-        !selectedFeedTypes.gtfs &&
-        !selectedFeedTypes.gbfs
-      ) {
-        setSelectedFeedTypes({ gtfs: true, gtfs_rt: true, gbfs: true });
-      }
-    }
-
     const observer = new IntersectionObserver(
       ([entry]) => {
         setIsSticky(!entry.isIntersecting);


### PR DESCRIPTION
**Summary:**
closes #1187 

When going on the feeds search page, the data formats are not auto selected anymore

**Expected behavior:** 

When you go to the feeds page, the data formats should not be auto selected

**Testing tips:**

Go to the feeds page from the header or from the home page, it should be empty

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
