### PR TITLE
fix: 1204 bounding boxes are missing for many feeds with good stopstxt files

### DIFF
--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -175,37 +175,6 @@ def get_datasets_with_missing_reports_query(
     return query
 
 
-# def get_feeds_ids_with_missing_bounding_boxes_query(
-#     db_session: Session,
-# ) -> Query:
-#     """
-#     Get GTFS feeds ids where the dataset is missing a bounding box.
-
-#     Args:
-#         db_session: SQLAlchemy session
-
-#     Returns:
-#         A SQLAlchemy query object for GTFS feeds with datasets missing bounding boxes
-#         ordered by dataset and feed stable id.
-#     """
-#     query = (
-#         db_session.query(
-#             Gtfsfeed.stable_id,
-#             Gtfsdataset.stable_id,
-#         )
-#         .select_from(Gtfsfeed)
-#         .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
-#         .filter(Gtfsdataset.bounding_box.is_(None))
-#         .filter(
-#             ~Gtfsfeed.feedlocationgrouppoints.any()
-#         )  # Only feeds with no location group points
-#         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
-#         .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
-#     )
-
-#     return query
-
-
 def get_feeds_with_missing_bounding_boxes_query(
     db_session: Session,
 ) -> Query:
@@ -222,6 +191,7 @@ def get_feeds_with_missing_bounding_boxes_query(
     query = (
         db_session.query(Gtfsfeed)
         .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
+        .filter(Gtfsdataset.latest.is_(True))
         .filter(Gtfsdataset.bounding_box.is_(None))
         .filter(~Gtfsfeed.feedlocationgrouppoints.any())
         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -175,35 +175,35 @@ def get_datasets_with_missing_reports_query(
     return query
 
 
-def get_feeds_ids_with_missing_bounding_boxes_query(
-    db_session: Session,
-) -> Query:
-    """
-    Get GTFS feeds ids where the dataset is missing a bounding box.
+# def get_feeds_ids_with_missing_bounding_boxes_query(
+#     db_session: Session,
+# ) -> Query:
+#     """
+#     Get GTFS feeds ids where the dataset is missing a bounding box.
 
-    Args:
-        db_session: SQLAlchemy session
+#     Args:
+#         db_session: SQLAlchemy session
 
-    Returns:
-        A SQLAlchemy query object for GTFS feeds with datasets missing bounding boxes
-        ordered by dataset and feed stable id.
-    """
-    query = (
-        db_session.query(
-            Gtfsfeed.stable_id,
-            Gtfsdataset.stable_id,
-        )
-        .select_from(Gtfsfeed)
-        .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
-        .filter(Gtfsdataset.bounding_box.is_(None))
-        .filter(
-            ~Gtfsfeed.feedlocationgrouppoints.any()
-        )  # Only feeds with no location group points
-        .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
-        .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
-    )
+#     Returns:
+#         A SQLAlchemy query object for GTFS feeds with datasets missing bounding boxes
+#         ordered by dataset and feed stable id.
+#     """
+#     query = (
+#         db_session.query(
+#             Gtfsfeed.stable_id,
+#             Gtfsdataset.stable_id,
+#         )
+#         .select_from(Gtfsfeed)
+#         .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
+#         .filter(Gtfsdataset.bounding_box.is_(None))
+#         .filter(
+#             ~Gtfsfeed.feedlocationgrouppoints.any()
+#         )  # Only feeds with no location group points
+#         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
+#         .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
+#     )
 
-    return query
+#     return query
 
 
 def get_feeds_with_missing_bounding_boxes_query(

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -200,6 +200,7 @@ def get_feeds_ids_with_missing_bounding_boxes_query(
             ~Gtfsfeed.feedlocationgrouppoints.any()
         )  # Only feeds with no location group points
         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
+        .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
     )
 
     return query
@@ -224,5 +225,6 @@ def get_feeds_with_missing_bounding_boxes_query(
         .filter(Gtfsdataset.bounding_box.is_(None))
         .filter(~Gtfsfeed.feedlocationgrouppoints.any())
         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
+        .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
     )
     return query

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -196,6 +196,9 @@ def get_feeds_with_missing_bounding_boxes_query(
         .select_from(Gtfsfeed)
         .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
         .filter(Gtfsdataset.bounding_box.is_(None))
+        .filter(
+            ~Gtfsfeed.feedlocationgrouppoints.any()
+        )  # Only feeds with no location group points
         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
         .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
     )

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -173,3 +173,31 @@ def get_datasets_with_missing_reports_query(
         Gtfsdataset.stable_id, Gtfsfeed.stable_id
     )
     return query
+
+
+def get_feeds_with_missing_bounding_boxes_query(
+    db_session: Session,
+) -> Query:
+    """
+    Get GTFS feeds and datasets where the dataset is missing a bounding box.
+
+    Args:
+        db_session: SQLAlchemy session
+
+    Returns:
+        A SQLAlchemy query object for GTFS feeds with datasets missing bounding boxes
+        ordered by dataset and feed stable id.
+    """
+    query = (
+        db_session.query(
+            Gtfsfeed.stable_id,
+            Gtfsdataset.stable_id,
+        )
+        .select_from(Gtfsfeed)
+        .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
+        .filter(Gtfsdataset.bounding_box.is_(None))
+        .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
+        .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
+    )
+
+    return query

--- a/functions-python/helpers/query_helper.py
+++ b/functions-python/helpers/query_helper.py
@@ -175,11 +175,11 @@ def get_datasets_with_missing_reports_query(
     return query
 
 
-def get_feeds_with_missing_bounding_boxes_query(
+def get_feeds_ids_with_missing_bounding_boxes_query(
     db_session: Session,
 ) -> Query:
     """
-    Get GTFS feeds and datasets where the dataset is missing a bounding box.
+    Get GTFS feeds ids where the dataset is missing a bounding box.
 
     Args:
         db_session: SQLAlchemy session
@@ -200,7 +200,29 @@ def get_feeds_with_missing_bounding_boxes_query(
             ~Gtfsfeed.feedlocationgrouppoints.any()
         )  # Only feeds with no location group points
         .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
-        .order_by(Gtfsdataset.stable_id, Gtfsfeed.stable_id)
     )
 
+    return query
+
+
+def get_feeds_with_missing_bounding_boxes_query(
+    db_session: Session,
+) -> Query:
+    """
+    Get GTFS feeds with datasets missing bounding boxes.
+
+    Args:
+        db_session: SQLAlchemy session
+
+    Returns:
+        A SQLAlchemy query object for GTFS feeds with datasets missing bounding boxes
+        ordered by feed stable id.
+    """
+    query = (
+        db_session.query(Gtfsfeed)
+        .join(Gtfsdataset, Gtfsdataset.feed_id == Gtfsfeed.id)
+        .filter(Gtfsdataset.bounding_box.is_(None))
+        .filter(~Gtfsfeed.feedlocationgrouppoints.any())
+        .distinct(Gtfsfeed.stable_id, Gtfsdataset.stable_id)
+    )
     return query

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_batch.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_batch.py
@@ -72,7 +72,6 @@ def parse_request_parameters(request: flask.Request) -> Tuple[List[str], bool]:
     return country_codes, include_only_unprocessed
 
 
-# mimic reverse_geolocation_batch function, format the data for the pub/sub message, add a different topic name
 def reverse_geolocation_batch(request: flask.Request) -> Tuple[str, int]:
     """Batch function to trigger reverse geolocation for feeds."""
     try:

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_batch.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_batch.py
@@ -72,6 +72,7 @@ def parse_request_parameters(request: flask.Request) -> Tuple[List[str], bool]:
     return country_codes, include_only_unprocessed
 
 
+# mimic reverse_geolocation_batch function, format the data for the pub/sub message, add a different topic name
 def reverse_geolocation_batch(request: flask.Request) -> Tuple[str, int]:
     """Batch function to trigger reverse geolocation for feeds."""
     try:

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -3,7 +3,9 @@
 This directory contains Google Cloud Functions used as a single point of access to multiple _tasks_.
 
 ## Usage
+
 The function receive the following payload:
+
 ```
 {
    "task": "string", # [required] Name of the task to execute
@@ -12,6 +14,7 @@ The function receive the following payload:
 ```
 
 Example:
+
 ```json
 {
    "task": "rebuild_missing_validation_reports",
@@ -21,11 +24,22 @@ Example:
     "filter_statuses": ["active", "inactive", "future"]
   }
 }
+{
+   "task": "rebuild_missing_bounding_boxes",
+   "payload": {
+    "dry_run": true,
+    "after_date": "2025-06-01"
+  }
+}
 ```
+
 To get the list of supported tasks use:
 ``
 {
-  "name": "list_tasks",
-  "payload": {}
+"name": "list_tasks",
+"payload": {}
 }
-`````
+
+```
+
+```

--- a/functions-python/tasks_executor/requirements.txt
+++ b/functions-python/tasks_executor/requirements.txt
@@ -16,6 +16,7 @@ geoalchemy2==0.14.7
 
 # Google specific packages for this function
 google-cloud-workflows
+google-cloud-pubsub
 flask
 
 # Configuration

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -42,6 +42,10 @@ tasks = {
         "description": "Rebuilds missing validation reports for GTFS datasets.",
         "handler": rebuild_missing_validation_reports_handler,
     },
+    "identify_missing_bounding_boxes": {
+        "description": "Rebuilds missing bounding boxes for GTFS datasets that contain valid stops.txt files.",
+        "handler": identify_missing_bounding_boxes_handler,
+    },
 }
 
 

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -45,7 +45,7 @@ tasks = {
         "description": "Rebuilds missing validation reports for GTFS datasets.",
         "handler": rebuild_missing_validation_reports_handler,
     },
-    "identify_missing_bounding_boxes": {
+    "rebuild_missing_bounding_boxes": {
         "description": "Rebuilds missing bounding boxes for GTFS datasets that contain valid stops.txt files.",
         "handler": rebuild_missing_bounding_boxes_handler,
     },

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -22,6 +22,9 @@ from shared.helpers.logger import init_logger
 from tasks.validation_reports.rebuild_missing_validation_reports import (
     rebuild_missing_validation_reports_handler,
 )
+from tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes import (
+    rebuild_missing_bounding_boxes_handler,
+)
 
 
 init_logger()
@@ -44,7 +47,7 @@ tasks = {
     },
     "identify_missing_bounding_boxes": {
         "description": "Rebuilds missing bounding boxes for GTFS datasets that contain valid stops.txt files.",
-        "handler": identify_missing_bounding_boxes_handler,
+        "handler": rebuild_missing_bounding_boxes_handler,
     },
 }
 

--- a/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
@@ -1,9 +1,12 @@
+import logging
 import os
+from typing import Dict, List
 from sqlalchemy.orm import Session
 
 from shared.database.database import with_db_session
+from shared.helpers.pub_sub import publish_messages
 from shared.helpers.query_helper import get_feeds_with_missing_bounding_boxes_query
-from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsdataset
+from shared.database_gen.sqlacodegen_models import Gtfsfeed
 
 
 def rebuild_missing_bounding_boxes_handler(payload) -> dict:
@@ -25,6 +28,8 @@ def rebuild_missing_bounding_boxes(
     db_session: Session | None = None,
 ) -> dict:
     query = get_feeds_with_missing_bounding_boxes_query(db_session)
+    logging.info("Filtering for unprocessed feeds.")
+    query = query.filter(~Gtfsfeed.feedlocationgrouppoints.any())
     feeds = query.all()
 
     if dry_run:
@@ -34,7 +39,77 @@ def rebuild_missing_bounding_boxes(
             "total_processed": total_processed,
         }
     else:
-        
+        # publish a message to a Pub/Sub topic for each feed
+        pubsub_topic_name = os.getenv("PUBSUB_TOPIC_NAME", None)  # todo: set new name
+        project_id = os.getenv("PROJECT_ID")
+
+        logging.info("Publishing to topic: %s", pubsub_topic_name)
+        publish_messages(prepare_feeds_data(feeds), project_id, pubsub_topic_name)
+
+        total_processed = len(feeds)
+        return {
+            "message": f"Successfully published {total_processed} feeds with missing bounding boxes.",
+            "total_processed": total_processed,
+        }
+
+
+@with_db_session
+def extract_country_codes_from_feeds(
+    feeds: List[Gtfsfeed], db_session: Session = None
+) -> List[str]:
+    """
+    Extract unique country codes from a list of feeds.
+
+    Args:
+        feeds: List of Gtfsfeed objects
+        db_session: SQLAlchemy database session
+
+    Returns:
+        List of unique country codes
+    """
+    country_codes = set()
+
+    for feed in feeds:
+        # Check if locations are already loaded, if not load them
+        if not feed.locations:
+            db_session.refresh(feed, ["locations"])
+
+        # Extract country codes from the feed's locations
+        for location in feed.locations:
+            if location.country_code:
+                country_codes.add(location.country_code)
+
+    return list(country_codes)
+
+
+def prepare_feeds_data(feeds: List[Gtfsfeed]) -> List[Dict]:
+    """
+    Format feeds data for Pub/Sub messages.
+
+    Args:
+        feeds: List of Gtfsfeed objects
+
+    Returns:
+        List of dictionaries with feed data
+    """
+    data = []
+
+    for feed in feeds:
+        # Get the latest dataset
+        if feed.gtfsdatasets and any(dataset.latest for dataset in feed.gtfsdatasets):
+            latest_dataset = next(
+                dataset for dataset in feed.gtfsdatasets if dataset.latest
+            )
+
+            data.append(
+                {
+                    "stable_id": feed.stable_id,
+                    "dataset_id": latest_dataset.stable_id,
+                    "url": latest_dataset.hosted_url,
+                }
+            )
+
+    return data
 
 
 def get_parameters(payload):

--- a/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
@@ -7,6 +7,7 @@ from shared.database.database import with_db_session
 from shared.helpers.pub_sub import publish_messages
 from shared.helpers.query_helper import get_feeds_with_missing_bounding_boxes_query
 from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsdataset
+from datetime import datetime
 
 
 def rebuild_missing_bounding_boxes_handler(payload) -> dict:

--- a/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
@@ -1,0 +1,52 @@
+import os
+from sqlalchemy.orm import Session
+
+from shared.database.database import with_db_session
+from shared.helpers.query_helper import get_feeds_with_missing_bounding_boxes_query
+from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsdataset
+
+
+def rebuild_missing_bounding_boxes_handler(payload) -> dict:
+    (
+        dry_run,
+        prod_env,
+    ) = get_parameters(payload)
+
+    return rebuild_missing_bounding_boxes(
+        dry_run=dry_run,
+        prod_env=prod_env,
+    )
+
+
+@with_db_session
+def rebuild_missing_bounding_boxes(
+    dry_run: bool = True,
+    prod_env: bool = False,
+    db_session: Session | None = None,
+) -> dict:
+    query = get_feeds_with_missing_bounding_boxes_query(db_session)
+    feeds = query.all()
+
+    if dry_run:
+        total_processed = len(feeds)
+        return {
+            "message": f"Dry run: {total_processed} feeds with missing bounding boxes found.",
+            "total_processed": total_processed,
+        }
+    else:
+        
+
+
+def get_parameters(payload):
+    """
+    Get parameters from the payload and environment variables.
+
+    Args:
+        payload (dict): dictionary containing the payload data.
+    Returns:
+        dict: dict with: dry_run, prod_env parameters
+    """
+    prod_env = os.getenv("ENV", "").lower() == "prod"
+    dry_run = payload.get("dry_run", True)
+    dry_run = dry_run if isinstance(dry_run, bool) else str(dry_run).lower() == "true"
+    return dry_run, prod_env

--- a/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/src/tasks/missing_bounding_boxes/rebuild_missing_bounding_boxes.py
@@ -11,10 +11,11 @@ from datetime import datetime
 
 
 def rebuild_missing_bounding_boxes_handler(payload) -> dict:
-    (dry_run,) = get_parameters(payload)
+    (dry_run, after_date) = get_parameters(payload)
 
     return rebuild_missing_bounding_boxes(
         dry_run=dry_run,
+        after_date=after_date,
     )
 
 

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -1,35 +1,88 @@
 import unittest
+from unittest.mock import patch, MagicMock
 from datetime import datetime
 
-from tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes import get_parameters
+from tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes import (
+    get_parameters,
+    rebuild_missing_bounding_boxes,
+)
 
 
 class TestTasksExecutor(unittest.TestCase):
     def test_get_parameters(self):
-        """
-        Test the get_parameters function to ensure it correctly extracts parameters from the payload.
-        """
-        payload = {
-            "dry_run": True,
-        }
-
+        payload = {"dry_run": True}
         dry_run, after_date = get_parameters(payload)
         self.assertTrue(dry_run)
         self.assertIsNone(after_date)
 
     def test_get_parameters_with_valid_after_date(self):
-        """
-        Test get_parameters returns a valid ISO date string for after_date.
-        """
-        payload = {
-            "dry_run": False,
-            "after_date": "2024-06-01",
-        }
-
+        payload = {"dry_run": False, "after_date": "2024-06-01"}
         dry_run, after_date = get_parameters(payload)
         self.assertFalse(dry_run)
-        # Check that after_date is a valid ISO date string
+        self.assertEqual(after_date, "2024-06-01")
+        # Check ISO format
         try:
             datetime.fromisoformat(after_date)
         except ValueError:
             self.fail(f"after_date '{after_date}' is not a valid ISO date string")
+
+    def test_get_parameters_with_string_bool(self):
+        payload = {"dry_run": "false", "after_date": None}
+        dry_run, after_date = get_parameters(payload)
+        self.assertFalse(dry_run)
+        self.assertIsNone(after_date)
+
+    def test_get_parameters_missing_keys(self):
+        payload = {}
+        dry_run, after_date = get_parameters(payload)
+        self.assertTrue(dry_run)
+        self.assertIsNone(after_date)
+
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+    )
+    def test_rebuild_missing_bounding_boxes_dry_run(self, mock_query):
+        # Mock the query and its .all() method
+        mock_query.return_value.filter.return_value = mock_query.return_value
+        mock_query.return_value.all.return_value = [
+            ("feed1", "dataset1"),
+            ("feed2", "dataset2"),
+        ]
+        result = rebuild_missing_bounding_boxes(
+            dry_run=True, after_date=None, db_session=MagicMock()
+        )
+        self.assertIn("Dry run", result["message"])
+        self.assertEqual(result["total_processed"], 2)
+
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.publish_messages"
+    )
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+    )
+    def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
+        mock_query.return_value.filter.return_value = mock_query.return_value
+        mock_query.return_value.all.return_value = [("feed1", "dataset1")]
+        mock_publish.return_value = None
+        result = rebuild_missing_bounding_boxes(
+            dry_run=False, after_date=None, db_session=MagicMock()
+        )
+        self.assertIn("Successfully published", result["message"])
+        self.assertEqual(result["total_processed"], 1)
+
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+    )
+    def test_rebuild_missing_bounding_boxes_invalid_after_date(self, mock_query):
+        mock_query.return_value.filter.return_value = mock_query.return_value
+        mock_query.return_value.all.return_value = []
+        # Should log a warning and not raise
+        result = rebuild_missing_bounding_boxes(
+            dry_run=True, after_date="not-a-date", db_session=MagicMock()
+        )
+        self.assertIn("Dry run", result["message"])
+        self.assertEqual(result["total_processed"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -39,60 +39,60 @@ class TestTasksExecutor(unittest.TestCase):
         self.assertIsNone(after_date)
 
     @patch(
-    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
-)
-def test_rebuild_missing_bounding_boxes_dry_run(self, mock_query):
-    # Mock Gtfsdataset and Gtfsfeed objects
-    mock_dataset1 = MagicMock()
-    mock_dataset1.latest = True
-    mock_dataset1.stable_id = "dataset1"
-    mock_dataset1.hosted_url = "http://example.com/dataset1"
-    mock_feed1 = MagicMock()
-    mock_feed1.stable_id = "feed1"
-    mock_feed1.gtfsdatasets = [mock_dataset1]
-
-    mock_dataset2 = MagicMock()
-    mock_dataset2.latest = True
-    mock_dataset2.stable_id = "dataset2"
-    mock_dataset2.hosted_url = "http://example.com/dataset2"
-    mock_feed2 = MagicMock()
-    mock_feed2.stable_id = "feed2"
-    mock_feed2.gtfsdatasets = [mock_dataset2]
-
-    mock_query.return_value.filter.return_value = mock_query.return_value
-    mock_query.return_value.all.return_value = [mock_feed1, mock_feed2]
-
-    result = rebuild_missing_bounding_boxes(
-        dry_run=True, after_date=None, db_session=MagicMock()
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
     )
-    self.assertIn("Dry run", result["message"])
-    self.assertEqual(result["total_processed"], 2)
+    def test_rebuild_missing_bounding_boxes_dry_run(self, mock_query):
+        # Mock Gtfsdataset and Gtfsfeed objects
+        mock_dataset1 = MagicMock()
+        mock_dataset1.latest = True
+        mock_dataset1.stable_id = "dataset1"
+        mock_dataset1.hosted_url = "http://example.com/dataset1"
+        mock_feed1 = MagicMock()
+        mock_feed1.stable_id = "feed1"
+        mock_feed1.gtfsdatasets = [mock_dataset1]
 
-@patch(
-    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.publish_messages"
-)
-@patch(
-    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
-)
-def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
-    # Mock Gtfsdataset and Gtfsfeed objects
-    mock_dataset = MagicMock()
-    mock_dataset.latest = True
-    mock_dataset.stable_id = "dataset1"
-    mock_dataset.hosted_url = "http://example.com/dataset1"
-    mock_feed = MagicMock()
-    mock_feed.stable_id = "feed1"
-    mock_feed.gtfsdatasets = [mock_dataset]
+        mock_dataset2 = MagicMock()
+        mock_dataset2.latest = True
+        mock_dataset2.stable_id = "dataset2"
+        mock_dataset2.hosted_url = "http://example.com/dataset2"
+        mock_feed2 = MagicMock()
+        mock_feed2.stable_id = "feed2"
+        mock_feed2.gtfsdatasets = [mock_dataset2]
 
-    mock_query.return_value.filter.return_value = mock_query.return_value
-    mock_query.return_value.all.return_value = [mock_feed]
-    mock_publish.return_value = None
+        mock_query.return_value.filter.return_value = mock_query.return_value
+        mock_query.return_value.all.return_value = [mock_feed1, mock_feed2]
 
-    result = rebuild_missing_bounding_boxes(
-        dry_run=False, after_date=None, db_session=MagicMock()
+        result = rebuild_missing_bounding_boxes(
+            dry_run=True, after_date=None, db_session=MagicMock()
+        )
+        self.assertIn("Dry run", result["message"])
+        self.assertEqual(result["total_processed"], 2)
+
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.publish_messages"
     )
-    self.assertIn("Successfully published", result["message"])
-    self.assertEqual(result["total_processed"], 1)
+    @patch(
+        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+    )
+    def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
+        # Mock Gtfsdataset and Gtfsfeed objects
+        mock_dataset = MagicMock()
+        mock_dataset.latest = True
+        mock_dataset.stable_id = "dataset1"
+        mock_dataset.hosted_url = "http://example.com/dataset1"
+        mock_feed = MagicMock()
+        mock_feed.stable_id = "feed1"
+        mock_feed.gtfsdatasets = [mock_dataset]
+
+        mock_query.return_value.filter.return_value = mock_query.return_value
+        mock_query.return_value.all.return_value = [mock_feed]
+        mock_publish.return_value = None
+
+        result = rebuild_missing_bounding_boxes(
+            dry_run=False, after_date=None, db_session=MagicMock()
+        )
+        self.assertIn("Successfully published", result["message"])
+        self.assertEqual(result["total_processed"], 1)
 
     @patch(
         "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -1,7 +1,5 @@
 import unittest
 
-from pytest import Session
-from shared.database.database import with_db_session
 from tasks.bounding_boxes.test_rebuild_missing_bounding_boxes import (
     get_parameters,
 )

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -39,46 +39,60 @@ class TestTasksExecutor(unittest.TestCase):
         self.assertIsNone(after_date)
 
     @patch(
-        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
-    )
-    def test_rebuild_missing_bounding_boxes_dry_run(self, mock_query):
-        # Mock the query and its .all() method
-        mock_query.return_value.filter.return_value = mock_query.return_value
-        mock_query.return_value.all.return_value = [
-            ("feed1", "dataset1"),
-            ("feed2", "dataset2"),
-        ]
-        result = rebuild_missing_bounding_boxes(
-            dry_run=True, after_date=None, db_session=MagicMock()
-        )
-        self.assertIn("Dry run", result["message"])
-        self.assertEqual(result["total_processed"], 2)
+    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+)
+def test_rebuild_missing_bounding_boxes_dry_run(self, mock_query):
+    # Mock Gtfsdataset and Gtfsfeed objects
+    mock_dataset1 = MagicMock()
+    mock_dataset1.latest = True
+    mock_dataset1.stable_id = "dataset1"
+    mock_dataset1.hosted_url = "http://example.com/dataset1"
+    mock_feed1 = MagicMock()
+    mock_feed1.stable_id = "feed1"
+    mock_feed1.gtfsdatasets = [mock_dataset1]
 
-    @patch(
-        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.publish_messages"
-    )
-    @patch(
-        "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
-    )
-    def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
-        # Mock Gtfsdataset and Gtfsfeed objects
-        mock_dataset = MagicMock()
-        mock_dataset.latest = True
-        mock_dataset.stable_id = "dataset1"
-        mock_dataset.hosted_url = "http://example.com/dataset1"
-        mock_feed = MagicMock()
-        mock_feed.stable_id = "feed1"
-        mock_feed.gtfsdatasets = [mock_dataset]
+    mock_dataset2 = MagicMock()
+    mock_dataset2.latest = True
+    mock_dataset2.stable_id = "dataset2"
+    mock_dataset2.hosted_url = "http://example.com/dataset2"
+    mock_feed2 = MagicMock()
+    mock_feed2.stable_id = "feed2"
+    mock_feed2.gtfsdatasets = [mock_dataset2]
 
-        mock_query.return_value.filter.return_value = mock_query.return_value
-        mock_query.return_value.all.return_value = [mock_feed]
-        mock_publish.return_value = None
+    mock_query.return_value.filter.return_value = mock_query.return_value
+    mock_query.return_value.all.return_value = [mock_feed1, mock_feed2]
 
-        result = rebuild_missing_bounding_boxes(
-            dry_run=False, after_date=None, db_session=MagicMock()
-        )
-        self.assertIn("Successfully published", result["message"])
-        self.assertEqual(result["total_processed"], 1)
+    result = rebuild_missing_bounding_boxes(
+        dry_run=True, after_date=None, db_session=MagicMock()
+    )
+    self.assertIn("Dry run", result["message"])
+    self.assertEqual(result["total_processed"], 2)
+
+@patch(
+    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.publish_messages"
+)
+@patch(
+    "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
+)
+def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
+    # Mock Gtfsdataset and Gtfsfeed objects
+    mock_dataset = MagicMock()
+    mock_dataset.latest = True
+    mock_dataset.stable_id = "dataset1"
+    mock_dataset.hosted_url = "http://example.com/dataset1"
+    mock_feed = MagicMock()
+    mock_feed.stable_id = "feed1"
+    mock_feed.gtfsdatasets = [mock_dataset]
+
+    mock_query.return_value.filter.return_value = mock_query.return_value
+    mock_query.return_value.all.return_value = [mock_feed]
+    mock_publish.return_value = None
+
+    result = rebuild_missing_bounding_boxes(
+        dry_run=False, after_date=None, db_session=MagicMock()
+    )
+    self.assertIn("Successfully published", result["message"])
+    self.assertEqual(result["total_processed"], 1)
 
     @patch(
         "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -1,0 +1,25 @@
+import unittest
+
+from pytest import Session
+from shared.database.database import with_db_session
+from tasks.bounding_boxes.test_rebuild_missing_bounding_boxes import (
+    get_parameters,
+)
+
+
+class TestTasksExecutor(unittest.TestCase):
+    def test_get_parameters(self):
+        """
+        Test the get_parameters function to ensure it correctly extracts parameters from the payload.
+        """
+        payload = {
+            "dry_run": True,
+        }
+
+        (
+            dry_run,
+            prod_env,
+        ) = get_parameters(payload)
+
+        self.assertTrue(dry_run)
+        self.assertFalse(prod_env)

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -61,9 +61,19 @@ class TestTasksExecutor(unittest.TestCase):
         "tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes.get_feeds_with_missing_bounding_boxes_query"
     )
     def test_rebuild_missing_bounding_boxes_publish(self, mock_query, mock_publish):
+        # Mock Gtfsdataset and Gtfsfeed objects
+        mock_dataset = MagicMock()
+        mock_dataset.latest = True
+        mock_dataset.stable_id = "dataset1"
+        mock_dataset.hosted_url = "http://example.com/dataset1"
+        mock_feed = MagicMock()
+        mock_feed.stable_id = "feed1"
+        mock_feed.gtfsdatasets = [mock_dataset]
+
         mock_query.return_value.filter.return_value = mock_query.return_value
-        mock_query.return_value.all.return_value = [("feed1", "dataset1")]
+        mock_query.return_value.all.return_value = [mock_feed]
         mock_publish.return_value = None
+
         result = rebuild_missing_bounding_boxes(
             dry_run=False, after_date=None, db_session=MagicMock()
         )

--- a/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
+++ b/functions-python/tasks_executor/tests/tasks/bounding_boxes/test_rebuild_missing_bounding_boxes.py
@@ -1,8 +1,7 @@
 import unittest
+from datetime import datetime
 
-from tasks.bounding_boxes.test_rebuild_missing_bounding_boxes import (
-    get_parameters,
-)
+from tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes import get_parameters
 
 
 class TestTasksExecutor(unittest.TestCase):
@@ -14,10 +13,23 @@ class TestTasksExecutor(unittest.TestCase):
             "dry_run": True,
         }
 
-        (
-            dry_run,
-            prod_env,
-        ) = get_parameters(payload)
-
+        dry_run, after_date = get_parameters(payload)
         self.assertTrue(dry_run)
-        self.assertFalse(prod_env)
+        self.assertIsNone(after_date)
+
+    def test_get_parameters_with_valid_after_date(self):
+        """
+        Test get_parameters returns a valid ISO date string for after_date.
+        """
+        payload = {
+            "dry_run": False,
+            "after_date": "2024-06-01",
+        }
+
+        dry_run, after_date = get_parameters(payload)
+        self.assertFalse(dry_run)
+        # Check that after_date is a valid ISO date string
+        try:
+            datetime.fromisoformat(after_date)
+        except ValueError:
+            self.fail(f"after_date '{after_date}' is not a valid ISO date string")

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1246,6 +1246,18 @@ resource "google_cloudfunctions2_function" "tasks_executor" {
   }
 }
 
+# Create the Pub/Sub topic used for publishing messages about rebuilding missing bounding boxes
+resource "google_pubsub_topic" "rebuild_missing_bounding_boxes" {
+  name = "rebuild-bounding-boxes-topic"
+}
+
+# Grant the Cloud Functions service account permission to publish messages to the rebuild-bounding-boxes-topic Pub/Sub topic
+resource "google_pubsub_topic_iam_member" "rebuild_missing_bounding_boxes_publisher" {
+  topic  = google_pubsub_topic.rebuild_bounding_boxes.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.functions_service_account.email}"
+}
+
 # IAM entry for all users to invoke the function
 resource "google_cloudfunctions2_function_iam_member" "tokens_invoker" {
   project        = var.project_id

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1253,7 +1253,7 @@ resource "google_pubsub_topic" "rebuild_missing_bounding_boxes" {
 
 # Grant the Cloud Functions service account permission to publish messages to the rebuild-bounding-boxes-topic Pub/Sub topic
 resource "google_pubsub_topic_iam_member" "rebuild_missing_bounding_boxes_publisher" {
-  topic  = google_pubsub_topic.rebuild_bounding_boxes.name
+  topic  = google_pubsub_topic.rebuild_missing_bounding_boxes.name
   role   = "roles/pubsub.publisher"
   member = "serviceAccount:${google_service_account.functions_service_account.email}"
 }

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1221,6 +1221,7 @@ resource "google_cloudfunctions2_function" "tasks_executor" {
     environment_variables = {
       PROJECT_ID  = var.project_id
       ENV = var.environment
+      PUBSUB_TOPIC_NAME = "rebuild-bounding-boxes-topic"
     }
     available_memory                 = local.function_tasks_executor_config.memory
     timeout_seconds                  = local.function_tasks_executor_config.timeout


### PR DESCRIPTION
**Summary:**

add support for the rebuild_missing_bounding_boxes task, enable the detection and processing of GTFS datasets missing bounding box information.

**Expected behavior:** 

<img width="964" alt="image" src="https://github.com/user-attachments/assets/8127c413-7a85-4523-92da-3efb3b727da8" />

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
