### PR TITLE
fix: task name set to none

### DIFF
--- a/api/src/shared/common/gcp_utils.py
+++ b/api/src/shared/common/gcp_utils.py
@@ -84,8 +84,6 @@ def create_http_task_with_name(
 
     task = tasks_v2.Task(
         # If task_name is provided, it will be used; otherwise, a unique name will be generated.
-        # The task_name should be unique to avoid conflicts.
-        # If task_name is None, the Cloud Tasks service will generate a unique name.
         # This is useful for deduplication purposes.
         name=f"{parent}/tasks/{task_name}" if task_name else None,
         schedule_time=task_time,


### PR DESCRIPTION
**Summary:**

This pull request ignores the task_name completely when creating an HTTP task. The previous code create a task with ID `NONE` as shown in the screenshot.

**Expected behavior:** 

The reverse geolocation task is created after a new dataset is downloaded. The GCP infrastructure automatically generates the task ID.

### Before the fix:
<img width="907" height="297" alt="Screenshot 2025-08-14 at 5 39 33 PM" src="https://github.com/user-attachments/assets/4e52ea9b-55a2-4d2a-b10b-4452b41e2954" />

### After the fix:
<img width="1526" height="237" alt="Screenshot 2025-08-14 at 5 39 18 PM" src="https://github.com/user-attachments/assets/33c30688-0c44-4385-81f8-a14c1397fabb" />

**Testing tips:**

[For internal team]:
- Trigger the batch-datasets-dev function(make sure at least one dataset is downloaded by changing the hash)
- Wait for the dataset to be downloaded (review logs for errors and warnings)
- Review the cloud task list in the console.
- Verify that at least one task is generated with an auto-generated ID

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
