### PR TITLE
feat: last touches to maps feature

### DIFF
--- a/web-app/public/locales/en/feeds.json
+++ b/web-app/public/locales/en/feeds.json
@@ -188,12 +188,13 @@
     "bodyLarge": "We’re indexing stops across the full extent. This might take a moment.",
     "body": "We’re indexing stops across the view to speed up filtering.",
     "gridTile": "Grid: {{grid}} • Tile {{tile}} / {{total}}",
-    "percentComplete": "{{percent}}% complete"
+    "percentComplete": "{{percent}}% complete",
+    "cancel": "Cancel"
   },
   "fullMapView": {
     "disabledTitle": "Full map view disabled",
     "disabledDescription": "The full map view feature is disabled at the moment. Please try again later.",
-    "dataBlurb":"Tiles are built from the GTFS feed: we read routes.txt, trips.txt, stop_times.txt, stops.txt (and shapes.txt when present), derive routes/stops to GeoJSON, compile them with Tippecanoe into pmtiles files for map rendering.",
+    "dataBlurb":"The visualization reflects data directly from the GTFS feed. Route paths, stops, colors, and labels are all derived from the feed files (routes.txt, trips.txt, stop_times.txt, stops.txt, and shapes.txt where it's defined). If a route doesn’t specify a color, it appears in black. When multiple shapes exist for different trips on the same route, they’re combined into one for display.",
     "clearAll": "Clear All",
     "hideStops": "Hide Stops",
     "closePanel": "Close",

--- a/web-app/src/app/components/Map/MapDataPopup.tsx
+++ b/web-app/src/app/components/Map/MapDataPopup.tsx
@@ -161,24 +161,28 @@ export const MapDataPopup = (
                     </Typography>
                   )}
 
-                {mapClickStopData.stop_code != null && (
-                  <Typography variant='body2'>
-                    <span style={{ marginRight: '8px' }}>{t('stopCode')}</span>
-                    <b>{mapClickStopData.stop_code}</b>
-                  </Typography>
-                )}
-                {mapClickStopData.stop_url != null && (
-                  <Link
-                    href={mapClickStopData.stop_url}
-                    underline='hover'
-                    target='_blank'
-                    rel='noreferrer'
-                    variant={'body2'}
-                    sx={{ mt: 1 }}
-                  >
-                    {t('viewStopInfo')}
-                  </Link>
-                )}
+                {mapClickStopData.stop_code != null &&
+                  mapClickStopData.stop_code.trim().length > 0 && (
+                    <Typography variant='body2'>
+                      <span style={{ marginRight: '8px' }}>
+                        {t('stopCode')}
+                      </span>
+                      <b>{mapClickStopData.stop_code}</b>
+                    </Typography>
+                  )}
+                {mapClickStopData.stop_url != null &&
+                  mapClickStopData.stop_url.trim().length > 0 && (
+                    <Link
+                      href={mapClickStopData.stop_url}
+                      underline='hover'
+                      target='_blank'
+                      rel='noreferrer'
+                      variant={'body2'}
+                      sx={{ mt: 1 }}
+                    >
+                      {t('viewStopInfo')}
+                    </Link>
+                  )}
               </Box>
             </Box>
           </Popup>

