### PR TITLE
fix: 2 corrections on gbfs populate

### DIFF
--- a/api/src/scripts/gbfs_utils/comparison.py
+++ b/api/src/scripts/gbfs_utils/comparison.py
@@ -47,6 +47,7 @@ def compare_db_to_csv(df_from_db, df_from_csv, logger):
         return None, None
 
     # Align both DataFrames by "System ID"
+    # Keep the System ID column because it's used later in the code
     df_from_db.set_index("System ID", inplace=True, drop=False)
     df_from_csv.set_index("System ID", inplace=True, drop=False)
 
@@ -85,6 +86,7 @@ def compare_db_to_csv(df_from_db, df_from_csv, logger):
             logger.info(80 * "-")
 
     # Merge differing rows with missing_in_db to capture all new or updated feeds
+    # Drop the index because we have it as the System ID column.
     all_differing_or_new_rows = pd.concat([differing_rows, missing_in_db]).reset_index(drop=True)
 
     return all_differing_or_new_rows, missing_in_csv

--- a/api/src/scripts/gbfs_utils/comparison.py
+++ b/api/src/scripts/gbfs_utils/comparison.py
@@ -5,9 +5,7 @@ from shared.database_gen.sqlacodegen_models import Gbfsfeed
 
 def generate_system_csv_from_db(df, db_session):
     """Generate a DataFrame from the database with the same columns as the CSV file."""
-    stable_ids = "gbfs-" + df["System ID"]
     query = db_session.query(Gbfsfeed)
-    query = query.filter(Gbfsfeed.stable_id.in_(stable_ids.to_list()))
     query = query.options(
         joinedload(Gbfsfeed.locations), joinedload(Gbfsfeed.gbfsversions), joinedload(Gbfsfeed.externalids)
     )
@@ -49,8 +47,8 @@ def compare_db_to_csv(df_from_db, df_from_csv, logger):
         return None, None
 
     # Align both DataFrames by "System ID"
-    df_from_db.set_index("System ID", inplace=True)
-    df_from_csv.set_index("System ID", inplace=True)
+    df_from_db.set_index("System ID", inplace=True, drop=False)
+    df_from_csv.set_index("System ID", inplace=True, drop=False)
 
     # Find rows that are in the CSV but not in the DB (new feeds)
     missing_in_db = df_from_csv[~df_from_csv.index.isin(df_from_db.index)]
@@ -68,7 +66,11 @@ def compare_db_to_csv(df_from_db, df_from_csv, logger):
     common_ids = df_from_db.index.intersection(df_from_csv.index)
     df_db_common = df_from_db.loc[common_ids]
     df_csv_common = df_from_csv.loc[common_ids]
-    differences = df_db_common != df_csv_common
+
+    # Exclude 'Location' from comparison because the DB values might have been changed in the
+    # python function that calculates the location.
+    columns_to_compare = [col for col in df_db_common.columns if col != "Location"]
+    differences = df_db_common[columns_to_compare] != df_csv_common[columns_to_compare]
     differing_rows = df_csv_common[differences.any(axis=1)]
 
     if not differing_rows.empty:
@@ -83,6 +85,6 @@ def compare_db_to_csv(df_from_db, df_from_csv, logger):
             logger.info(80 * "-")
 
     # Merge differing rows with missing_in_db to capture all new or updated feeds
-    all_differing_or_new_rows = pd.concat([differing_rows, missing_in_db]).reset_index()
+    all_differing_or_new_rows = pd.concat([differing_rows, missing_in_db]).reset_index(drop=True)
 
     return all_differing_or_new_rows, missing_in_csv

--- a/api/src/scripts/populate_db_gbfs.py
+++ b/api/src/scripts/populate_db_gbfs.py
@@ -36,14 +36,15 @@ class GBFSDatabasePopulateHelper(DatabasePopulateHelper):
             self.logger.info("No feeds to deprecate.")
             return
 
-        self.logger.info(f"Deprecating {len(deprecated_feeds)} feed(s).")
+        self.logger.info(f"Deleting {len(deprecated_feeds)} feed(s).")
         with self.db.start_db_session() as session:
             for index, row in deprecated_feeds.iterrows():
                 stable_id = self.get_stable_id(row)
                 gbfs_feed = self.query_feed_by_stable_id(session, stable_id, "gbfs")
                 if gbfs_feed:
-                    self.logger.info(f"Deprecating feed with stable_id={stable_id}")
-                    gbfs_feed.status = "deprecated"
+                    self.logger.info(f"Deleting feed with stable_id={stable_id}")
+                    session.delete(gbfs_feed)
+                    session.flush()
 
     def populate_db(self, session, fetch_url=True):
         """Populate the database with the GBFS feeds"""

--- a/api/src/scripts/populate_db_gbfs.py
+++ b/api/src/scripts/populate_db_gbfs.py
@@ -20,7 +20,6 @@ class GBFSDatabasePopulateHelper(DatabasePopulateHelper):
         """Filter out rows with Authentication Info and duplicate System IDs"""
         self.df = self.df[pd.isna(self.df["Authentication Info URL"])]
         self.df = self.df[~self.df.duplicated(subset="System ID", keep=False)]
-        # self.df = self.df.set_index(subset="System ID", inplace=True)
         self.logger.info(f"Data = {self.df}")
 
     @staticmethod

--- a/api/src/scripts/populate_db_gbfs.py
+++ b/api/src/scripts/populate_db_gbfs.py
@@ -42,6 +42,11 @@ class GBFSDatabasePopulateHelper(DatabasePopulateHelper):
                 stable_id = self.get_stable_id(row)
                 gbfs_feed = self.query_feed_by_stable_id(session, stable_id, "gbfs")
                 if gbfs_feed:
+                    # A note about the deletion done here:
+                    # Some other tables have a foreign key pointing to the feed, and these cannot be null
+                    # (e.g. gbfsversion). So the delete will fail, unless we cascade the deletion of the
+                    # gbfs_feed to the deletion of the entry in gbfsversion, which is done in the DB
+                    # schema. It's also the case for other tables and other foreign keys.
                     self.logger.info(f"Deleting feed with stable_id={stable_id}")
                     session.delete(gbfs_feed)
                     session.flush()

--- a/api/src/scripts/populate_db_gbfs.py
+++ b/api/src/scripts/populate_db_gbfs.py
@@ -20,6 +20,7 @@ class GBFSDatabasePopulateHelper(DatabasePopulateHelper):
         """Filter out rows with Authentication Info and duplicate System IDs"""
         self.df = self.df[pd.isna(self.df["Authentication Info URL"])]
         self.df = self.df[~self.df.duplicated(subset="System ID", keep=False)]
+        # self.df = self.df.set_index(subset="System ID", inplace=True)
         self.logger.info(f"Data = {self.df}")
 
     @staticmethod

--- a/api/src/shared/database/database.py
+++ b/api/src/shared/database/database.py
@@ -17,11 +17,6 @@ from shared.database_gen.sqlacodegen_models import (
     Gbfsvalidationreport,
     Osmlocationgroup,
     Validationreport,
-    Gbfsendpoint,
-    Httpaccesslog,
-    Feature,
-    Location,
-    Gtfsdataset,
 )
 from sqlalchemy.orm import sessionmaker
 import logging
