### PR TITLE
feat: refactor Pmtiles build using visualization_dataset_id to check existence

### DIFF
--- a/functions-python/pmtiles_builder/src/main.py
+++ b/functions-python/pmtiles_builder/src/main.py
@@ -306,6 +306,7 @@ class PmtilesBuilder:
             self._upload_files_to_gcs(files_to_upload)
         self._update_database()
 
+        self.logger.info("Completed PMTiles build")
         return self.OperationStatus.SUCCESS, "success"
 
     def _download_files_from_gcs(self, unzipped_files_path):

--- a/functions-python/tasks_executor/tests/conftest.py
+++ b/functions-python/tasks_executor/tests/conftest.py
@@ -47,6 +47,24 @@ def populate_database(db_session: Session | None = None):
         )
         db_session.add(feed)
         feeds.append(feed)
+    wip_feed = Gtfsfeed(
+        id="feed_wip",
+        stable_id="stable_feed_wip_feed",
+        data_type="gtfs",
+        status="active",
+        created_at=now,
+        operational_status="wip",
+    )
+    with_visualization_feed = Gtfsfeed(
+        id="feed_visualization",
+        stable_id="stable_feed_visualization",
+        data_type="gtfs",
+        status="active",
+        created_at=now,
+        operational_status="wip",
+    )
+    db_session.add(wip_feed)
+    db_session.add(with_visualization_feed)
     gbfs_feed = Gbfsfeed(
         id=f"feed_{uuid.uuid4()}",
         stable_id=f"stable_feed_gbfs_{uuid.uuid4()}",
@@ -69,6 +87,25 @@ def populate_database(db_session: Session | None = None):
         )
         db_session.add(dataset)
         datasets.append(dataset)
+
+    wip_dataset = Gtfsdataset(
+        id="dataset_wip",
+        feed=wip_feed,
+        stable_id="dataset_stable_wip",
+        downloaded_at=now - timedelta(days=i),
+        bounding_box="POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))",
+    )
+    with_visualization_dataset = Gtfsdataset(
+        id="dataset_visualization",
+        feed=with_visualization_feed,
+        stable_id="dataset_stable_visualization",
+        downloaded_at=now - timedelta(days=i),
+        bounding_box="POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))",
+    )
+    db_session.add(with_visualization_dataset)
+    db_session.add(wip_dataset)
+    db_session.flush()
+    with_visualization_feed.visualization_dataset_id = with_visualization_dataset.id
 
     db_session.commit()
 

--- a/functions-python/tasks_executor/tests/tasks/validation_reports/test_rebuild_missing_validation_reports.py
+++ b/functions-python/tasks_executor/tests/tasks/validation_reports/test_rebuild_missing_validation_reports.py
@@ -108,7 +108,7 @@ class TestTasksExecutor(unittest.TestCase):
 
         # Assert the expected behavior
         self.assertIsNotNone(response)
-        self.assertEquals(response["total_processed"], 7)
+        self.assertEquals(response["total_processed"], 9)
         self.assertEquals(
             response["message"],
             "Rebuild missing validation reports task executed successfully.",
@@ -137,12 +137,12 @@ class TestTasksExecutor(unittest.TestCase):
 
         # Assert the expected behavior
         self.assertIsNotNone(response)
-        self.assertEquals(response["total_processed"], 7)
+        self.assertEquals(response["total_processed"], 9)
         self.assertEquals(
             response["message"],
             "Rebuild missing validation reports task executed successfully.",
         )
-        self.assertEquals(execute_workflows_mock.call_count, 4)
+        self.assertEquals(execute_workflows_mock.call_count, 5)
 
     @with_db_session(db_url=default_db_url)
     @patch(
@@ -166,7 +166,7 @@ class TestTasksExecutor(unittest.TestCase):
 
         # Assert the expected behavior
         self.assertIsNotNone(response)
-        self.assertEquals(response["total_processed"], 7)
+        self.assertEquals(response["total_processed"], 9)
         self.assertEquals(response["message"], "Dry run: no datasets processed.")
         execute_workflows_mock.assert_not_called()
 


### PR DESCRIPTION
**Summary:**

**From our AI friend:**
This pull request refactors the logic for rebuilding missing visualization files, with a focus on simplifying configuration, improving testability, and adding new filtering capabilities. The most significant changes include removing the dependency on the `DATASETS_BUCKET_NAME` environment variable, eliminating unused GCS bucket/file checks, and introducing support for filtering datasets by feed operational status. Related tests and fixtures have been updated to match the new logic.

**Refactoring and configuration simplification:**

* Removed all code and test logic related to the `DATASETS_BUCKET_NAME` environment variable and GCS storage client interactions (including the `bucket_name` parameter and `PMTILES_FILES` checks) from `rebuild_missing_visualization_files.py` and its tests, making the function more portable and easier to test. [[1]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL18-L21) [[2]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL35-L39) [[3]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL61-R90) [[4]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL125-L159) [[5]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL180) [[6]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL202-L204) [[7]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L17) [[8]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L33-L112) [[9]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L137-R135) [[10]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L163-L168) [[11]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L182-R172) [[12]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L203-L208)

**New features and filtering:**

* Added support for filtering datasets by a list of feed operational statuses via the new `include_feed_op_status` parameter in both the handler and core function, defaulting to `["published"]`. This allows for more granular control over which datasets are processed. [[1]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cR45-R46) [[2]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL61-R90) [[3]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cL110-R114) [[4]](diffhunk://#diff-ed67439e6856e4330247957bed2b51505ea84ff38ebdc2434b84ebdc30df6a6cR196-R204) [[5]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L33-L112) [[6]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L126-R121)

**Testing and fixtures:**

* Updated and expanded test fixtures in `conftest.py` to include feeds and datasets with different operational statuses, ensuring new filtering logic is exercised. [[1]](diffhunk://#diff-fb2d76406fcc3fd6ddf2cc25059b334766b54b4e695c06c4afeb0c120cda83b4R50-R67) [[2]](diffhunk://#diff-fb2d76406fcc3fd6ddf2cc25059b334766b54b4e695c06c4afeb0c120cda83b4R91-R109)
* Modified unit tests to remove now-irrelevant environment variable patches and bucket mocks, and to assert correct handling of the new `include_feed_op_status` parameter. [[1]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L33-L112) [[2]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L126-R121) [[3]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L137-R135) [[4]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L163-L168) [[5]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L182-R172) [[6]](diffhunk://#diff-ebcd890705b855cc48e5d52cf43151d0f6cc7e40bfe97d5d98e8c0c1c4830963L203-L208)

**Other improvements:**

* Added a completion log message to the PMTiles build process for better traceability.
* Updated validation report tests to match new dataset counts in the fixtures. [[1]](diffhunk://#diff-5d7635cfd7d273b0610103dabc9c610beb8988c1afc2306b663bc217fa1894fbL111-R111) [[2]](diffhunk://#diff-5d7635cfd7d273b0610103dabc9c610beb8988c1afc2306b663bc217fa1894fbL140-R145) [[3]](diffhunk://#diff-5d7635cfd7d273b0610103dabc9c610beb8988c1afc2306b663bc217fa1894fbL169-R169)

**Expected behavior:** 

- The task executor function rebuild_missing_visualization_files now uses the visualization_dataset_id field to check if the pmtiles are generated already
- By default the pmtiles will not be generated for feed that are not published

**Testing tips:**

_[internal team]_: tested in dev

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