--- a/web-app/src/app/screens/Feed/components/FullMapView.tsx
+++ b/web-app/src/app/screens/Feed/components/FullMapView.tsx
@@ -306,367 +306,369 @@ export default function FullMapView(): React.ReactElement {
   );
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        position: 'relative',
-        display: 'flex',
-        pt: 1,
-        height: 'calc(100vh - 64px - 36px)',
-        mt: { xs: -2, md: -4 },
-      }}
-    >
-      <StyledMapControlPanel
-        showMapControlMobile={showMapControlMobile}
-        id='map-controls'
-      >
-        <Box
-          width={'100%'}
-          sx={{
-            backgroundColor: theme.palette.background.paper,
-            zIndex: 1,
-            top: 0,
-            left: 0,
-            position: { xs: 'fixed', md: 'relative' },
-            p: { xs: 1, md: 0 },
-          }}
-        >
-          <Button
-            size='large'
-            startIcon={<ChevronLeft />}
-            color={'inherit'}
-            sx={{ pl: 0, display: { xs: 'none', md: 'inline-flex' } }}
-            onClick={() => {
-              if (!hasError && feedId != null) {
-                navigate(`/feeds/${feedId}`);
-              } else {
-                navigate('/');
-              }
-            }}
-          >
-            {t('common:back')}
-          </Button>
-          <Button
-            size='large'
-            color={'inherit'}
-            sx={{ pl: 0, display: { xs: 'block', md: 'none' } }}
-            onClick={() => {
-              setShowMapControlMobile(!showMapControlMobile);
-            }}
-          >
-            {t('fullMapView.closePanel')}
-          </Button>
-          <Box sx={{ display: { xs: 'block', md: 'none' } }}>
-            {renderFilterChips()}
-          </Box>
-        </Box>
-
-        <SearchHeader variant='h6' className='no-collapse'>
-          {t('fullMapView.headers.routeTypes')}
-        </SearchHeader>
-
-        {isLoading ? (
-          renderPanelSkeleton()
-        ) : (
-          <>
-            <NestedCheckboxList
-              checkboxData={getUniqueRouteTypesCheckboxData()}
-              onCheckboxChange={(checkboxData: CheckboxStructure[]) => {
-                const nextTypeIds = checkboxData
-                  .map((item) =>
-                    item.checked ? item?.props?.routeTypeId ?? '' : '',
-                  )
-                  .filter((item) => item !== '');
-
-                setFilteredRouteTypeIds(nextTypeIds);
-
-                // Keep only route IDs that match the newly selected route types.
-                // If no type is selected, allow any route (don't force-clear).
-                if (nextTypeIds.length > 0) {
-                  setFilteredRoutes((prev) =>
-                    prev.filter((rid) =>
-                      nextTypeIds.includes(getRouteType(rid) ?? ''),
-                    ),
-                  );
-                }
-              }}
-            />
-
-            <SearchHeader variant='h6' className='no-collapse'>
-              {t('fullMapView.headers.visibility')}
-            </SearchHeader>
-            <NestedCheckboxList
-              checkboxData={[
-                {
-                  title: t('fullMapView.hideStops'),
-                  checked: hideStops,
-                  type: 'checkbox',
-                },
-              ]}
-              onCheckboxChange={(checkboxData: CheckboxStructure[]) => {
-                setHideStops(checkboxData[0].checked);
-              }}
-            />
-
-            <SearchHeader variant='h6' className='no-collapse'>
-              {t('fullMapView.headers.routes')}
-            </SearchHeader>
-            <RouteSelector
-              routes={
-                routes?.filter(
-                  (r) =>
-                    filteredRouteTypeIds.length === 0 ||
-                    filteredRouteTypeIds.includes(r.routeType ?? ''),
-                ) ?? []
-              }
-              selectedRouteIds={filteredRoutes}
-              onSelectionChange={(val) => {
-                // Ensure selections remain valid under the current type filter.
-                const filteredVal = val.filter(
-                  (v) =>
-                    filteredRouteTypeIds.length === 0 ||
-                    filteredRouteTypeIds.includes(getRouteType(v) ?? ''),
-                );
-                setFilteredRoutes(filteredVal);
-              }}
-            />
-            <Alert severity='info' variant='outlined' sx={{ mt: 2 }}>
-              <Typography variant='caption'>
-                {t('fullMapView.dataBlurb')}
-              </Typography>
-            </Alert>
-            <Box
-              id='mobile-control-action'
-              sx={{
-                display: { xs: 'block', md: 'none' },
-                position: 'sticky',
-                bottom: '10px',
-              }}
-            >
-              <Button
-                variant='contained'
-                fullWidth
-                onClick={() => {
-                  setShowMapControlMobile(!showMapControlMobile);
-                }}
-              >
-                {t('fullMapView.backToMap')}
-              </Button>
-            </Box>
-          </>
-        )}
-      </StyledMapControlPanel>
-
+    <>
       <Box
         sx={{
           width: '100%',
           position: 'relative',
           display: 'flex',
-          flexDirection: 'column',
+          pt: 1,
+          height: 'calc(100vh - 64px - 36px)',
+          mt: { xs: -2, md: -4 },
         }}
       >
