### PR TITLE
fix: Corrected a bug that broke rebuild_missing_dataset_files

### DIFF
--- a/functions-python/tasks_executor/src/tasks/dataset_files/rebuild_missing_dataset_files.py
+++ b/functions-python/tasks_executor/src/tasks/dataset_files/rebuild_missing_dataset_files.py
@@ -117,7 +117,7 @@ def rebuild_missing_dataset_files(
     execution_id = f"task-executor-uuid-{uuid.uuid4()}"
     messages = []
     all_datasets_count = datasets.count()
-    topic = (os.getenv("DATASET_PROCESSING_TOPIC_NAME"),)
+    topic = os.getenv("DATASET_PROCESSING_TOPIC_NAME")
 
     for dataset in datasets.all():
         try:


### PR DESCRIPTION
This bug caused the topic name (e.g. datasets-batch-topic-qa) to be wrong in tasks-executor so the cloud function batch-process-dataset never received the message and never extracted the files.

Tested in QA with this payload:
```
{
   "task": "rebuild_missing_dataset_files",
   "payload": {
      "dataset_id": "mdb-437-202507110121",
      "dry_run": false
   }
}
```
and made sure the dataset files were extracted.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