@@ -59,32 +54,24 @@ def configure_polymorphic_mappers():
     gbfsfeed_mapper.polymorphic_identity = Gbfsfeed.__tablename__.lower()
 
 
-# Entities for which we do a passive_deletes = True, which enables passive deletion for the relationship.
-# See set_cascade function below for more details.
-# This means that when a parent entity is deleted, SQLAlchemy will not issue explicit DELETE statements for the
-# related child entities. Instead, it relies on the database's ON DELETE CASCADE constraint to handle the deletion
-# How to read this: e.g. the first one means that if a Feature is deleted, then the entry in the featurevalidationreport
-# association table must also be deleted.
+# The `cascade_entities` dictionary maps SQLAlchemy models to lists of their relationship attributes
+# that should have cascading delete-orphan behavior. When a parent entity (such as `Feed`, `Gbfsfeed`, etc.)
+# is deleted, any related child entities listed here will also be deleted if they become orphans.
+# The `set_cascade` function applies this configuration by setting the `cascade` property to "all, delete-orphan"
+# and enabling `passive_deletes` for each specified relationship. This leverages the database's ON DELETE CASCADE
+# constraints and ensures that related records are cleaned up automatically when a parent is removed.
 cascade_entities = {
-    Feature: [
-        Feature.validations,  # featurevalidationreport_validation_id_fkey
-    ],
     Feed: [
         Feed.externalids,  # externalid_feed_id_fkey
         Feed.feedlocationgrouppoints,
         Feed.feedosmlocationgroups,  # feedosmlocation_feed_id_fkey
         Feed.gtfsdatasets,  # gtfsdataset_feed_id_fkey
-        Feed.locations,  # locationfeed_feed_id_fkey
         Feed.officialstatushistories,  # officialstatushistory_feed_id_fkey
         Feed.redirectingids,  # redirectingid_source_id_fkey
         Feed.redirectingids_,  # redirectingid_target_id_fkey
     ],
-    Gbfsendpoint: [
-        Gbfsendpoint.httpaccesslogs,  # gbfsendpointhttpaccesslog_gbfs_endpoint_id_fkey
-    ],
     Gbfsfeed: [
         Gbfsfeed.gbfsversions,  # gbfsversion_feed_id_fkey
-        Gbfsfeed.httpaccesslogs,  # gbfsfeedhttpaccesslog_gbfs_feed_id_fkey
     ],
     Gbfsvalidationreport: [
         Gbfsvalidationreport.gbfsnotices,  # gbfsnotice_validation_report_id_fkey
@@ -93,37 +80,11 @@ cascade_entities = {
         Gbfsversion.gbfsendpoints,  # gbfsendpoint_gbfs_version_id_fkey
         Gbfsversion.gbfsvalidationreports,  # gbfsvalidationreport_gbfs_version_id_fkey
     ],
-    Gtfsdataset: [
-        Gtfsdataset.locations,  # location_gtfsdataset_gtfsdataset_id_fkey
-        # Gtfsdataset.notices,  # Notices will be deleted via the validationreport notice_dataset_id_fkey
-        # Gtfsdataset.validation_reports,  # DONE validationreportgtfsdataset_dataset_id_fkey
-    ],
-    Gtfsfeed: [
-        Gtfsfeed.gtfs_rt_feeds,  # feedreference_gtfs_feed_id_fkey
-    ],
-    Gtfsrealtimefeed: [
-        Gtfsrealtimefeed.entitytypes,  # DONE
-        Gtfsrealtimefeed.gtfs_feeds,  # DONE entitytypefeed_feed_id_fkey, feedreference_gtfs_rt_feed_id_fkey
-    ],
-    Httpaccesslog: [
-        Httpaccesslog.gbfs_endpoints,  # DONE gbfsendpointhttpaccesslog_http_access_log_fkey
-        Httpaccesslog.gbfs_feeds,  # DONE gbfsfeedhttpaccesslog_http_access_log_fkey
-    ],
-    Location: [
-        Location.feeds,  # DONE locationfeed_location_id_fkey
-        Location.gtfsdatasets,  # DONE location_gtfsdataset_location_id_fkey
-    ],
-    # Officialstatushistory: [
-    #     Officialstatushistory.feed,  # DONE officialstatushistory_feed_id_fkey
-    # ],
     Osmlocationgroup: [
         Osmlocationgroup.feedlocationgrouppoints,  # DONE
         Osmlocationgroup.feedosmlocationgroups,  # DONE feedosmlocation_group_id_fkey
-        Osmlocationgroup.osms,  # DONE osmlocationgroupgeopolygon_group_id_fkey
     ],
     Validationreport: [
-        Validationreport.datasets,  # DONE validationreportgtfsdataset_validation_report_id_fkey
-        Validationreport.features,  # DONE featurevalidationreport_validation_id_fkey
         Validationreport.notices,  # DONE notice_validation_report_id_fkey
     ],
 }
@@ -139,7 +100,7 @@ def set_cascade(mapper, class_):
         relationship_keys = {rel.prop.key for rel in cascade_entities[class_]}
         for rel in class_.__mapper__.relationships:
             if rel.key in relationship_keys:
-                rel.cascade = "all"
+                rel.cascade = "all, delete-orphan"
                 rel.passive_deletes = True
 
 

--- a/api/src/shared/database/database.py
+++ b/api/src/shared/database/database.py
@@ -81,11 +81,11 @@ cascade_entities = {
         Gbfsversion.gbfsvalidationreports,  # gbfsvalidationreport_gbfs_version_id_fkey
     ],
     Osmlocationgroup: [
-        Osmlocationgroup.feedlocationgrouppoints,  # DONE
-        Osmlocationgroup.feedosmlocationgroups,  # DONE feedosmlocation_group_id_fkey
+        Osmlocationgroup.feedlocationgrouppoints,
+        Osmlocationgroup.feedosmlocationgroups,  # feedosmlocation_group_id_fkey
     ],
     Validationreport: [
-        Validationreport.notices,  # DONE notice_validation_report_id_fkey
+        Validationreport.notices,  # notice_validation_report_id_fkey
     ],
 }
 

