### PR TITLE
fix: Removed a not supported line in main.tf

### DIFF
--- a/infra/postgresql/main.tf
+++ b/infra/postgresql/main.tf
@@ -73,7 +73,6 @@ resource "google_sql_database_instance" "db" {
     backup_configuration {
       enabled    = true
       start_time = "00:00"
-      binary_log_enabled = true
       point_in_time_recovery_enabled = true
       transaction_log_retention_days = local.transaction_log_retention_days
       backup_retention_settings {


### PR DESCRIPTION
We had this error when running the db-qa.yml GH action:
  

> google_sql_database_instance.db: Modifying... [id=***]
>   ╷
>   │ Error: Error, failed to update instance settings for : googleapi: Error 400: Invalid request: Binary log can only be enabled for MySQL instances., invalid
>   │ 
>   │   with google_sql_database_instance.db,
>   │   on main.tf line 52, in resource "google_sql_database_instance" "db":
>   │   52: resource "google_sql_database_instance" "db" {
>   │ 
>   ╵
>   Error: Process completed with exit code 1.

It seems that, in terraform and GCP,  `binary_log_enabled` in the `backup_configuration` section of `google_sql_database_instance` is just not supported for Postgresql.   
See [binary_log_enabled](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#binary_log_enabled-1)

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
