### PR TITLE
fix: prepare validated_at to be null when validation report is not returned

### DIFF
--- a/web-app/src/app/utils/date.spec.ts
+++ b/web-app/src/app/utils/date.spec.ts
@@ -1,4 +1,56 @@
-import { getTimeLeftForTokenExpiration } from './date';
+import { getTimeLeftForTokenExpiration, displayFormattedDate } from './date';
+
+describe('displayFormattedDate', () => {
+  test('returns empty string for null', () => {
+    expect(displayFormattedDate(null as unknown as string)).toBe('');
+  });
+
+  test('returns empty string for undefined', () => {
+    expect(displayFormattedDate(undefined as unknown as string)).toBe('');
+  });
+
+  test('returns empty string for empty string', () => {
+    expect(displayFormattedDate('')).toBe('');
+  });
+
+  test('returns empty string for invalid date string', () => {
+    expect(displayFormattedDate('not-a-date')).toBe('');
+  });
+
+  test('returns formatted string for valid ISO date', () => {
+    const result = displayFormattedDate('2023-01-01T12:00:00Z');
+    // Format manually to match expected UTC time
+    expect(result).toBe(
+      new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: 'UTC',
+      }).format(new Date('2023-01-01T12:00:00Z')),
+    );
+  });
+
+  test('returns formatted string for valid date-only string', () => {
+    const result = displayFormattedDate('2023-01-01');
+    expect(result).toBe(
+      new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: 'UTC',
+      }).format(new Date('2023-01-01')),
+    );
+  });
+
+  test('returns formatted string for ISO with timezone offset', () => {
+    const result = displayFormattedDate('2023-01-01T12:00:00-05:00');
+    expect(result).toBe(
+      new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: 'UTC',
+      }).format(new Date('2023-01-01T12:00:00-05:00')),
+    );
+  });
+});
 
 describe('getTimeLeftForTokenExpiration', () => {
   const nowHours = 12;

--- a/web-app/src/app/utils/date.ts
+++ b/web-app/src/app/utils/date.ts
@@ -1,7 +1,7 @@
 import { utcToZonedTime } from 'date-fns-tz';
 import { intervalToDuration, isFuture } from 'date-fns';
 
-export const displayFormattedDate = (stringDate: string): string => {
+export const displayFormattedDate = (stringDate?: string): string => {
   if (stringDate == null) {
     return '';
   }

--- a/web-app/src/app/utils/date.ts
+++ b/web-app/src/app/utils/date.ts
@@ -2,7 +2,14 @@ import { utcToZonedTime } from 'date-fns-tz';
 import { intervalToDuration, isFuture } from 'date-fns';
 
 export const displayFormattedDate = (stringDate: string): string => {
+  if (stringDate == null) {
+    return '';
+  }
   const date = new Date(stringDate);
+  // Check if the date is valid
+  if (isNaN(date.getTime())) {
+    return '';
+  }
   return new Intl.DateTimeFormat('en-US', {
     dateStyle: 'medium',
     timeStyle: 'short',


### PR DESCRIPTION
**Summary:**

Closes #1241 

This PR allows date parameters to be null or undefined.

**Expected behavior:** 

The blank page issue is fixed for the offending feeds

**Testing tips:**

The following URL should render correctly:
- https://mobility-feeds-dev--pr-1267-yszhktsg.web.app/feeds/gbfs-voi_Antwerp
- https://qa.mobilitydatabase.org/feeds/gbfs-voi_Antwerp (This has prod data and failed with previous releases)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