--- a/api/tests/integration/cascade_delete/conftest.py
+++ b/api/tests/integration/cascade_delete/conftest.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from shared.database.database import Database
+from main import app as application
+from tests.test_utils.database import populate_database
+
+
+@pytest.fixture(scope="package")
+def app() -> FastAPI:
+    application.dependency_overrides = {}
+    return application
+
+
+@pytest.fixture(scope="package")
+def test_database():
+    # Restrict the tests to the test database
+    os.environ["FEEDS_DATABASE_URL"] = "postgresql://postgres:postgres@localhost:54320/MobilityDatabaseTest"
+
+    data_dirs = []
+    second_phase_data_dirs = []
+    with populate_database(Database(), data_dirs, second_phase_data_dirs) as db:
+        yield db
+
+
+@pytest.fixture(scope="package")
+def client(app, test_database) -> TestClient:
+    return TestClient(app)
+
+
+# We want to delete all data from the database after each test so we don't have to coordinate the DB ids between tests.
+@pytest.fixture(autouse=True)
+def clean_database(test_database, request):
+    yield
+    # Check if the test passed
+    if request.node.rep_call.outcome == "passed":
+        with test_database.start_db_session() as session:
+            for table in session.execute(text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")):
+                session.execute(text(f"TRUNCATE {table[0]} CASCADE"))
+            session.commit()
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # Attach test result to the request object
+    outcome = yield
+    report = outcome.get_result()
+    setattr(item, f"rep_{call.when}", report)

--- a/api/tests/integration/cascade_delete/test_cascade_delete.py
+++ b/api/tests/integration/cascade_delete/test_cascade_delete.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import datetime
 import uuid
 from sqlalchemy.orm import Session
@@ -63,8 +62,7 @@ def test_delete_feature_cascadeto_featurevalidationreport(test_database):
         )
 
 
-# Direct one-to-many: child table has a foreign key to the parent table.
-def test__delete_feed_cascadeto_externalids(test_database):
+def test_delete_feed_cascadeto_externalids(test_database):
 
     with test_database.start_db_session() as session:
         feed = Feed(id="f1")
@@ -79,7 +77,6 @@ def test__delete_feed_cascadeto_externalids(test_database):
         )
 
 
-# Association object pattern: parent table links to an association table, which references the child table
 def test_delete_feed_cascadeto_feedlocationgrouppoint(test_database):
     with test_database.start_db_session() as session:
 