-        {renderFilterChips()}
-
-        <Box
-          id='map-container'
-          position={'relative'}
-          sx={{
-            mr: 2,
-            borderRadius: '6px',
-            border: `2px solid ${theme.palette.primary.main}`,
-            overflow: 'hidden',
-            flex: 1,
-            ml: { xs: 2, md: 0 },
-          }}
+        <StyledMapControlPanel
+          showMapControlMobile={showMapControlMobile}
+          id='map-controls'
         >
-          <Fab
-            size='small'
-            aria-label={t('fullMapView.aria.close')}
-            sx={{ position: 'absolute', top: 10, right: 10, zIndex: 1000 }}
-            onClick={() => {
-              if (!hasError && feedId != null) {
-                navigate(`/feeds/${feedId}`);
-              } else {
-                navigate('/');
-              }
-            }}
-          >
-            <CloseIcon />
-          </Fab>
-          <Fab
-            size='small'
-            aria-label={t('fullMapView.aria.refocus')}
+          <Box
+            width={'100%'}
             sx={{
-              position: 'absolute',
-              top: 10,
-              right: { xs: 60 + 40 + 10, md: 60 },
-              zIndex: 1000,
-            }}
-            disabled={hasError || feedId == null}
-            onClick={() => {
-              setRefocusTrigger(true);
-              setTimeout(() => {
-                setRefocusTrigger(false);
-              }, 500);
+              backgroundColor: theme.palette.background.paper,
+              zIndex: 1,
+              top: 0,
+              left: 0,
+              position: { xs: 'fixed', md: 'relative' },
+              p: { xs: 1, md: 0 },
             }}
           >
