### PR TITLE
feat: update feed geolocation information

### DIFF
--- a/api/src/shared/common/gcp_utils.py
+++ b/api/src/shared/common/gcp_utils.py
@@ -1,8 +1,6 @@
 import json
 import logging
 import os
-from google.cloud import tasks_v2
-from google.protobuf.timestamp_pb2 import Timestamp
 
 REFRESH_VIEW_TASK_EXECUTOR_BODY = json.dumps(
     {"task": "refresh_materialized_view", "payload": {"dry_run": False}}
@@ -10,6 +8,8 @@ REFRESH_VIEW_TASK_EXECUTOR_BODY = json.dumps(
 
 
 def create_refresh_materialized_view_task():
+    from google.cloud import tasks_v2
+
     """
     Asynchronously refresh a materialized view.
     Ensures deduplication by generating a unique task name.
@@ -70,18 +70,19 @@ def create_refresh_materialized_view_task():
 
 
 def create_http_task_with_name(
-    client: "tasks_v2.CloudTasksClient",
+    client: any,  # tasks_v2.CloudTasksClient
     body: bytes,
     url: str,
     project_id: str,
     gcp_region: str,
     queue_name: str,
     task_name: str,
-    task_time: Timestamp,
-    http_method: "tasks_v2.HttpMethod",
+    task_time,
+    http_method: any,  # tasks_v2.HttpMethod
     timeout_s: int = 1800,  # 30 minutes
 ):
     """Creates a GCP Cloud Task."""
+    from google.cloud import tasks_v2
     from google.protobuf import duration_pb2
 
     token = tasks_v2.OidcToken(service_account_email=os.getenv("SERVICE_ACCOUNT_EMAIL"))

--- a/api/src/shared/database/database.py
+++ b/api/src/shared/database/database.py
@@ -5,7 +5,7 @@ import threading
 import uuid
 from typing import Type, Callable
 from dotenv import load_dotenv
-from sqlalchemy import create_engine, text, event
+from sqlalchemy import create_engine, text, event, func, select
 from sqlalchemy.orm import load_only, Query, class_mapper, Session, mapper
 from shared.database_gen.sqlacodegen_models import (
     Base,
@@ -31,6 +31,11 @@ def generate_unique_id() -> str:
     :return: the ID
     """
     return str(uuid.uuid4())
+
+
+def get_db_timestamp(db_session: Session) -> func.current_timestamp():
+    """Get the current time from the database."""
+    return db_session.execute(select(func.current_timestamp())).scalar()
 
 
 def configure_polymorphic_mappers():

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
@@ -377,7 +377,6 @@ def reverse_geolocation_process(
         create_geojson_aggregate(
             list(location_groups.values()),
             total_stops=total_stops,
-            stable_id=stable_id,
             bounding_box=bounding_box,
             data_type=data_type,
             extraction_urls=extraction_urls,

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
@@ -344,6 +344,7 @@ def reverse_geolocation_process(
 
     try:
         # Update the bounding box of the dataset
+        gtfs_dataset: Gtfsdataset = None
         if dataset_id:
             gtfs_dataset = load_dataset(dataset_id, db_session)
         feed = load_feed(stable_id, data_type, logger, db_session)

--- a/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
@@ -26,7 +26,7 @@ from location_group_utils import (
 )
 from parse_request import parse_request_parameters
 from shared.common.gcp_utils import create_refresh_materialized_view_task
-from shared.database.database import with_db_session
+from shared.database.database import with_db_session, get_db_timestamp
 from shared.database_gen.sqlacodegen_models import (
     Feed,
     Feedlocationgrouppoint,
@@ -134,15 +134,18 @@ def clean_stop_cache(db_session, feed, geometries_to_delete, logger):
     db_session.commit()
 
 
+@with_db_session
 def create_geojson_aggregate(
     location_groups: List[GeopolygonAggregate],
     total_stops: int,
-    stable_id: str,
     bounding_box: shapely.Polygon,
     data_type: str,
     logger,
+    feed: Feed,
+    gtfs_dataset: Gtfsdataset = None,
     extraction_urls: List[str] = None,
     public: bool = True,
+    db_session: Session = None,
 ) -> None:
     """Create a GeoJSON file with the aggregated locations. This file will be uploaded to GCS and used for
     visualization."""
@@ -197,10 +200,13 @@ def create_geojson_aggregate(
     else:
         raise ValueError("The data type must be either 'gtfs' or 'gbfs'.")
     bucket = storage_client.bucket(bucket_name)
-    blob = bucket.blob(f"{stable_id}/geolocation.geojson")
+    blob = bucket.blob(f"{feed.stable_id}/geolocation.geojson")
     blob.upload_from_string(json.dumps(json_data))
     if public:
         blob.make_public()
+    feed.geolocation_file_created_date = get_db_timestamp(db_session)
+    if gtfs_dataset:
+        feed.geolocation_file_dataset = gtfs_dataset
     logger.info("GeoJSON data saved to %s", blob.name)
 
 
@@ -210,10 +216,9 @@ def get_storage_client():
     return storage.Client()
 
 
-@with_db_session
 @track_metrics(metrics=("time", "memory", "cpu"))
 def update_dataset_bounding_box(
-    dataset_id: str, stops_df: pd.DataFrame, db_session: Session
+    gtfs_dataset: Gtfsdataset, stops_df: pd.DataFrame, db_session: Session
 ) -> shapely.Polygon:
     """
     Update the bounding box of the dataset using the stops DataFrame.
@@ -231,19 +236,12 @@ def update_dataset_bounding_box(
         f")",
         srid=4326,
     )
-    if not dataset_id:
-        return to_shape(bounding_box)
-    gtfs_dataset = (
-        db_session.query(Gtfsdataset)
-        .filter(Gtfsdataset.stable_id == dataset_id)
-        .one_or_none()
-    )
     if not gtfs_dataset:
-        raise ValueError(f"Dataset {dataset_id} does not exist in the database.")
+        return to_shape(bounding_box)
     gtfs_feed = db_session.get(Gtfsfeed, gtfs_dataset.feed_id)
     if not gtfs_feed:
         raise ValueError(
-            f"GTFS feed for dataset {dataset_id} does not exist in the database."
+            f"GTFS feed for dataset {gtfs_dataset.stable_id} does not exist in the database."
         )
     gtfs_feed.bounding_box = bounding_box
     gtfs_feed.bounding_box_dataset = gtfs_dataset
@@ -252,8 +250,22 @@ def update_dataset_bounding_box(
     return to_shape(bounding_box)
 
 
+def load_dataset(dataset_id: str, db_session: Session) -> Gtfsdataset:
+    gtfs_dataset = (
+        db_session.query(Gtfsdataset)
+        .filter(Gtfsdataset.stable_id == dataset_id)
+        .one_or_none()
+    )
+    if not gtfs_dataset:
+        raise ValueError(
+            f"Dataset with ID {dataset_id} does not exist in the database."
+        )
+    return gtfs_dataset
+
+
+@with_db_session()
 def reverse_geolocation_process(
-    request: flask.Request,
+    request: flask.Request, db_session: Session = None
 ) -> Tuple[str, int] | Tuple[Dict, int]:
     """
     Main function to handle reverse geolocation processing.
@@ -331,7 +343,27 @@ def reverse_geolocation_process(
 
     try:
         # Update the bounding box of the dataset
-        bounding_box = update_dataset_bounding_box(dataset_id, stops_df)
+        if dataset_id:
+            gtfs_dataset = load_dataset(dataset_id, db_session)
+            feed = gtfs_dataset.feed
+        if not feed:
+            feed = (
+                db_session.query(Feed).filter(Feed.stable_id == stable_id).one_or_none()
+            )
+            if not feed:
+                no_feed_message = f"No feed found for stable ID {stable_id}."
+                logger.warning(no_feed_message)
+                record_execution_trace(
+                    execution_id=execution_id,
+                    stable_id=stable_id,
+                    status=Status.FAILED,
+                    logger=logger,
+                    dataset_file=None,
+                    error_message=no_feed_message,
+                )
+                return no_feed_message, ERROR_STATUS_CODE
+
+        bounding_box = update_dataset_bounding_box(gtfs_dataset, stops_df, db_session)
 
         location_groups = reverse_geolocation(
             strategy=strategy,
@@ -339,6 +371,7 @@ def reverse_geolocation_process(
             stops_df=stops_df,
             logger=logger,
             use_cache=use_cache,
+            db_session=db_session,
         )
 
         if not location_groups:
@@ -364,8 +397,14 @@ def reverse_geolocation_process(
             extraction_urls=extraction_urls,
             logger=logger,
             public=public,
+            feed=feed,
+            gtfs_dataset=gtfs_dataset,
+            db_session=db_session,
         )
 
+        # Commit the changes to the database
+        db_session.commit()
+        create_refresh_materialized_view_task()
         logger.info(
             "COMPLETED. Processed %s stops for stable ID %s with strategy. "
             "Retrieved %s locations.",
@@ -453,7 +492,6 @@ def reverse_geolocation(
         logger=logger,
         db_session=db_session,
     )
-    create_refresh_materialized_view_task()
     return cache_location_groups
 
 
@@ -508,5 +546,3 @@ def update_feed_location(
                 gtfs_rt_feed.locations = feed_locations
     if feed_locations:
         feed.locations = feed_locations
-    # Commit the changes to the database
-    db_session.commit()

--- a/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
@@ -287,12 +287,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             else None
         )
 
-        # mock_getenv.side_effect = (
-        #     lambda var_name, default=None: "test_bucket"
-        #     if var_name in ["DATASETS_BUCKET_NAME_GTFS", "DATASETS_BUCKET_NAME_GBFS"]
-        #     else default
-        # )
-
         # Mock the storage client and blob
         mock_bucket = MagicMock()
         mock_blob = MagicMock()
@@ -333,16 +327,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
                 )
             ],
         )
-
-        # location_groups: List[GeopolygonAggregate],
-        # total_stops: int,
-        # bounding_box: shapely.Polygon,
-        # data_type: str,
-        # logger,
-        # feed: Feed,
-        # gtfs_dataset: Gtfsdataset = None,
-        # extraction_urls: List[str] = None,
-        # public: bool = True,
         # Call the function
         create_geojson_aggregate(
             location_groups=[aggregate],

--- a/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
@@ -451,10 +451,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     @patch("reverse_geolocation_processor.check_maximum_executions")
     @patch("reverse_geolocation_processor.get_execution_id")
     @patch("reverse_geolocation_processor.load_dataset")
+    @patch("reverse_geolocation_processor.load_feed")
     @patch("reverse_geolocation_processor.record_execution_trace")
     def test_valid_request(
         self,
         _,
+        mock_load_feed,
         mock_load_dataset,
         mock_get_execution_id,
         mock_check_maximum_executions,
@@ -482,9 +484,10 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         mock_update_bounding_box.return_value = MagicMock()
         mock_reverse_geolocation.return_value = {"group_id": MagicMock()}
         mock_create_geojson_aggregate.return_value = MagicMock()
+        mock_load_feed.return_value = MagicMock()
+        mock_load_dataset.return_value = MagicMock()
         # Mocking a Flask request
         request = MagicMock(spec=Request)
-
         # Call the function
         response, status_code = reverse_geolocation_process(request)
 
@@ -520,10 +523,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     @patch("reverse_geolocation_processor.check_maximum_executions")
     @patch("reverse_geolocation_processor.get_execution_id")
     @patch("reverse_geolocation_processor.load_dataset")
+    @patch("reverse_geolocation_processor.load_feed")
     @patch("reverse_geolocation_processor.record_execution_trace")
     def test_exception_handling(
         self,
         _,
+        mock_load_feed,
         mock_load_dataset,
         mock_check_get_execution_id,
         mock_check_maximum_executions,
@@ -549,6 +554,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             1,
         )
         mock_load_dataset.return_value = MagicMock()
+        mock_load_feed.return_value = MagicMock()
         mock_update_bounding_box.side_effect = Exception("Unexpected error")
 
         # Mocking a Flask request
@@ -632,6 +638,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             stable_id="test_stable_id",
             stops_df=pd.DataFrame({"stop_lat": [1.0], "stop_lon": [1.0]}),
             logger=MagicMock(),
+            data_type="gtfs",
             use_cache=True,
             db_session=MagicMock(spec=Session),
         )
@@ -670,6 +677,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             strategy=ReverseGeocodingStrategy.PER_POLYGON,
             stable_id="test_stable_id",
             stops_df=pd.DataFrame({"stop_lat": [1.0], "stop_lon": [1.0]}),
+            data_type="gtfs",
             logger=MagicMock(),
             use_cache=True,
             db_session=MagicMock(spec=Session),
@@ -689,7 +697,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         from reverse_geolocation_processor import reverse_geolocation
 
         id = str(uuid.uuid4())
-        feed = Feed(
+        feed = Gtfsfeed(
             id=id,
             stable_id=f"test_feed{id}",
             status="active",
@@ -705,6 +713,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             stable_id=f"test_feed{id}",
             stops_df=pd.DataFrame({"stop_lat": [1.0], "stop_lon": [1.0]}),
             logger=MagicMock(),
+            data_type=feed.data_type,
             use_cache=True,
             db_session=db_session,
         )
@@ -724,6 +733,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
                 strategy=ReverseGeocodingStrategy.PER_POINT,
                 stable_id="missing_stable_id",
                 stops_df=pd.DataFrame({"stop_lat": [1.0], "stop_lon": [1.0]}),
+                data_type="gtfs",
                 logger=MagicMock(),
                 use_cache=True,
                 db_session=db_session,

--- a/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/tests/test_reverse_geolocation_processor.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import unittest
+import uuid
 from unittest.mock import patch, MagicMock
 
 import pandas as pd
@@ -16,6 +17,7 @@ from shared.database_gen.sqlacodegen_models import (
     Geopolygon,
     Gtfsdataset,
     Gtfsrealtimefeed,
+    Feed,
 )
 from shared.database_gen.sqlacodegen_models import (
     Gtfsfeed,
@@ -25,7 +27,6 @@ from shared.database_gen.sqlacodegen_models import (
 from shared.helpers.locations import ReverseGeocodingStrategy
 from test_shared.test_utils.database_utils import (
     default_db_url,
-    clean_testing_db,
 )
 
 faker = Faker()
@@ -210,7 +211,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
                 "stop_lon": [1.0, 2.0],
             }
         )
-        clean_testing_db()
         stable_id = faker.uuid4(cast_to=str)
         feed_id = faker.uuid4(cast_to=str)
         feed = Gtfsfeed(
@@ -237,7 +237,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
                 "stop_lon": [1, 2],
             }
         )
-        clean_testing_db()
         stable_id = faker.uuid4(cast_to=str)
         feed_id = faker.uuid4(cast_to=str)
         country_name = faker.country()
@@ -273,9 +272,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         self.assertEqual(len(location_groups), 1)
         self.assertEqual(results_df.shape, (1, 6))  # Added geometry columns
 
+    @with_db_session(db_url=default_db_url)
     @patch("reverse_geolocation_processor.get_storage_client")
     @patch("os.getenv")
-    def test_create_geojson_aggregate(self, mock_getenv, mock_storage_client):
+    def test_create_geojson_aggregate(
+        self, mock_getenv, mock_storage_client, db_session
+    ):
         from reverse_geolocation_processor import create_geojson_aggregate
 
         # Mock the specific environment variable
@@ -284,6 +286,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             if var_name in ["DATASETS_BUCKET_NAME_GTFS", "DATASETS_BUCKET_NAME_GBFS"]
             else None
         )
+
+        # mock_getenv.side_effect = (
+        #     lambda var_name, default=None: "test_bucket"
+        #     if var_name in ["DATASETS_BUCKET_NAME_GTFS", "DATASETS_BUCKET_NAME_GBFS"]
+        #     else default
+        # )
 
         # Mock the storage client and blob
         mock_bucket = MagicMock()
@@ -310,15 +318,42 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         # Bounding box that fully contains the geopolygon
         bounding_box = shapely.geometry.box(-1, -1, 2, 2)
 
+        feed = Feed(
+            id=faker.uuid4(cast_to=str),
+            stable_id="test_stable_id",
+            data_type="gtfs",
+            gtfsdatasets=[
+                Gtfsdataset(
+                    id=faker.uuid4(cast_to=str),
+                    stable_id=faker.uuid4(cast_to=str),
+                    feed=Gtfsfeed(
+                        id=faker.uuid4(cast_to=str),
+                        stable_id="test_stable_id",
+                    ),
+                )
+            ],
+        )
+
+        # location_groups: List[GeopolygonAggregate],
+        # total_stops: int,
+        # bounding_box: shapely.Polygon,
+        # data_type: str,
+        # logger,
+        # feed: Feed,
+        # gtfs_dataset: Gtfsdataset = None,
+        # extraction_urls: List[str] = None,
+        # public: bool = True,
         # Call the function
         create_geojson_aggregate(
             location_groups=[aggregate],
             total_stops=20,
-            stable_id="test_stable_id",
             bounding_box=bounding_box,
             data_type="gtfs",
+            feed=feed,
+            gtfs_dataset=feed.gtfsdatasets[0],
             extraction_urls=["test_extraction_url"],
             logger=logger,
+            db_session=db_session,
         )
 
         # Assertions on blob upload
@@ -344,9 +379,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     @with_db_session(db_url=default_db_url)
     def test_update_dataset_bounding_box_success(self, db_session):
         from reverse_geolocation_processor import update_dataset_bounding_box
-
-        # Clean DB before test
-        clean_testing_db()
 
         # Create sample dataset
         feed_id = faker.uuid4(cast_to=str)
@@ -375,7 +407,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
 
         # Call the function
         bounding_box = update_dataset_bounding_box(
-            dataset_id, stops_df, db_session=db_session
+            dataset, stops_df, db_session=db_session
         )
 
         # Expected bounding box: POLYGON((30 10, 40 10, 40 20, 30 20, 30 10))
@@ -399,7 +431,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     def test_update_dataset_bounding_box_exception(self, db_session):
         from reverse_geolocation_processor import update_dataset_bounding_box
 
-        clean_testing_db()
         stops_df = pd.DataFrame(
             {
                 "stop_id": [1, 2, 3, 4],
@@ -419,10 +450,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     @patch("reverse_geolocation_processor.create_geojson_aggregate")
     @patch("reverse_geolocation_processor.check_maximum_executions")
     @patch("reverse_geolocation_processor.get_execution_id")
+    @patch("reverse_geolocation_processor.load_dataset")
     @patch("reverse_geolocation_processor.record_execution_trace")
     def test_valid_request(
         self,
         _,
+        mock_load_dataset,
         mock_get_execution_id,
         mock_check_maximum_executions,
         mock_create_geojson_aggregate,
@@ -448,7 +481,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         )
         mock_update_bounding_box.return_value = MagicMock()
         mock_reverse_geolocation.return_value = {"group_id": MagicMock()}
-
+        mock_create_geojson_aggregate.return_value = MagicMock()
         # Mocking a Flask request
         request = MagicMock(spec=Request)
 
@@ -456,7 +489,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         response, status_code = reverse_geolocation_process(request)
 
         # Assertions
-        self.assertEqual(status_code, 200)
+        self.assertEqual(200, status_code)
         self.assertIn("Processed 1 stops", response)
         mock_parse_request_parameters.assert_called_once()
         mock_update_bounding_box.assert_called_once()
@@ -486,10 +519,12 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     @patch("reverse_geolocation_processor.reverse_geolocation")
     @patch("reverse_geolocation_processor.check_maximum_executions")
     @patch("reverse_geolocation_processor.get_execution_id")
+    @patch("reverse_geolocation_processor.load_dataset")
     @patch("reverse_geolocation_processor.record_execution_trace")
     def test_exception_handling(
         self,
         _,
+        mock_load_dataset,
         mock_check_get_execution_id,
         mock_check_maximum_executions,
         mock_reverse_geolocation,
@@ -513,6 +548,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
             False,
             1,
         )
+        mock_load_dataset.return_value = MagicMock()
         mock_update_bounding_box.side_effect = Exception("Unexpected error")
 
         # Mocking a Flask request
@@ -652,10 +688,10 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     ):
         from reverse_geolocation_processor import reverse_geolocation
 
-        clean_testing_db()
-        feed = Gtfsfeed(
-            id="test_feed",
-            stable_id="test_feed",
+        id = str(uuid.uuid4())
+        feed = Feed(
+            id=id,
+            stable_id=f"test_feed{id}",
             status="active",
             gtfsdatasets=[],
             locations=[],
@@ -666,7 +702,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         # Call the function
         result = reverse_geolocation(
             strategy="invalid_strategy",
-            stable_id="test_feed",
+            stable_id=f"test_feed{id}",
             stops_df=pd.DataFrame({"stop_lat": [1.0], "stop_lon": [1.0]}),
             logger=MagicMock(),
             use_cache=True,
@@ -677,7 +713,6 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         self.assertEqual(
             ("Invalid strategy: invalid_strategy", ERROR_STATUS_CODE), result
         )
-        clean_testing_db()
 
     @with_db_session(db_url=default_db_url)
     def test_load_feed_missing_feed(self, db_session):
@@ -700,26 +735,26 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
     def test_update_feed_location_success(self, db_session):
         from reverse_geolocation_processor import update_feed_location
 
-        clean_testing_db()
+        id = str(uuid.uuid4())
         feed = Gtfsfeed(
-            id="test_feed",
+            id=id,
             data_type="gtfs",
-            stable_id="test_feed",
+            stable_id=f"test_feed{id}",
             status="active",
             gtfsdatasets=[],
             locations=[],
             gtfs_rt_feeds=[
                 Gtfsrealtimefeed(
-                    id="test_rt_feed",
+                    id=f"test_rt_feed{id}",
                 )
             ],
         )
         group = Osmlocationgroup(
-            group_id="group_1",
+            group_id=f"group_1{id}",
             group_name="group_name",
             osms=[
                 Geopolygon(
-                    osm_id=1,
+                    osm_id=faker.random_int(),
                     admin_level=2,
                     geometry=WKTElement(
                         "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", srid=4326
@@ -728,7 +763,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
                     name="Canada",
                 ),
                 Geopolygon(
-                    osm_id=2,
+                    osm_id=faker.random_int(),
                     admin_level=4,
                     geometry=WKTElement(
                         "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))", srid=4326
@@ -743,7 +778,7 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         db_session.commit()
 
         location_group = GeopolygonAggregate(group, stops_count=1)
-        cache_location_groups = {"group_1": location_group}
+        cache_location_groups = {f"group_1{id}": location_group}
 
         # Call the function
         update_feed_location(
@@ -757,4 +792,3 @@ class TestReverseGeolocationProcessor(unittest.TestCase):
         self.assertEqual("CA", feed.locations[0].country_code)
         self.assertEqual(1, len(feed.gtfs_rt_feeds[0].locations))
         self.assertEqual("CA", feed.gtfs_rt_feeds[0].locations[0].country_code)
-        clean_testing_db()

--- a/functions-python/tasks_executor/tests/tasks/geojson/test_update_geojson_files_precision.py
+++ b/functions-python/tasks_executor/tests/tasks/geojson/test_update_geojson_files_precision.py
@@ -282,7 +282,6 @@ class TestUpdateGeojsonFilesPrecision(unittest.TestCase):
             .limit(1)
             .first()
         )
-        self.assertIsNone(reloaded_testing_feed.geolocation_file_dataset_id)
         self.assertIsNotNone(reloaded_testing_feed.geolocation_file_created_date)
 
     @with_db_session(db_url=default_db_url)

--- a/functions-python/update_feed_status/tests/conftest.py
+++ b/functions-python/update_feed_status/tests/conftest.py
@@ -17,6 +17,8 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 
+import pytest
+
 from shared.database.database import with_db_session
 from shared.database_gen.sqlacodegen_models import (
     Feed,
@@ -57,7 +59,7 @@ def populate_database(db_session):
             db_session.add(
                 Feed(id=str(_id), status=status, stable_id="mdb-" + str(_id))
             )
-
+    db_session.flush()
     # -> inactive
     for _id in [
         "0",  # already inactive
@@ -87,6 +89,7 @@ def populate_database(db_session):
     db_session.commit()
 
 
-def pytest_sessionstart(session):
+@pytest.fixture(autouse=True)
+def setup():
     clean_testing_db()
     populate_database()

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, MagicMock
 
-from conftest import clean_testing_db, populate_database
 from shared.database.database import with_db_session
 from test_shared.test_utils.database_utils import default_db_url
 from main import (
@@ -64,8 +63,8 @@ def test_update_feed_status(db_session: Session) -> None:
 
 @with_db_session(db_url=default_db_url)
 def test_update_feed_status_with_ids(db_session: Session) -> None:
-    clean_testing_db()
-    populate_database()
+    # clean_testing_db()
+    # populate_database()
     feeds_before: dict[str, PartialFeed] = {f.id: f for f in fetch_feeds(db_session)}
     result = dict(update_feed_statuses_query(db_session, ["mdb-8"]))
     assert result == {

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -68,4 +68,5 @@
     <include file="changes/feat_1260.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_1333.sql" relativeToChangelogFile="true"/>
     <include file="changes/feat_pt_152.sql" relativeToChangelogFile="true"/>
+    <include file="changes/feat_fix_geolocation_circular_dep.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes/feat_fix_geolocation_circular_dep.sql
+++ b/liquibase/changes/feat_fix_geolocation_circular_dep.sql
@@ -1,0 +1,23 @@
+-- This script fix a circular dependency between the gtfsdataset and feed tables
+
+-- 1. Add the new column to gtfsfeed (if not already added)
+ALTER TABLE gtfsfeed
+  ADD COLUMN IF NOT EXISTS geolocation_file_dataset_id VARCHAR(255);
+
+-- 2. Copy existing values from feed to gtfsfeed
+--    (we assume gtfsfeed.id = feed.id, since gtfsfeed is a subtype of feed)
+UPDATE gtfsfeed gf
+SET geolocation_file_dataset_id = f.geolocation_file_dataset_id
+FROM feed f
+WHERE gf.id = f.id
+  AND f.geolocation_file_dataset_id IS NOT NULL;
+
+-- 3. Add the foreign key constraint on gtfsfeed
+ALTER TABLE gtfsfeed
+  ADD CONSTRAINT fk_gtfsfeed_geolocation_file_dataset
+  FOREIGN KEY (geolocation_file_dataset_id) REFERENCES gtfsdataset(id)
+  ON DELETE SET NULL;
+
+-- 4. Drop the old constraint and column from feed
+ALTER TABLE feed DROP CONSTRAINT IF EXISTS fk_feed_geolocation_file_dataset;
+ALTER TABLE feed DROP COLUMN IF EXISTS geolocation_file_dataset_id;


### PR DESCRIPTION
**Summary:**

In #1353 we introduced `feed. geolocation_file_created_date` and `feed. geolocation_file_dataset_id` fields to track the generation og the geolocation files per feed. All current feeds were updated with the information as part of #1353 issue. In this PR, we are updating the geolocation generation to persist those fields for the new added datasets.

**Expected behavior:** 
The feed. geolocation_file_created_date` and `feed. geolocation_file_dataset_id` fields are populated as part of the location extraction process.


**Testing tips:**
This can tested in local using the reverse_geolocation_process_verifier.py.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