--- a/api/tests/integration/cascade_delete/test_cascade_delete.py
+++ b/api/tests/integration/cascade_delete/test_cascade_delete.py
@@ -1,0 +1,547 @@
+# coding: utf-8
+import datetime
+import uuid
+from sqlalchemy.orm import Session
+
+from shared.database_gen.sqlacodegen_models import (
+    Feed,
+    Gtfsrealtimefeed,
+    Gtfsdataset,
+    Location,
+    Osmlocationgroup,
+    Feedlocationgrouppoint,
+    Externalid,
+    Entitytype,
+    Feedosmlocationgroup,
+    Feature,
+    Validationreport,
+    Officialstatushistory,
+    Redirectingid,
+    Gbfsendpoint,
+    Gbfsversion,
+    Gbfsfeed,
+    Httpaccesslog,
+    Gbfsvalidationreport,
+    Gbfsnotice,
+    Notice,
+    Gtfsfeed,
+    Geopolygon,
+)
+
+from sqlalchemy import text
+from geoalchemy2 import WKTElement
+
+
+def delete_and_assert(session: "Session", sql_queries: list[str], parent_instance):
+
+    # Assert all queries return 1 before deletion
+    for sql_query in sql_queries:
+        count = session.execute(text(sql_query)).scalar()
+        assert count == 1, f"Expected count 1 before delete for query: {sql_query}, got {count}"
+
+    session.delete(parent_instance)
+    session.commit()
+
+    # Assert all queries return 0 after deletion
+    for sql_query in sql_queries:
+        count = session.execute(text(sql_query)).scalar()
+        assert count == 0, f"Expected count 0 after delete for query: {sql_query}, got {count}"
+
+
+def test_delete_feature_cascadeto_featurevalidationreport(test_database):
+
+    with test_database.start_db_session() as session:
+        feature = Feature(name="f1")
+        validationreport = Validationreport(id="v1")
+
+        session.add_all([feature, validationreport])
+        feature.validations.append(validationreport)
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM feature", "SELECT COUNT(*) FROM featurevalidationreport"], feature
+        )
+
+
+# Direct one-to-many: child table has a foreign key to the parent table.
+def test__delete_feed_cascadeto_externalids(test_database):
+
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        externalid = Externalid(feed_id="f1", associated_id="Some id 1")
+        session.add_all([feed, externalid])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM feed where id = 'f1'", "SELECT COUNT(*) FROM externalid where feed_id = 'f1'"],
+            feed,
+        )
+
+
+# Association object pattern: parent table links to an association table, which references the child table
+def test_delete_feed_cascadeto_feedlocationgrouppoint(test_database):
+    with test_database.start_db_session() as session:
+
+        feed = Feed(id="f1")
+        group = Osmlocationgroup(group_id="g1", group_name="G1")
+        assoc = Feedlocationgrouppoint(feed_id="f1", group_id="g1", geometry=WKTElement("POINT (1.0 1.0)"))
+        session.add_all([feed, group, assoc])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM feed where id = 'f1'",
+                "SELECT COUNT(*) FROM feedlocationgrouppoint where feed_id = 'f1'",
+            ],
+            feed,
+        )
+
+
+def test_delete_feed_cascadeto_feedosmlocationgroup(test_database):
+
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        group = Osmlocationgroup(group_id="g1", group_name="G1")
+        session.add_all([feed, group])
+        feed.feedosmlocationgroups.append(Feedosmlocationgroup(feed_id="f1", group_id="g1", stops_count=1))
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM feed where id = 'f1'",
+                "SELECT COUNT(*) FROM feedosmlocationgroup where feed_id = 'f1'",
+            ],
+            feed,
+        )
+
+
+def test_delete_feed_cascadeto_gtfsdataset(test_database):
+
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        dataset = Gtfsdataset(id="d1", feed_id="f1")
+        session.add_all([feed, dataset])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM feed where id = 'f1'", "SELECT COUNT(*) FROM gtfsdataset where feed_id = 'f1'"],
+            feed,
+        )
+
+
+def test_delete_feed_cascadeto_locationfeed(test_database):
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        location = Location(id="l1")
+        session.add_all([feed, location])
+        feed.locations.append(location)
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM feed where id = 'f1'", "SELECT COUNT(*) FROM locationfeed where feed_id = 'f1'"],
+            feed,
+        )
+
+
+def test_cascade_delete_feed_officialstatushistory(test_database):
+
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        officialstatushistory = Officialstatushistory(
+            is_official=True, feed_id="f1", timestamp=datetime.datetime.now(), reviewer_email=""
+        )
+        session.add_all([feed, officialstatushistory])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM feed where id = 'f1'",
+                "SELECT COUNT(*) FROM officialstatushistory where feed_id = 'f1'",
+            ],
+            feed,
+        )
+
+
+def test_delete_feed_cascadeto_redirectingid(test_database):
+    with test_database.start_db_session() as session:
+        feed1 = Feed(id="f1")
+        feed2 = Feed(id="f2")
+        feed3 = Feed(id="f3")
+        assoc1 = Redirectingid(source_id="f1", target_id="f2")
+        assoc2 = Redirectingid(source_id="f2", target_id="f3")
+
+        session.add_all([feed1, feed2, feed3, assoc1, assoc2])
+
+        session.commit()
+
+        assoc_count = session.execute(text("SELECT COUNT(*) FROM redirectingid")).scalar()
+        assert assoc_count == 2
+
+        session.delete(feed2)
+        session.commit()
+        assoc_count = session.execute(text("SELECT COUNT(*) FROM redirectingid")).scalar()
+        assert assoc_count == 0
+
+
+def test_delete_gbfsfeed_cascadeto_gbfsversion_cascadeto_gbfsendpoint_cascadeto_gbfsendpointhttpaccesslog(
+    test_database,
+):
+    with test_database.start_db_session() as session:
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        endpoint = Gbfsendpoint(id="e1", name="e1", gbfs_version_id="v1", url="https://example.com")
+        accesslogid = uuid.uuid4()
+        accesslog = Httpaccesslog(
+            id=accesslogid, request_method="allo", request_url="https://example.com", status_code=200
+        )
+        endpoint.httpaccesslogs.append(accesslog)
+        session.add_all([feed, version, endpoint, accesslog])
+        session.commit()
+
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsendpoint WHERE id = 'e1'")).scalar()
+        assert count == 1
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsversion WHERE id = 'v1'")).scalar()
+        assert count == 1
+        count = session.execute(text("SELECT COUNT(*) FROM httpaccesslog WHERE id = :id"), {"id": accesslogid}).scalar()
+        assert count == 1
+        count = session.execute(
+            text("SELECT COUNT(*) FROM gbfsendpointhttpaccesslog WHERE gbfs_endpoint_id = 'e1'")
+        ).scalar()
+        assert count == 1
+
+        session.delete(feed)
+        session.commit()
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsendpoint WHERE id = 'e1'")).scalar()
+        assert count == 0
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsversion WHERE id = 'v1'")).scalar()
+        assert count == 0
+        # Make sure the row in the association is deleted
+        count = session.execute(
+            text("SELECT COUNT(*) FROM gbfsendpointhttpaccesslog WHERE gbfs_endpoint_id = 'e1'")
+        ).scalar()
+        assert count == 0
+        # But not the access log entry itself. The only way to delete this safely is if it's removed from
+        # gbfsfeedhttpaccesslog and gbfsendpointhttpaccesslog, since both of these tables refer to Httpaccesslog
+        count = session.execute(text("SELECT COUNT(*) FROM httpaccesslog WHERE id = :id"), {"id": accesslogid}).scalar()
+        assert count == 1
+
+
+def test_delete_gbfsfeed_cascadeto_gbfsfeedhttpaccesslog(test_database):
+    with test_database.start_db_session() as session:
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        endpoint = Gbfsendpoint(id="e1", name="e1", gbfs_version_id="v1", url="https://example.com")
+        accesslogid = uuid.uuid4()
+        accesslog = Httpaccesslog(
+            id=accesslogid, request_method="allo", request_url="https://example.com", status_code=200
+        )
+
+        feed.httpaccesslogs.append(accesslog)
+        endpoint.httpaccesslogs.append(accesslog)
+        session.add_all([feed, version, endpoint, accesslog])
+
+        session.commit()
+
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsfeedhttpaccesslog WHERE gbfs_feed_id = 'f1'")).scalar()
+        assert count == 1
+
+        session.delete(feed)
+        session.commit()
+
+        count = session.execute(text("SELECT COUNT(*) FROM gbfsfeedhttpaccesslog WHERE gbfs_feed_id = 'f1'")).scalar()
+        assert count == 0
+
+
+def test_delete_gbfsvalidationreport_cascadeto_gbfsnotice(test_database):
+    with test_database.start_db_session() as session:
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        validationreport = Gbfsvalidationreport(
+            id="v1",
+            gbfs_version_id="v1",
+            report_summary_url="some url",
+            total_errors_count=0,
+            validator_version="2.3.0",
+        )
+        notice = Gbfsnotice(
+            keyword="allo",
+            message="some message",
+            schema_path="some path",
+            gbfs_file="some file",
+            validation_report_id="v1",
+            count=1,
+        )
+        session.add_all([feed, version, validationreport, notice])
+        validationreport.gbfsnotices.append(notice)
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM gbfsvalidationreport where id = 'v1'",
+                "SELECT COUNT(*) FROM gbfsnotice where validation_report_id = 'v1'",
+            ],
+            validationreport,
+        )
+
+
+def test_delete_gbfsfeed_cascadeto_gbfsversion_cascadeto_gbfsvalidationreport(test_database):
+    with test_database.start_db_session() as session:
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        validationreport = Gbfsvalidationreport(
+            id="v1",
+            gbfs_version_id="v1",
+            report_summary_url="some url",
+            total_errors_count=0,
+            validator_version="2.3.0",
+        )
+        session.add_all([feed, version, validationreport])
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM gbfsversion", "SELECT COUNT(*) FROM gbfsvalidationreport"], feed
+        )
+
+
+def test_delete_gtfsdataset_cascadeto_location_gtfsdataset(test_database):
+    with test_database.start_db_session() as session:
+        dataset = Gtfsdataset(id="d1")
+        location = Location(id="l1")
+        session.add_all([dataset, location])
+        session.flush()
+        dataset.locations.append(location)
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM gtfsdataset",
+                "SELECT COUNT(*) FROM location_gtfsdataset WHERE gtfsdataset_id = 'd1'",
+            ],
+            dataset,
+        )
+
+
+def test_delete_gtfsfeed_cascadeto_feedreference(test_database):
+    with test_database.start_db_session() as session:
+        gtfsfeed = Gtfsfeed(id="f1")
+        gtfsrtfeed = Gtfsrealtimefeed(id="f2")
+        session.add_all([gtfsfeed, gtfsrtfeed])
+        gtfsfeed.gtfs_rt_feeds.append(gtfsrtfeed)
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM feed where id = 'f1'", "SELECT COUNT(*) FROM feedreference"], gtfsfeed
+        )
+
+
+def test_delete_gtfsrealtimefeed_cascadeto_feedreference(test_database):
+    with test_database.start_db_session() as session:
+        gtfsfeed = Gtfsfeed(id="f1")
+        gtfsrtfeed = Gtfsrealtimefeed(id="f2")
+        session.add_all([gtfsfeed, gtfsrtfeed])
+        gtfsfeed.gtfs_rt_feeds.append(gtfsrtfeed)
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM feed where id = 'f2'", "SELECT COUNT(*) FROM feedreference"], gtfsrtfeed
+        )
+
+
+def test_delete_gtfsrealtimefeed_cascadeto_entitytypes(test_database):
+    with test_database.start_db_session() as session:
+        gtfsrtfeed = Gtfsrealtimefeed(id="f1")
+        entitytype = Entitytype(name="type1")
+        session.add_all([gtfsrtfeed, gtfsrtfeed])
+        gtfsrtfeed.entitytypes.append(entitytype)
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM gtfsrealtimefeed where id = 'f1'", "SELECT COUNT(*) FROM entitytypefeed"],
+            gtfsrtfeed,
+        )
+
+
+def test_delete_httpaccesslog_cascadeto_gbfsendpointhttpaccesslog(test_database):
+    with (test_database.start_db_session() as session):
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        endpoint = Gbfsendpoint(id="e1", name="e1", gbfs_version_id="v1", url="https://example.com")
+        accesslogid = uuid.uuid4()
+        accesslog = Httpaccesslog(
+            id=accesslogid, request_method="allo", request_url="https://example.com", status_code=200
+        )
+
+        endpoint.httpaccesslogs.append(accesslog)
+        session.add_all([feed, version, endpoint, accesslog])
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM httpaccesslog", "SELECT COUNT(*) FROM gbfsendpointhttpaccesslog"], accesslog
+        )
+
+
+def test_delete_httpaccesslog_cascadeto_gbfsfeedhttpaccesslog(test_database):
+    with (test_database.start_db_session() as session):
+        feed = Gbfsfeed(id="f1")
+        version = Gbfsversion(id="v1", feed_id="f1", version="1.0", url="https://example.com/version")
+        endpoint = Gbfsendpoint(id="e1", name="e1", gbfs_version_id="v1", url="https://example.com")
+        accesslogid = uuid.uuid4()
+        accesslog = Httpaccesslog(
+            id=accesslogid, request_method="allo", request_url="https://example.com", status_code=200
+        )
+
+        feed.httpaccesslogs.append(accesslog)
+        endpoint.httpaccesslogs.append(accesslog)
+        session.add_all([feed, version, endpoint, accesslog])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM gbfsfeed where id = 'f1'", "SELECT COUNT(*) FROM gbfsfeedhttpaccesslog"],
+            feed,
+        )
+
+
+def test_delete_location_cascadeto_locationfeed(test_database):
+    with (test_database.start_db_session() as session):
+        feed = Gtfsfeed(id="f1")
+        location = Location(id="l1")
+
+        feed.locations.append(location)
+        session.add_all([feed, location])
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM gtfsfeed where id = 'f1'", "SELECT COUNT(*) FROM locationfeed"], feed
+        )
+
+
+def test_delete_location_cascadeto_location_gtfsdataset(test_database):
+    with (test_database.start_db_session() as session):
+
+        location = Location(id="l1")
+        dataset = Gtfsdataset(id="d1")
+        session.add_all([dataset, location])
+        dataset.locations.append(location)
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM gtfsdataset where id = 'd1'", "SELECT COUNT(*) FROM location_gtfsdataset"],
+            dataset,
+        )
+
+
+def test_cascade_delete_osmlocationgroup_cascadeto_feedlocationgrouppoint(test_database):
+    with test_database.start_db_session() as session:
+        feed = Gtfsfeed(id="f1")
+        group = Osmlocationgroup(group_id="g1", group_name="G1")
+        assoc = Feedlocationgrouppoint(feed_id="f1", group_id="g1", geometry=WKTElement("POINT (1.0 1.0)"))
+        session.add_all([feed, group, assoc])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM osmlocationgroup where group_id = 'g1'",
+                "SELECT COUNT(*) FROM feedlocationgrouppoint",
+            ],
+            group,
+        )
+
+
+def test_cascade_delete_osmlocationgroup_cascadeto_feedosmlocationgroup(test_database):
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        group = Osmlocationgroup(group_id="g1", group_name="G1")
+        assoc = Feedosmlocationgroup(feed_id="f1", group_id="g1", stops_count=1)
+        session.add_all([feed, group, assoc])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM osmlocationgroup where group_id = 'g1'",
+                "SELECT COUNT(*) FROM feedosmlocationgroup",
+            ],
+            group,
+        )
+
+
+def test_cascade_delete_osmlocationgroup_cascadeto_osmlocationgroupgeopolygon(test_database):
+    with test_database.start_db_session() as session:
+        feed = Gtfsfeed(id="f1")
+        group = Osmlocationgroup(group_id="g1", group_name="G1")
+        geopolygon = Geopolygon(osm_id=1)
+        group.osms.append(geopolygon)
+
+        session.add_all([feed, group, geopolygon])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM osmlocationgroup where group_id = 'g1'",
+                "SELECT COUNT(*) FROM osmlocationgroupgeopolygon",
+            ],
+            group,
+        )
+
+
+def test_cascade_delete_validationreport_cascadeto_validationreportgtfsdataset(test_database):
+    with test_database.start_db_session() as session:
+        dataset = Gtfsdataset(id="d1")
+        validationreport = Validationreport(id="v1")
+        dataset.validation_reports.append(validationreport)
+
+        session.add_all([dataset, validationreport])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM validationreport where id = 'v1'",
+                "SELECT COUNT(*) FROM validationreportgtfsdataset",
+            ],
+            validationreport,
+        )
+
+
+def test_delete_validationreport_cascadeto_featurevalidationreport(test_database):
+    with test_database.start_db_session() as session:
+        feature = Feature(name="f1")
+        validationreport = Validationreport(id="v1")
+        feature.validations.append(validationreport)
+
+        session.add_all([feature, validationreport])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            ["SELECT COUNT(*) FROM validationreport where id = 'v1'", "SELECT COUNT(*) FROM featurevalidationreport"],
+            validationreport,
+        )
+
+
+def test_delete_validationreport_cascadeto_notice(test_database):
+    with test_database.start_db_session() as session:
+        dataset = Gtfsdataset(id="d1")
+        validationreport = Validationreport(id="v1")
+        notice = Notice(dataset_id="d1", notice_code="code1", total_notices=1, validation_report_id="v1")
+        session.add_all([dataset, validationreport, notice])
+
+        validationreport.notices.append(notice)
+        session.commit()
+
+        delete_and_assert(
+            session, ["SELECT COUNT(*) FROM validationreport", "SELECT COUNT(*) FROM notice"], validationreport
+        )