-            <CenterFocusStrong />
-          </Fab>
-
-          {/* Style FAB (opens overlay) */}
-          <Fab
-            size='small'
-            aria-label={t('fullMapView.aria.mapStyle')}
-            sx={{
-              position: 'absolute',
-              top: 10,
-              right: { xs: 60 + (40 + 10) * 2, md: 110 },
-              zIndex: 1000,
-            }}
-            onClick={() => {
-              setStylePanelOpen((v) => !v);
-            }}
-          >
-            <TuneIcon />
-          </Fab>
-
-          {/* Click-away overlay for style controls */}
-          {stylePanelOpen && (
-            <ClickAwayListener
-              onClickAway={() => {
-                setStylePanelOpen(false);
+            <Button
+              size='large'
+              startIcon={<ChevronLeft />}
+              color={'inherit'}
+              sx={{ pl: 0, display: { xs: 'none', md: 'inline-flex' } }}
+              onClick={() => {
+                if (!hasError && feedId != null) {
+                  navigate(`/feeds/${feedId}`);
+                } else {
+                  navigate('/');
+                }
               }}
             >
+              {t('common:back')}
+            </Button>
+            <Button
+              size='large'
+              color={'inherit'}
+              sx={{ pl: 0, display: { xs: 'block', md: 'none' } }}
+              onClick={() => {
+                setShowMapControlMobile(!showMapControlMobile);
+              }}
+            >
+              {t('fullMapView.closePanel')}
+            </Button>
+            <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+              {renderFilterChips()}
+            </Box>
+          </Box>
+
+          <SearchHeader variant='h6' className='no-collapse'>
+            {t('fullMapView.headers.routeTypes')}
+          </SearchHeader>
+
+          {isLoading ? (
+            renderPanelSkeleton()
+          ) : (
+            <>
+              <NestedCheckboxList
+                checkboxData={getUniqueRouteTypesCheckboxData()}
+                onCheckboxChange={(checkboxData: CheckboxStructure[]) => {
+                  const nextTypeIds = checkboxData
+                    .map((item) =>
+                      item.checked ? item?.props?.routeTypeId ?? '' : '',
+                    )
+                    .filter((item) => item !== '');
+
+                  setFilteredRouteTypeIds(nextTypeIds);
+
+                  // Keep only route IDs that match the newly selected route types.
+                  // If no type is selected, allow any route (don't force-clear).
+                  if (nextTypeIds.length > 0) {
+                    setFilteredRoutes((prev) =>
+                      prev.filter((rid) =>
+                        nextTypeIds.includes(getRouteType(rid) ?? ''),
+                      ),
+                    );
+                  }
+                }}
+              />
+
+              <SearchHeader variant='h6' className='no-collapse'>
+                {t('fullMapView.headers.visibility')}
+              </SearchHeader>
+              <NestedCheckboxList
+                checkboxData={[
+                  {
+                    title: t('fullMapView.hideStops'),
+                    checked: hideStops,
+                    type: 'checkbox',
+                  },
+                ]}
+                onCheckboxChange={(checkboxData: CheckboxStructure[]) => {
+                  setHideStops(checkboxData[0].checked);
+                }}
+              />
+
+              <SearchHeader variant='h6' className='no-collapse'>
+                {t('fullMapView.headers.routes')}
+              </SearchHeader>
+              <RouteSelector
+                routes={
+                  routes?.filter(
+                    (r) =>
+                      filteredRouteTypeIds.length === 0 ||
+                      filteredRouteTypeIds.includes(r.routeType ?? ''),
+                  ) ?? []
+                }
+                selectedRouteIds={filteredRoutes}
+                onSelectionChange={(val) => {
+                  // Ensure selections remain valid under the current type filter.
+                  const filteredVal = val.filter(
+                    (v) =>
+                      filteredRouteTypeIds.length === 0 ||
+                      filteredRouteTypeIds.includes(getRouteType(v) ?? ''),
+                  );
+                  setFilteredRoutes(filteredVal);
+                }}
+              />
               <Box
+                id='mobile-control-action'
                 sx={{
-                  position: 'absolute',
-                  top: 58,
-                  right: { xs: 10, md: 10 },
-                  zIndex: 1100,
+                  display: { xs: 'block', md: 'none' },
+                  position: 'sticky',
+                  bottom: '10px',
                 }}
               >
-                <Paper
-                  elevation={6}
-                  sx={{
-                    p: 1.5,
-                    width: 300,
-                    borderRadius: 2,
-                    border: `1px solid ${theme.palette.divider}`,
-                    backgroundColor: theme.palette.background.paper,
+                <Button
+                  variant='contained'
+                  fullWidth
+                  onClick={() => {
+                    setShowMapControlMobile(!showMapControlMobile);
                   }}
                 >
-                  <Typography
-                    variant='subtitle2'
-                    sx={{ fontWeight: 700, mb: 1 }}
-                  >
-                    {t('fullMapView.style.title')}
-                  </Typography>
-
-                  <Typography
-                    variant='caption'
-                    sx={{ color: theme.palette.text.secondary }}
-                  >
-                    {t('fullMapView.style.stopSize')}
-                  </Typography>
-
-                  <ToggleButtonGroup
-                    exclusive
-                    fullWidth
-                    size='small'
-                    value={stopPreset}
-                    onChange={(_, val) => {
-                      if (val == null) return;
-                      setStopPreset(val);
-                    }}
-                    sx={{ mt: 0.5, mb: 1 }}
-                  >
-                    <ToggleButton value='small'>
-                      {t('fullMapView.style.size.small')}
-                    </ToggleButton>
-                    <ToggleButton value='medium'>
-                      {t('fullMapView.style.size.medium')}
-                    </ToggleButton>
-                    <ToggleButton value='large'>
-                      {t('fullMapView.style.size.large')}
-                    </ToggleButton>
-                    <ToggleButton value='custom'>
-                      {t('fullMapView.style.size.custom')}
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-
-                  {stopPreset === 'custom' && (
-                    <Box sx={{ px: 0.5, pt: 0.5 }}>
-                      <Slider
-                        size='small'
-                        value={customStopRadius}
-                        min={2}
-                        max={14}
-                        step={1}
-                        marks={[
-                          { value: 2, label: '2' },
-                          { value: 8, label: '8' },
-                          { value: 14, label: '14' },
-                        ]}
-                        onChange={(_, v) => {
-                          setCustomStopRadius(v as number);
-                        }}
-                        aria-label={t('fullMapView.style.customStopRadiusAria')}
-                      />
-                      <Typography
-                        variant='caption'
-                        sx={{ color: theme.palette.text.secondary }}
-                      >
-                        {t('fullMapView.style.radius', {
-                          px: customStopRadius,
-                        })}
-                      </Typography>
-                    </Box>
-                  )}
-                </Paper>
+                  {t('fullMapView.backToMap')}
+                </Button>
               </Box>
-            </ClickAwayListener>
+            </>
           )}
+        </StyledMapControlPanel>
 
-          <Fab
+        <Box
+          sx={{
+            width: '100%',
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {renderFilterChips()}
+
+          <Box
+            id='map-container'
+            position={'relative'}
             sx={{
-              position: 'absolute',
-              top: 10,
-              right: 60,
-              zIndex: 1000,
-              display: { xs: 'inline-flex', md: 'none' },
-            }}
-            size='small'
-            aria-label={t('fullMapView.aria.filter')}
-            onClick={() => {
-              setShowMapControlMobile(!showMapControlMobile);
+              mr: 2,
+              borderRadius: '6px',
+              border: `2px solid ${theme.palette.primary.main}`,
+              overflow: 'hidden',
+              flex: 1,
+              ml: { xs: 2, md: 0 },
             }}
           >
-            <FilterAltIcon />
-          </Fab>
+            <Fab
+              size='small'
+              aria-label={t('fullMapView.aria.close')}
+              sx={{ position: 'absolute', top: 10, right: 10, zIndex: 1000 }}
+              onClick={() => {
+                if (!hasError && feedId != null) {
+                  navigate(`/feeds/${feedId}`);
+                } else {
+                  navigate('/');
+                }
+              }}
+            >
+              <CloseIcon />
+            </Fab>
+            <Fab
+              size='small'
+              aria-label={t('fullMapView.aria.refocus')}
+              sx={{
+                position: 'absolute',
+                top: 10,
+                right: { xs: 60 + 40 + 10, md: 60 },
+                zIndex: 1000,
+              }}
+              disabled={hasError || feedId == null}
+              onClick={() => {
+                setRefocusTrigger(true);
+                setTimeout(() => {
+                  setRefocusTrigger(false);
+                }, 500);
+              }}
+            >
+              <CenterFocusStrong />
+            </Fab>
 
-          {isLoading && renderMapSkeleton()}
+            {/* Style FAB (opens overlay) */}
+            <Fab
+              size='small'
+              aria-label={t('fullMapView.aria.mapStyle')}
+              sx={{
+                position: 'absolute',
+                top: 10,
+                right: { xs: 60 + (40 + 10) * 2, md: 110 },
+                zIndex: 1000,
+              }}
+              onClick={() => {
+                setStylePanelOpen((v) => !v);
+              }}
+            >
+              <TuneIcon />
+            </Fab>
 
-          {!isLoading && hasError && renderError()}
+            {/* Click-away overlay for style controls */}
+            {stylePanelOpen && (
+              <ClickAwayListener
+                onClickAway={() => {
+                  setStylePanelOpen(false);
+                }}
+              >
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: 58,
+                    right: { xs: 10, md: 10 },
+                    zIndex: 1100,
+                  }}
+                >
+                  <Paper
+                    elevation={6}
+                    sx={{
+                      p: 1.5,
+                      width: 300,
+                      borderRadius: 2,
+                      border: `1px solid ${theme.palette.divider}`,
+                      backgroundColor: theme.palette.background.paper,
+                    }}
+                  >
+                    <Typography
+                      variant='subtitle2'
+                      sx={{ fontWeight: 700, mb: 1 }}
+                    >
+                      {t('fullMapView.style.title')}
+                    </Typography>
 
-          {!isLoading &&
-            !hasError &&
-            config.enableGtfsVisualizationMap &&
-            boundingBox != null && (
-              <GtfsVisualizationMap
-                polygon={boundingBox}
-                latestDataset={latestDatasetLite}
-                filteredRouteTypeIds={filteredRouteTypeIds}
-                filteredRoutes={filteredRoutes}
-                hideStops={hideStops}
-                dataDisplayLimit={config.visualizationMapFullDataLimit}
-                routes={routes}
-                refocusTrigger={refocusTrigger}
-                stopRadius={currentStopRadius}
-                preview={false}
-              />
+                    <Typography
+                      variant='caption'
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      {t('fullMapView.style.stopSize')}
+                    </Typography>
+
+                    <ToggleButtonGroup
+                      exclusive
+                      fullWidth
+                      size='small'
+                      value={stopPreset}
+                      onChange={(_, val) => {
+                        if (val == null) return;
+                        setStopPreset(val);
+                      }}
+                      sx={{ mt: 0.5, mb: 1 }}
+                    >
+                      <ToggleButton value='small'>
+                        {t('fullMapView.style.size.small')}
+                      </ToggleButton>
+                      <ToggleButton value='medium'>
+                        {t('fullMapView.style.size.medium')}
+                      </ToggleButton>
+                      <ToggleButton value='large'>
+                        {t('fullMapView.style.size.large')}
+                      </ToggleButton>
+                      <ToggleButton value='custom'>
+                        {t('fullMapView.style.size.custom')}
+                      </ToggleButton>
+                    </ToggleButtonGroup>
+
+                    {stopPreset === 'custom' && (
+                      <Box sx={{ px: 0.5, pt: 0.5 }}>
+                        <Slider
+                          size='small'
+                          value={customStopRadius}
+                          min={2}
+                          max={14}
+                          step={1}
+                          marks={[
+                            { value: 2, label: '2' },
+                            { value: 8, label: '8' },
+                            { value: 14, label: '14' },
+                          ]}
+                          onChange={(_, v) => {
+                            setCustomStopRadius(v as number);
+                          }}
+                          aria-label={t(
+                            'fullMapView.style.customStopRadiusAria',
+                          )}
+                        />
+                        <Typography
+                          variant='caption'
+                          sx={{ color: theme.palette.text.secondary }}
+                        >
+                          {t('fullMapView.style.radius', {
+                            px: customStopRadius,
+                          })}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Paper>
+                </Box>
+              </ClickAwayListener>
             )}
+
+            <Fab
+              sx={{
+                position: 'absolute',
+                top: 10,
+                right: 60,
+                zIndex: 1000,
+                display: { xs: 'inline-flex', md: 'none' },
+              }}
+              size='small'
+              aria-label={t('fullMapView.aria.filter')}
+              onClick={() => {
+                setShowMapControlMobile(!showMapControlMobile);
+              }}
+            >
+              <FilterAltIcon />
+            </Fab>
+
+            {isLoading && renderMapSkeleton()}
+
+            {!isLoading && hasError && renderError()}
+
+            {!isLoading &&
+              !hasError &&
+              config.enableGtfsVisualizationMap &&
+              boundingBox != null && (
+                <GtfsVisualizationMap
+                  polygon={boundingBox}
+                  latestDataset={latestDatasetLite}
+                  filteredRouteTypeIds={filteredRouteTypeIds}
+                  filteredRoutes={filteredRoutes}
+                  hideStops={hideStops}
+                  dataDisplayLimit={config.visualizationMapFullDataLimit}
+                  routes={routes}
+                  refocusTrigger={refocusTrigger}
+                  stopRadius={currentStopRadius}
+                  preview={false}
+                />
+              )}
+          </Box>
         </Box>
       </Box>
-    </Box>
+      <Alert severity='info' variant='outlined' sx={{ mt: 5, mx: 2 }}>
+        <Typography variant='caption'>{t('fullMapView.dataBlurb')}</Typography>
+      </Alert>
+    </>
   );
 }


### PR DESCRIPTION
**Summary**
This PR improves the GTFS visualization map with three main changes and some polish:

1. Cancelable “scan feed” precomputation
2. Fix MapLibre color parse error found in logs
3. Fix “Rendered more hooks than during the previous render” causing issues in PROD
* Removed the conditional hook usage (`if (!preview) useEffect(...)`).
* Replaced with a top-level `useEffect` that checks conditions inside the effect body:
4. Rephrased and moved the visualization data-source description/disclaimer (how the map is built from GTFS) to the bottom of the full map view.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
