### PR TITLE
fix: rendered more hooks

### DIFF
--- a/web-app/src/app/screens/Feed/components/FullMapView.tsx
+++ b/web-app/src/app/screens/Feed/components/FullMapView.tsx
@@ -55,16 +55,6 @@ export default function FullMapView(): React.ReactElement {
   const { t } = useTranslation('feeds');
   const { config } = useRemoteConfig();
 
-  if (!config.enableGtfsVisualizationMap) {
-    return (
-      <Box>
-        <Alert severity='error' sx={{ m: 2 }}>
-          <AlertTitle>{t('fullMapView.disabledTitle')}</AlertTitle>
-          {t('fullMapView.disabledDescription')}
-        </Alert>
-      </Box>
-    );
-  }
   const { feedId } = useParams();
   const navigate = useNavigate();
 
@@ -304,6 +294,17 @@ export default function FullMapView(): React.ReactElement {
       </Stack>
     </Box>
   );
+
+  if (!config.enableGtfsVisualizationMap) {
+    return (
+      <Box>
+        <Alert severity='error' sx={{ m: 2 }}>
+          <AlertTitle>{t('fullMapView.disabledTitle')}</AlertTitle>
+          {t('fullMapView.disabledDescription')}
+        </Alert>
+      </Box>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
**Summary:**

Fixes `Rendered more hooks than during the previous render.` when opening the map without going through the feed page or refreshing the map page.