--- a/api/tests/integration/populate_twice_gbfs/conftest.py
+++ b/api/tests/integration/populate_twice_gbfs/conftest.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from shared.database.database import Database
+from main import app as application
+from tests.test_utils.database import populate_database
+
+
+@pytest.fixture(scope="package")
+def app() -> FastAPI:
+    application.dependency_overrides = {}
+    return application
+
+
+@pytest.fixture(scope="package")
+def test_database():
+    # Restrict the tests to the test database
+    os.environ["FEEDS_DATABASE_URL"] = "postgresql://postgres:postgres@localhost:54320/MobilityDatabaseTest"
+
+    current_path = os.path.dirname(os.path.abspath(__file__))
+
+    data_dirs = [current_path + "/test_data"]
+    second_phase_data_dirs = [current_path + "/test_data_part_2"]
+    with populate_database(Database(), data_dirs, second_phase_data_dirs) as db:
+        yield db
+
+
+@pytest.fixture(scope="package")
+def client(app, test_database) -> TestClient:
+    return TestClient(app)

--- a/api/tests/integration/populate_twice_gbfs/test_data/systems_test.csv
+++ b/api/tests/integration/populate_twice_gbfs/test_data/systems_test.csv
@@ -1,0 +1,4 @@
+Country Code,Name,Location,System ID,URL,Auto-Discovery URL,Supported Versions,Authentication Info URL,Authentication Type,Authentication Parameter Name
+AE,Feed 1,Dubai,feed_1,https://www.careem.com/en-ae/careem-bike/,https://some_url/gbfs.json,1.1 ; 2.3,,,
+AE,Feed 2,Abu Dhabi,feed_2,https://ridedott.com/,https://some_url/gbfs.json,2.3,,,
+AE,Feed 3,Dubai,feed_3,https://ridedott.com/,https://some_url/gbfs.json,2.3,,,

