### PR TITLE
Fix: problem fetching datasets with type 1 authentication.

### DIFF
--- a/functions-python/helpers/utils.py
+++ b/functions-python/helpers/utils.py
@@ -107,8 +107,11 @@ def download_and_get_hash(
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/126.0.0.0 Mobile Safari/537.36"
         }
+        # Careful, some URLs may already contain a query string
+        # (e.g. http://api.511.org/transit/datafeeds?operator_id=CE)
         if authentication_type == 1 and api_key_parameter_name and credentials:
-            url += f"?{api_key_parameter_name}={credentials}"
+            separator = "&" if "?" in url else "?"
+            url += f"{separator}{api_key_parameter_name}={credentials}"
 
         # authentication_type == 2 -> the credentials are passed in the header
         if authentication_type == 2 and api_key_parameter_name and credentials:


### PR DESCRIPTION
**Summary:**

Datasets were not downloaded for mdb-2684.
mdb-2684 has type 1 authentication, meaning the token is passed as a query in the URL.
The base URL for this feed is: `http://api.511.org/transit/datafeeds?operator_id=CE`
The code would just append `?api_key=...` to the base url, giving a resulting url with two `?`
The correction is to use the `&` separator if the URL already has a `?`.

Note this could fix other feeds with the same configuration.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
