### PR TITLE
fix: feed files are not been extracted

### DIFF
--- a/functions-python/batch_process_dataset/.coveragerc
+++ b/functions-python/batch_process_dataset/.coveragerc
@@ -5,6 +5,7 @@ omit =
     */database_gen/*
     */dataset_service/*
     */shared/*
+    */scripts/*
 
 [report]
 exclude_lines =

--- a/functions-python/batch_process_dataset/src/scripts/download_verifier.py
+++ b/functions-python/batch_process_dataset/src/scripts/download_verifier.py
@@ -1,0 +1,46 @@
+import logging
+import os
+
+from main import DatasetProcessor
+
+
+def verify_download_content(producer_url: str):
+    """
+    Verifies the download_content is able to retrieve the file
+    This is useful to simulate the download code locally and test issues related with user-agent and downloaded content.
+    Not supported authenticated feeds currently.
+    """
+    logging.info("Verifying downloaded content... (not implemented)")
+
+    logging.info(f"Producer URL: {producer_url}")
+
+    processor = DatasetProcessor(
+        producer_url=producer_url,
+        feed_id=None,
+        feed_stable_id=None,
+        execution_id=None,
+        latest_hash=None,
+        bucket_name=None,
+        authentication_type=0,
+        api_key_parameter_name=None,
+        public_hosted_datasets_url=None,
+    )
+    tempfile = processor.generate_temp_filename()
+    logging.info(f"Temp filename: {tempfile}")
+    file_hash, is_zip, extracted_files_path = processor.download_content(tempfile)
+    are_files_extracted = os.path.exists(extracted_files_path)
+    logging.info(f"File hash: {file_hash}")
+    logging.info(
+        f"File path: {extracted_files_path} "
+        f"- { 'Files extracted' if are_files_extracted else 'Files not extracted'}"
+    )
+    logging.info(f"Downloaded file path: {extracted_files_path}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    # Replace with actual producer URL
+    verify_download_content(
+        producer_url="https://files.mobilitydatabase.org"
+        "/mdb-1891/mdb-1891-202507020119/mdb-1891-202507020119.zip"
+    )

--- a/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
+++ b/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
@@ -56,7 +56,7 @@ class TestDatasetProcessor(unittest.TestCase):
         mock_blob.public_url = public_url
         mock_blob.path = public_url
         upload_file_to_storage.return_value = mock_blob, []
-        mock_download_url_content.return_value = file_hash, True
+        mock_download_url_content.return_value = file_hash, True, "path/file"
 
         processor = DatasetProcessor(
             public_url,
@@ -94,7 +94,7 @@ class TestDatasetProcessor(unittest.TestCase):
         mock_blob = MagicMock()
         mock_blob.public_url = public_url
         upload_file_to_storage.return_value = mock_blob
-        mock_download_url_content.return_value = file_hash, True
+        mock_download_url_content.return_value = file_hash, True, "path/file"
 
         processor = DatasetProcessor(
             public_url,
@@ -126,7 +126,7 @@ class TestDatasetProcessor(unittest.TestCase):
         mock_blob = MagicMock()
         mock_blob.public_url = public_url
         upload_file_to_storage.return_value = mock_blob
-        mock_download_url_content.return_value = file_hash, False
+        mock_download_url_content.return_value = file_hash, False, "path/file"
 
         processor = DatasetProcessor(
             public_url,
@@ -178,6 +178,7 @@ class TestDatasetProcessor(unittest.TestCase):
     def test_upload_file_to_storage(self):
         bucket_name = "test-bucket"
         source_file_path = "path/to/source/file"
+        extracted_file_path = "path/to/source/file"
 
         mock_blob = Mock()
         mock_blob.public_url = public_url
@@ -204,7 +205,9 @@ class TestDatasetProcessor(unittest.TestCase):
                 test_hosted_public_url,
             )
             dataset_id = faker.Faker().uuid4()
-            result, _ = processor.upload_file_to_storage(source_file_path, dataset_id)
+            result, _ = processor.upload_file_to_storage(
+                source_file_path, dataset_id, extracted_file_path
+            )
             self.assertEqual(result.public_url, public_url)
             mock_client.get_bucket.assert_called_with(bucket_name)
             mock_bucket.blob.assert_called_with(


### PR DESCRIPTION
**Summary:**

The extracted file's path was built in two different places with a minor logic difference. In this PR, the folder path is created only once and passed along to the functions where needed.

**Expected behavior:** 
The extracted feeds files are copy over the GCP bucket.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