--- a/api/tests/integration/populate_twice_gbfs/test_data_part_2/systems_test.csv
+++ b/api/tests/integration/populate_twice_gbfs/test_data_part_2/systems_test.csv
@@ -1,0 +1,10 @@
+# We want to test the populate when there is already stuff in the DB and we rerun
+# with changes in systems.csv
+Country Code,Name,Location,System ID,URL,Auto-Discovery URL,Supported Versions,Authentication Info URL, Authentication Type,Authentication Parameter Name
+# Feed 1 stays the same
+AE,Feed 1,Dubai,feed_1,https://www.careem.com/en-ae/careem-bike/,https://some_url/gbfs.json,1.1 ; 2.3,,,
+# Feed 2 was removed. We expect it to be made deprecated in the DB
+# Feed 3 was modified (Name will be Feed 3 modified instead of Feed 3)
+AE,Feed 3 modified,Dubai,feed_3,https://www.careem.com/en-ae/careem-bike/,https://some_url/gbfs.json,1.1 ; 2.3,,,
+# Feed 4 was added
+AE,Feed 4,Dubai,feed_4,https://ridedott.com/,https://some_url/gbfs.json,2.3,,,

--- a/api/tests/integration/populate_twice_gbfs/test_populate_gbfs.py
+++ b/api/tests/integration/populate_twice_gbfs/test_populate_gbfs.py
@@ -5,7 +5,6 @@ from tests.test_utils.token import authHeaders
 
 
 def test_gbfs_populate(client: TestClient):
