### PR TITLE
feat: add referer header to download request

### DIFF
--- a/functions-python/batch_process_dataset/src/main.py
+++ b/functions-python/batch_process_dataset/src/main.py
@@ -332,8 +332,9 @@ class DatasetProcessor:
         """
         Generates a temporary filename
         """
+        working_dir = os.getenv("WORKING_DIR", "/in-memory")
         temporary_file_path = (
-            f"/in-memory/{self.feed_stable_id}-{random.randint(0, 1000000)}.zip"
+            f"{working_dir}/{self.feed_stable_id}-{random.randint(0, 1000000)}.zip"
         )
         return temporary_file_path
 

--- a/functions-python/batch_process_dataset/src/scripts/download_verifier.py
+++ b/functions-python/batch_process_dataset/src/scripts/download_verifier.py
@@ -68,6 +68,10 @@ if __name__ == "__main__":
     # Replace with actual producer URL
     try:
         os.environ["STORAGE_EMULATOR_HOST"] = f"http://{HOST}:{PORT}"
+        os.environ["WORKING_DIR"] = "/tmp/verifier"
+        # create working dir if not exists
+        if not os.path.exists(os.environ["WORKING_DIR"]):
+            os.makedirs(os.environ["WORKING_DIR"])
         server = create_server(
             host=HOST, port=PORT, in_memory=False, default_bucket=BUCKET_NAME
         )

--- a/functions-python/helpers/tests/test_helpers.py
+++ b/functions-python/helpers/tests/test_helpers.py
@@ -104,6 +104,7 @@ class TestHelpers(unittest.TestCase):
                 preload_content=False,
                 headers={
                     "User-Agent": expected_user_agent,
+                    "Referer": url,
                     api_key_parameter_name: credentials,
                 },
                 redirect=True,
@@ -155,7 +156,7 @@ class TestHelpers(unittest.TestCase):
                 "GET",
                 modified_url,
                 preload_content=False,
-                headers={"User-Agent": expected_user_agent},
+                headers={"User-Agent": expected_user_agent, "Referer": base_url},
                 redirect=True,
             )
 

--- a/functions-python/helpers/utils.py
+++ b/functions-python/helpers/utils.py
@@ -149,7 +149,8 @@ def download_and_get_hash(
         headers = {
             "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/126.0.0.0 Mobile Safari/537.36"
+            "Chrome/126.0.0.0 Mobile Safari/537.36",
+            "Referer": url,
         }
         # Careful, some URLs may already contain a query string
         # (e.g. http://api.511.org/transit/datafeeds?operator_id=CE)


### PR DESCRIPTION
**Summary:**

Closes MobilityData/mobility-database-catalogs#917
This PR adds the referer URL to the download feed request headers.

**Expected behavior:** 

The referer URL is added to the download feed header with the producer url as a value.

**Testing tips:**

Use the download_verifier with `https://www.vre.org/gtfs/google_transit.zip`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
