### PR TITLE
fix: published filter on get_feed by id

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -136,8 +136,12 @@ class FeedsApiImpl(BaseFeedsApi):
     def _get_gtfs_feed(
         self, stable_id: str, db_session: Session, include_options_for_joinedload: bool = True
     ) -> Optional[Gtfsfeed]:
+        published_only = is_user_email_restricted()
         query = get_gtfs_feeds_query(
-            db_session=db_session, stable_id=stable_id, include_options_for_joinedload=include_options_for_joinedload
+            db_session=db_session,
+            stable_id=stable_id,
+            include_options_for_joinedload=include_options_for_joinedload,
+            published_only=published_only,
         )
         results = query.all()
         if len(results) == 0:


### PR DESCRIPTION
**Summary:**

This pull request introduces a change to the GTFS feed retrieval logic to respect user email restrictions when querying for feeds. Now, the query will only return published feeds if the user has restricted email access.

Access control improvements:

* Updated the `_get_gtfs_feed` method in `feeds_api_impl.py` to determine if only published feeds should be returned based on the result of `is_user_email_restricted()`, and passed this information to the `get_gtfs_feeds_query` function.

**Expected behavior:** 

Internal users can get the non-published feeds

**Testing tips:**

Test in dev using https://mobility-feeds-dev--pr-1393-ncii6pry.web.app/feeds/mdb-742


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
