### PR TITLE
fix: gbfs update title on detail page

### DIFF
--- a/web-app/src/app/screens/Feed/Feed.functions.tsx
+++ b/web-app/src/app/screens/Feed/Feed.functions.tsx
@@ -51,10 +51,15 @@ export function generatePageTitle(
   feedName?: string,
 ): string {
   let newDocTitle = getFeedFormattedName(sortedProviders, feedName);
-  const dataTypeVerbose = dataType === 'gtfs' ? 'Schedule' : 'Realtime';
 
   if (newDocTitle !== '') {
-    newDocTitle += ` GTFS ${dataTypeVerbose} Feed - `;
+    if (dataType === 'gtfs') {
+      newDocTitle += ' GTFS Schedule Feed - ';
+    } else if (dataType === 'gtfs_rt') {
+      newDocTitle += ' GTFS Realtime Feed - ';
+    } else if (dataType === 'gbfs') {
+      newDocTitle += ' GBFS Feed - ';
+    }
   }
 
   newDocTitle += 'Mobility Database';

--- a/web-app/src/app/screens/Feed/Feed.spec.tsx
+++ b/web-app/src/app/screens/Feed/Feed.spec.tsx
@@ -197,6 +197,9 @@ describe('Feed page', () => {
 
     const titleAllEmpty = generatePageTitle([], 'gtfs', '');
     expect(titleAllEmpty).toEqual('Mobility Database');
+
+    const gbfsTitle = generatePageTitle(['Flamingo Porirua'], 'gbfs');
+    expect(gbfsTitle).toEqual('Flamingo Porirua GBFS Feed - Mobility Database');
   });
 
   it('should generate the correct page description', () => {


### PR DESCRIPTION
**Summary:**

closes #1193 

When going on the feed detail page, the title of the page updates to relevant gbfs text

**Expected behavior:** 

When going on the feed detail page, the title of the page updates to relevant gbfs text

Title is in format: `Flamingo Porirua GBFS Feed - Mobility Database`

**Testing tips:**

Go on any feed detail page and the title should be relevant to gtfs gtfs_rt or gbfs

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
![image](https://github.com/user-attachments/assets/eac51ba1-be2a-4250-972b-321882884e3c)

