### PR TITLE
hide route map info behind feature flag

### DIFF
--- a/web-app/src/app/screens/Feed/components/FeedSummary.tsx
+++ b/web-app/src/app/screens/Feed/components/FeedSummary.tsx
@@ -46,6 +46,7 @@ import FeedAuthenticationSummaryInfo from './FeedAuthenticationSummaryInfo';
 import CommuteIcon from '@mui/icons-material/Commute';
 import { Link as RouterLink } from 'react-router-dom';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import { useRemoteConfig } from '../../../context/RemoteConfigProvider';
 
 export interface FeedSummaryProps {
   feed: GTFSFeedType | GTFSRTFeedType | undefined;
@@ -67,7 +68,7 @@ export default function FeedSummary({
   const providersToDisplay = showAllProviders
     ? sortedProviders
     : sortedProviders.slice(0, 4);
-
+  const { config } = useRemoteConfig();
   return (
     <ContentBox
       width={width}
@@ -142,7 +143,7 @@ export default function FeedSummary({
           )}
         </Box>
       </Box>
-      {feed?.data_type === 'gtfs' && (
+      {feed?.data_type === 'gtfs' && config.enableGtfsVisualizationMap && (
         <Box sx={boxElementStyle}>
           <StyledTitleContainer>
             {/* TODO: get back to this */}
@@ -166,7 +167,7 @@ export default function FeedSummary({
           </Typography>
         </Box>
       )}
-      {feed?.data_type === 'gtfs' && (
+      {feed?.data_type === 'gtfs' && config.enableGtfsVisualizationMap && (
         <Box sx={boxElementStyle}>
           <StyledTitleContainer>
             {/* TODO: get back to this */}


### PR DESCRIPTION
**Summary:**

This PR hides the route information in the feed summary page behind the  _enableGtfsVisualizationMap_ feature flag

**Expected behavior:** 

The route information is only shown with feature flag enabled.

**Testing tips:**

- Go to the link created in this PR
- Without logging in, go to the feed summary and verify that the routes' information is not shown on the screen
- After logging in, go to the feed summary and verify that the routes' information is shown on the screen.

Feed summary without logging in:
<img width="1500" height="729" alt="Screenshot 2025-08-26 at 1 33 23 PM" src="https://github.com/user-attachments/assets/a4ca1478-169f-41a6-8f6a-da9b34962942" />

Feed summary after logging in:
<img width="1606" height="697" alt="Screenshot 2025-08-26 at 1 34 17 PM" src="https://github.com/user-attachments/assets/6a927f55-b407-45ff-8517-722146e602f9" />

Please make sure these boxes are checked before submitting your pull request - thanks!


- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
