### PR TITLE
fix: prevent validation report from being crawled by search engines

### DIFF
--- a/web-app/src/app/screens/Feed/components/DataQualitySummary.tsx
+++ b/web-app/src/app/screens/Feed/components/DataQualitySummary.tsx
@@ -41,7 +41,7 @@ export default function DataQualitySummary({
                 component='a'
                 href={latestDataset?.validation_report?.url_html}
                 target='_blank'
-                rel='noopener noreferrer'
+                rel='noopener noreferrer nofollow'
                 icon={
                   latestDataset?.validation_report?.unique_error_count !==
                     undefined &&
@@ -75,7 +75,7 @@ export default function DataQualitySummary({
                 component='a'
                 href={latestDataset?.validation_report?.url_html}
                 target='_blank'
-                rel='noopener noreferrer'
+                rel='noopener noreferrer nofollow'
                 icon={
                   latestDataset?.validation_report?.unique_warning_count !==
                     undefined &&
@@ -112,7 +112,7 @@ export default function DataQualitySummary({
                 component='a'
                 href={latestDataset?.validation_report?.url_html}
                 target='_blank'
-                rel='noopener noreferrer'
+                rel='noopener noreferrer nofollow'
                 label={`${
                   latestDataset?.validation_report?.unique_info_count ?? '0'
                 } ${t('common:feedback.infoNotices')}`}

--- a/web-app/src/app/screens/Feed/components/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/components/FeedSummary.tsx
@@ -189,7 +189,7 @@ export default function FeedSummary({
                 className='inline line-start'
                 href={feed?.source_info?.producer_url}
                 target='_blank'
-                rel='noopener noreferrer'
+                rel='noopener noreferrer nofollow'
               >
                 {feed?.source_info?.producer_url}
               </Button>

--- a/web-app/src/app/screens/Feed/index.tsx
+++ b/web-app/src/app/screens/Feed/index.tsx
@@ -448,7 +448,7 @@ export default function Feed(): React.ReactElement {
           >
             {t('dataAattribution')}{' '}
             <a
-              rel='noreferrer'
+              rel='noreferrer nofollow'
               target='_blank'
               href='https://www.transit.land/terms'
             >
@@ -466,7 +466,7 @@ export default function Feed(): React.ReactElement {
             {t('dataAattribution')}
             {' the United States '}
             <a
-              rel='noreferrer'
+              rel='noreferrer nofollow'
               target='_blank'
               href='https://www.transit.dot.gov/ntd/data-product/2023-annual-database-general-transit-feed-specification-gtfs-weblinks'
             >


### PR DESCRIPTION
**Summary:**

Add properties to prevent validation report links from being crawled or indexed. search engines have a certain budget per page and it's being wasted on links that are not core

**Expected behavior:** 

validation report urls should not be indexed

**Testing tips:**

assure that everything looks normal on feed detail page

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
