### PR TITLE
Changed memory to 4GB and max instances to 50 for the feed api

### DIFF
--- a/infra/feed-api/main.tf
+++ b/infra/feed-api/main.tf
@@ -69,6 +69,10 @@ resource "google_cloud_run_v2_service" "mobility-feed-api" {
   location = var.gcp_region
   ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
+  scaling {
+    max_instance_count = 50
+  }
+
   template {
     service_account = google_service_account.containers_service_account.email
     vpc_access {
@@ -93,7 +97,7 @@ resource "google_cloud_run_v2_service" "mobility-feed-api" {
       resources {
         limits = {
           cpu    = "1"
-          memory = "2Gi"
+          memory = "4Gi"
         }
       }
     }


### PR DESCRIPTION
We manually changed the memory from 2GB to 4GB and max instances to 50 for the feed api in prod.
This PR is to make it official.

This is related to #1375. It's a stop-gap measure.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
