### PR TITLE
fix: cartesian product with gtfsdatasets in query

### DIFF
--- a/api/src/shared/common/db_utils.py
+++ b/api/src/shared/common/db_utils.py
@@ -359,6 +359,7 @@ def apply_bounding_filtering(
         wkt_polygon,
         srid=Gtfsdataset.bounding_box.type.srid,
     )
+    query = query.join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
 
     if bounding_filter_method == "partially_enclosed":
         return query.filter(


### PR DESCRIPTION
**Summary**
Closes #1221.

 **Details**

Previously, the query used to filter feeds by bounding box did not properly join `GtfsDataset` and `GtfsFeed`, resulting in a cartesian product. This caused the `ST_Covers(...)` spatial filter to be applied incorrectly or not at all.

The query has been updated to explicitly join `GtfsDataset` on `feed_id` when applying bounding box filters, preventing duplicate table references and ensuring the spatial filtering works as intended.

 **Validation**

The following request now returns the correct GTFS feed for the Lisbon area (as expected):

```
GET /v1/gtfs_feeds?limit=10&offset=0&bounding_filter_method=completely_enclosed&is_official=true&dataset_latitudes=38.4,39.0&dataset_longitudes=-8.8,-9.5
```

Example response from `dev`:

<details>
<summary>Sample output</summary>

```json
[
  {
    "id": "mdb-1272",
    "data_type": "gtfs",
    ...
    "provider": "Cascais Próxima, E.M., S.A.",
    ...
    "locations": [
      { "country_code": "PT", "municipality": "Cascais e Estoril", ... },
      ...
    ],
    "latest_dataset": {
      "id": "mdb-1272-202502251645",
      "bounding_box": {
        "minimum_latitude": 38.679561,
        "maximum_latitude": 38.763594,
        "minimum_longitude": -9.484887,
        "maximum_longitude": -9.313059
      },
      ...
    }
  }
]
```

</details>

✅ Verified locally pointing to `dev`.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