-    """Test case for gbfs populate"""
 
     response = client.request(
         "GET",
@@ -15,17 +14,16 @@ def test_gbfs_populate(client: TestClient):
 
     assert response.status_code == 200
     json_response = response.json()
-    assert json_response["total"] == 4
+    assert json_response["total"] == 3, "The return count from the search should be 3"
 
     results = json_response["results"]
-    assert len(results) == 4, "There should be 4 results in the response"
+    assert len(results) == 3, "There should be 3 results in the response"
 
     feed_1 = next((item for item in results if item["id"] == "gbfs-feed_1"), None)
-    feed_2 = next((item for item in results if item["id"] == "gbfs-feed_2"), None)
+    # Feed 2 was deleted because removed from the 2nd systems.csv
     feed_3 = next((item for item in results if item["id"] == "gbfs-feed_3"), None)
     feed_4 = next((item for item in results if item["id"] == "gbfs-feed_4"), None)
     assert feed_1["status"] == "active"
-    assert feed_2["status"] == "deprecated", "Feed 2 should be deprecated since it was removed in the 2nd systems.csv"
     assert feed_3["status"] == "active"
     assert feed_4["status"] == "active"
 

--- a/api/tests/integration/populate_twice_gbfs/test_populate_gbfs.py
+++ b/api/tests/integration/populate_twice_gbfs/test_populate_gbfs.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+from fastapi.testclient import TestClient
+
+from tests.test_utils.token import authHeaders
+
+
+def test_gbfs_populate(client: TestClient):
+    """Test case for gbfs populate"""
+
+    response = client.request(
+        "GET",
+        "/v1/search",
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 200
+    json_response = response.json()
+    assert json_response["total"] == 4
+
+    results = json_response["results"]
+    assert len(results) == 4, "There should be 4 results in the response"
+
+    feed_1 = next((item for item in results if item["id"] == "gbfs-feed_1"), None)
+    feed_2 = next((item for item in results if item["id"] == "gbfs-feed_2"), None)
+    feed_3 = next((item for item in results if item["id"] == "gbfs-feed_3"), None)
+    feed_4 = next((item for item in results if item["id"] == "gbfs-feed_4"), None)
+    assert feed_1["status"] == "active"
+    assert feed_2["status"] == "deprecated", "Feed 2 should be deprecated since it was removed in the 2nd systems.csv"
+    assert feed_3["status"] == "active"
+    assert feed_4["status"] == "active"
+
+    assert feed_3["provider"] == "Feed 3 modified", "Feed 3 name was modified in the 2nd systems.csv"

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -25,10 +25,13 @@ datasets_download_first_date: Final[datetime] = datetime.strptime(date_string, d
 
 
 @contextlib.contextmanager
-def populate_database(db: Database, data_dirs: List[str]):
+def populate_database(db: Database, data_dirs: List[str], second_phase_data_dirs: List[str] = None):
+    """
+    Populate the database in two phases before yielding for tests.
+    - First phase: populate with data_dirs.
+    - Second phase: populate with more data to see the effect of adding to a DB that is not empty.
+    """
     try:
-
-        # Check if connected to test DB.
         url = make_url(db.engine.url)
         if not is_test_db(url):
             raise Exception("Not connected to MobilityDatabaseTest, aborting operation")
@@ -39,47 +42,60 @@ def populate_database(db: Database, data_dirs: List[str]):
         ):
             empty_database(db, url)
 
-        # Make a list of all the sources_test.csv in test_data and keep only if the file exists
-        csv_filepaths = [
-            filepath
-            for directory in data_dirs
-            if (filepath := os.path.join(directory, "sources_test.csv")) and os.path.isfile(filepath)
-        ]
+        # --- Phase 1 population ---
+        _populate_db_phase(db, data_dirs)
 
-        if len(csv_filepaths) == 0:
-            raise Exception("No sources_test.csv file found in test_data directories")
+        # --- Phase 2 population (only if provided) ---
+        if second_phase_data_dirs is not None:
+            _populate_db_phase(db, second_phase_data_dirs)
 
-        gtfs_db_helper = GTFSDatabasePopulateHelper(csv_filepaths)
-        gtfs_db_helper.initialize(trigger_downstream_tasks=False)
-
-        # Add GBFS data to the database
-        gbfs_csv_filepaths = [
-            filepath
-            for directory in data_dirs
-            if (filepath := os.path.join(directory, "systems_test.csv")) and os.path.isfile(filepath)
-        ]
-        GBFSDatabasePopulateHelper(gbfs_csv_filepaths).initialize(trigger_downstream_tasks=False, fetch_url=False)
-
-        # Make a list of all the extra_test_data.json files in the test_data directories and load the data
-        json_filepaths = [
-            filepath
-            for dir in data_dirs
-            if (filepath := os.path.join(dir, "extra_test_data.json")) and os.path.isfile(filepath)
-        ]
-
-        if len(json_filepaths) == 0:
-            print("No extra_test_data.json file found in test_data directories")
-        else:
-            db_helper = DatabasePopulateTestDataHelper(json_filepaths)
-            db_helper.populate()
         yield db
-        # Dump the DB data if requested by providing a file name for the dump
+
+        # Optionally dump the database after tests
         if (test_db_dump_filename := os.getenv("TEST_DB_DUMP_FILENAME")) is not None:
             dump_database(db, test_db_dump_filename)
         if (test_raw_db_dump_filename := os.getenv("TEST_RAW_DB_DUMP_FILENAME")) is not None:
             dump_raw_database(db, test_raw_db_dump_filename)
-        # Note that the DB is cleaned before the test, if requested, not after so the DB can be manually examined
-        # if the tests fail.
     except Exception as e:
         print(e)
         raise e
+
+
+def _populate_db_phase(db: Database, data_dirs: List[str]):
+    """
+    Populate the DB with files located in a set of directories.
+    Populates GTFS, GBFS, and extra test data, if available.
+    """
+    csv_filepaths = [
+        filepath
+        for directory in data_dirs
+        if (filepath := os.path.join(directory, "sources_test.csv")) and os.path.isfile(filepath)
+    ]
+    if csv_filepaths:
+        gtfs_db_helper = GTFSDatabasePopulateHelper(csv_filepaths)
+        gtfs_db_helper.initialize(trigger_downstream_tasks=False)
+    else:
+        print("No sources_test.csv file found in test_data directories")
+
+    # GBFS
+    gbfs_csv_filepaths = [
+        filepath
+        for directory in data_dirs
+        if (filepath := os.path.join(directory, "systems_test.csv")) and os.path.isfile(filepath)
+    ]
+    if gbfs_csv_filepaths:
+        GBFSDatabasePopulateHelper(gbfs_csv_filepaths).initialize(trigger_downstream_tasks=False, fetch_url=False)
+    else:
+        print("No systems_test.csv file found in test_data directories")
+
+    # Extra test data
+    json_filepaths = [
+        filepath
+        for dir in data_dirs
+        if (filepath := os.path.join(dir, "extra_test_data.json")) and os.path.isfile(filepath)
+    ]
+    if json_filepaths:
+        db_helper = DatabasePopulateTestDataHelper(json_filepaths)
+        db_helper.populate()
+    else:
+        print("No extra_test_data.json file found in test_data directories")

--- a/api/tests/test_utils/database.py
+++ b/api/tests/test_utils/database.py
@@ -74,8 +74,6 @@ def _populate_db_phase(db: Database, data_dirs: List[str]):
     if csv_filepaths:
         gtfs_db_helper = GTFSDatabasePopulateHelper(csv_filepaths)
         gtfs_db_helper.initialize(trigger_downstream_tasks=False)
-    else:
-        print("No sources_test.csv file found in test_data directories")
 
     # GBFS
     gbfs_csv_filepaths = [
@@ -85,8 +83,6 @@ def _populate_db_phase(db: Database, data_dirs: List[str]):
     ]
     if gbfs_csv_filepaths:
         GBFSDatabasePopulateHelper(gbfs_csv_filepaths).initialize(trigger_downstream_tasks=False, fetch_url=False)
-    else:
-        print("No systems_test.csv file found in test_data directories")
 
     # Extra test data
     json_filepaths = [
@@ -97,5 +93,3 @@ def _populate_db_phase(db: Database, data_dirs: List[str]):
     if json_filepaths:
         db_helper = DatabasePopulateTestDataHelper(json_filepaths)
         db_helper.populate()
-    else:
-        print("No extra_test_data.json file found in test_data directories")

--- a/functions-python/operations_api/src/feeds_operations/impl/feeds_operations_impl.py
+++ b/functions-python/operations_api/src/feeds_operations/impl/feeds_operations_impl.py
@@ -182,7 +182,7 @@ class OperationsApiImpl(BaseOperationsApi):
         Update the specified feed in the Mobility Database
         """
         try:
-            feed = await OperationsApiImpl.fetch_feed(
+            feed_from_db = await OperationsApiImpl.fetch_feed(
                 data_type, db_session, update_request_feed
             )
 
@@ -196,13 +196,13 @@ class OperationsApiImpl(BaseOperationsApi):
                 if data_type == DataType.GTFS
                 else UpdateRequestGtfsRtFeedImpl
             )
-            diff = self.detect_changes(feed, update_request_feed, impl_class)
+            diff = self.detect_changes(feed_from_db, update_request_feed, impl_class)
             if len(diff.affected_paths) > 0 or (
                 update_request_feed.operational_status_action is not None
                 and update_request_feed.operational_status_action != "no_change"
             ):
                 await OperationsApiImpl._populate_feed_values(
-                    feed, impl_class, db_session, update_request_feed
+                    feed_from_db, impl_class, db_session, update_request_feed
                 )
                 db_session.flush()
                 refreshed = refresh_materialized_view(db_session, t_feedsearch.name)

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -63,4 +63,5 @@
     <include file="changes/feat_1182.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1200.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1195.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_1265_cascade_delete.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_1265_cascade_delete.sql
+++ b/liquibase/changes/feat_1265_cascade_delete.sql
@@ -1,0 +1,149 @@
+-- These changes are to enable cascading deletes for various foreign key constraints in the database.
+--
+ALTER TABLE EntityTypeFeed DROP CONSTRAINT IF EXISTS entitytypefeed_feed_id_fkey;
+ALTER TABLE EntityTypeFeed
+ADD CONSTRAINT entitytypefeed_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES GTFSRealtimeFeed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE ExternalID DROP CONSTRAINT IF EXISTS externalid_feed_id_fkey;
+ALTER TABLE ExternalID
+ADD CONSTRAINT externalid_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES Feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeatureValidationReport DROP CONSTRAINT IF EXISTS featurevalidationreport_validation_id_fkey;
+ALTER TABLE FeatureValidationReport
+ADD CONSTRAINT featurevalidationreport_validation_id_fkey
+FOREIGN KEY (validation_id) REFERENCES ValidationReport(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedOSMLocationGroup DROP CONSTRAINT IF EXISTS feedosmlocation_feed_id_fkey;
+ALTER TABLE FeedOSMLocationGroup
+ADD CONSTRAINT feedosmlocation_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES Feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedOSMLocationGroup DROP CONSTRAINT IF EXISTS feedosmlocation_group_id_fkey;
+ALTER TABLE FeedOSMLocationGroup
+ADD CONSTRAINT feedosmlocation_group_id_fkey
+FOREIGN KEY (group_id) REFERENCES osmlocationgroup(group_id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedReference DROP CONSTRAINT IF EXISTS feedreference_gtfs_feed_id_fkey;
+ALTER TABLE FeedReference
+ADD CONSTRAINT feedreference_gtfs_feed_id_fkey
+FOREIGN KEY (gtfs_feed_id) REFERENCES public.gtfsfeed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedReference DROP CONSTRAINT IF EXISTS feedreference_gtfs_rt_feed_id_fkey;
+ALTER TABLE FeedReference
+ADD CONSTRAINT feedreference_gtfs_rt_feed_id_fkey
+FOREIGN KEY (gtfs_rt_feed_id) REFERENCES public.gtfsrealtimefeed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE GtfsFeed DROP CONSTRAINT IF EXISTS gtfsfeed_id_fkey;
+ALTER TABLE GtfsFeed
+ADD CONSTRAINT gtfsfeed_id_fkey
+FOREIGN KEY (id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--
+ALTER TABLE GtfsDataset DROP CONSTRAINT IF EXISTS gtfsdataset_feed_id_fkey;
+ALTER TABLE GtfsDataset
+ADD CONSTRAINT gtfsdataset_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE GTFSRealtimeFeed DROP CONSTRAINT IF EXISTS gtfsrealtimefeed_id_fkey;
+ALTER TABLE GTFSRealtimeFeed
+ADD CONSTRAINT gtfsrealtimefeed_id_fkey
+FOREIGN KEY (id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE Location_GtfsDataset DROP CONSTRAINT IF EXISTS location_gtfsdataset_gtfsdataset_id_fkey;
+ALTER TABLE Location_GtfsDataset
+ADD CONSTRAINT location_gtfsdataset_gtfsdataset_id_fkey
+FOREIGN KEY (gtfsdataset_id) REFERENCES public.gtfsdataset(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE Location_GtfsDataset DROP CONSTRAINT IF EXISTS location_gtfsdataset_location_id_fkey;
+ALTER TABLE Location_GtfsDataset
+ADD CONSTRAINT location_gtfsdataset_location_id_fkey
+FOREIGN KEY (location_id) REFERENCES public.location(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE LocationFeed DROP CONSTRAINT IF EXISTS locationfeed_feed_id_fkey;
+ALTER TABLE LocationFeed
+ADD CONSTRAINT locationfeed_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE LocationFeed DROP CONSTRAINT IF EXISTS locationfeed_location_id_fkey;
+ALTER TABLE LocationFeed
+ADD CONSTRAINT locationfeed_location_id_fkey
+FOREIGN KEY (location_id) REFERENCES public.location(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE Notice DROP CONSTRAINT IF EXISTS notice_validation_report_id_fkey;
+ALTER TABLE Notice
+ADD CONSTRAINT notice_validation_report_id_fkey
+FOREIGN KEY (validation_report_id) REFERENCES public.validationreport(id) ON DELETE CASCADE;
+
+ALTER TABLE Notice DROP CONSTRAINT IF EXISTS notice_dataset_id_fkey;
+ALTER TABLE Notice
+ADD CONSTRAINT notice_dataset_id_fkey
+FOREIGN KEY (dataset_id) REFERENCES public.gtfsdataset(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE OfficialStatusHistory DROP CONSTRAINT IF EXISTS officialstatushistory_feed_id_fkey;
+ALTER TABLE OfficialStatusHistory
+ADD CONSTRAINT officialstatushistory_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE OsmLocationGroupGeopolygon DROP CONSTRAINT IF EXISTS osmlocationgroupgeopolygon_group_id_fkey;
+ALTER TABLE OsmLocationGroupGeopolygon
+ADD CONSTRAINT osmlocationgroupgeopolygon_group_id_fkey
+FOREIGN KEY (group_id) REFERENCES public.osmlocationgroup(group_id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE OsmLocationGroupGeopolygon DROP CONSTRAINT IF EXISTS osmlocationgroupgeopolygon_osm_id_fkey;
+ALTER TABLE OsmLocationGroupGeopolygon
+ADD CONSTRAINT osmlocationgroupgeopolygon_osm_id_fkey
+FOREIGN KEY (osm_id) REFERENCES public.geopolygon(osm_id) ON DELETE CASCADE;
+
+--
+ALTER TABLE RedirectingID DROP CONSTRAINT IF EXISTS redirectingid_source_id_fkey;
+ALTER TABLE RedirectingID
+ADD CONSTRAINT redirectingid_source_id_fkey
+FOREIGN KEY (source_id) REFERENCES Feed(id) ON DELETE CASCADE;
+
+--
+ALTER TABLE RedirectingID DROP CONSTRAINT IF EXISTS redirectingid_target_id_fkey;
+ALTER TABLE RedirectingID
+ADD CONSTRAINT redirectingid_target_id_fkey
+FOREIGN KEY (target_id) REFERENCES Feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedLocationGroupPoint DROP CONSTRAINT IF EXISTS stop_feed_id_fkey;
+ALTER TABLE FeedLocationGroupPoint
+ADD CONSTRAINT stop_feed_id_fkey
+FOREIGN KEY (feed_id) REFERENCES public.feed(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE FeedLocationGroupPoint DROP CONSTRAINT IF EXISTS stop_group_id_fkey;
+ALTER TABLE FeedLocationGroupPoint
+ADD CONSTRAINT stop_group_id_fkey
+FOREIGN KEY (group_id) REFERENCES public.osmlocationgroup(group_id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE ValidationReportGTFSDataset DROP CONSTRAINT IF EXISTS validationreportgtfsdataset_dataset_id_fkey;
+ALTER TABLE ValidationReportGTFSDataset
+ADD CONSTRAINT validationreportgtfsdataset_dataset_id_fkey
+FOREIGN KEY (dataset_id) REFERENCES public.gtfsdataset(id) ON DELETE CASCADE;
+
+--                                             
+ALTER TABLE ValidationReportGTFSDataset DROP CONSTRAINT IF EXISTS validationreportgtfsdataset_validation_report_id_fkey;
+ALTER TABLE ValidationReportGTFSDataset
+ADD CONSTRAINT validationreportgtfsdataset_validation_report_id_fkey
+FOREIGN KEY (validation_report_id) REFERENCES public.validationreport(id) ON DELETE CASCADE;

--- a/scripts/function-python-setup.sh
+++ b/scripts/function-python-setup.sh
@@ -24,7 +24,7 @@
 # The function config must be defined in the file `functions-python/<function_name>/function_config.json`.
 
 # Usage:
-#   function-python-setup.sh --function_name <function name> --all
+#   function-python-setup.sh --function_name <function name> --all --clean
 # Examples:
 #   function-python-setup.sh --function_name batch_datasets
 #   function-python-setup.sh --all


### PR DESCRIPTION
Closes #1242 
Closes #1268 

The two corrections are:

- Deleted feeds from the DB if removed form systems.csv
   - There was code that would filter out feeds that were in in the DB but not in systems.csv. Thus we did not know that some feeds were removed from systems.csv
-  Stopped processing feeds based on changes in location
   - The location is initially set with the populate scripts from systems.csv, but then it is changed by the function that determines the location from the data. So comparing locations to see if something changed in CSV did not work.

For deletion, this PR also setup cascade deletes on certain DB tables in the SQL schema. For example, id a GbfsFeed is deleted, the entry in gbfsversion table referring to this feed is also deleted. This prevent failing of the deletion because gbfsversion.feed_id cannot be null and is a foreign key to gbfsfeed.

**Testing tips:**
See test_populate_gbfs.py for the tests that have been done.
We miodified the way the DB is filled in the api integration tests to allow 2 .csv files to be loaded. This allowed to test loading a csv in a DB that is already populated, as was necessary for this PR.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
