### PR TITLE
feat: transitland and fta attribution

### DIFF
--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -145,5 +145,6 @@
     "viewJsonReport": "View Validation Report in JSON format"
   },
   "viewRealtimeVisualization": "View real-time visualization",
-  "versions": "Versions"
+  "versions": "Versions",
+  "dataAattribution": "Transit data provided by"
 }

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -463,13 +463,14 @@ export default function Feed(): React.ReactElement {
             width={'100%'}
             component={'div'}
           >
-            {t('dataAattribution')}{' '}
+            {t('dataAattribution')}
+            {' the United States '}
             <a
               rel='noreferrer'
               target='_blank'
               href='https://www.transit.dot.gov/ntd/data-product/2023-annual-database-general-transit-feed-specification-gtfs-weblinks'
             >
-              Federal Transit Administration
+              National Transit Database
             </a>
           </Typography>
         )}

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -439,7 +439,7 @@ export default function Feed(): React.ReactElement {
             ).toDateString()}`}
           </Typography>
         )}
-        {feed.external_ids?.some((eId) => eId.source === 'tld') && (
+        {feed.external_ids?.some((eId) => eId.source === 'tld') === true && (
           <Typography
             data-testid='transitland-attribution'
             variant={'caption'}
@@ -456,7 +456,7 @@ export default function Feed(): React.ReactElement {
             </a>
           </Typography>
         )}
-        {feed.external_ids?.some((eId) => eId.source === 'ntd') && (
+        {feed.external_ids?.some((eId) => eId.source === 'ntd') === true && (
           <Typography
             data-testid='fta-attribution'
             variant={'caption'}

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -439,6 +439,40 @@ export default function Feed(): React.ReactElement {
             ).toDateString()}`}
           </Typography>
         )}
+        {feed.external_ids?.some((eId) => eId.source === 'tld') && (
+          <Typography
+            data-testid='transitland-attribution'
+            variant={'caption'}
+            width={'100%'}
+            component={'div'}
+          >
+            {t('dataAattribution')}{' '}
+            <a
+              rel='noreferrer'
+              target='_blank'
+              href='https://www.transit.land/terms'
+            >
+              Transitland
+            </a>
+          </Typography>
+        )}
+        {feed.external_ids?.some((eId) => eId.source === 'ntd') && (
+          <Typography
+            data-testid='fta-attribution'
+            variant={'caption'}
+            width={'100%'}
+            component={'div'}
+          >
+            {t('dataAattribution')}{' '}
+            <a
+              rel='noreferrer'
+              target='_blank'
+              href='https://www.transit.dot.gov/ntd/data-product/2023-annual-database-general-transit-feed-specification-gtfs-weblinks'
+            >
+              Federal Transit Administration
+            </a>
+          </Typography>
+        )}
       </Box>
 
       {feed?.data_type === 'gtfs_rt' &&


### PR DESCRIPTION
**Summary:**

Giving attribution to transitland and fta when using their data

**Expected behavior:** 

On feed detail pages that have external sources of `tld` or `ntd` it will display an attribution for transitland and fta repectfully. Clicking the name will bring you to licensed page

**Testing tips:**

Go on a feed with tld or ntd and see the attribution

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![image](https://github.com/user-attachments/assets/158288d6-2444-46ac-b3ab-d2ec5d4ab9c3)

