### PR TITLE
feat: transitfeeds redirect banner

### DIFF
--- a/web-app/src/app/components/Header.tsx
+++ b/web-app/src/app/components/Header.tsx
@@ -13,6 +13,8 @@ import {
   Select,
   useTheme,
   Link,
+  Alert,
+  AlertTitle,
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -26,7 +28,7 @@ import {
   gbfsMetricsNavItems,
 } from '../constants/Navigation';
 import type NavigationItem from '../interface/Navigation';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { selectIsAuthenticated, selectUserEmail } from '../store/selectors';
 import LogoutConfirmModal from './LogoutConfirmModal';
@@ -44,9 +46,15 @@ import ThemeToggle from './ThemeToggle';
 import { useTranslation } from 'react-i18next';
 
 export default function DrawerAppBar(): React.ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const hasTransitFeedsRedirectParam =
+    searchParams.get('utm_source') === 'transitfeeds';
   const theme = useTheme();
   const location = useLocation();
   const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [hasTransitFeedsRedirect, setHasTransitFeedsRedirect] = React.useState(
+    hasTransitFeedsRedirectParam,
+  );
   const [openDialog, setOpenDialog] = React.useState(false);
   const [activeTab, setActiveTab] = React.useState('');
   const [navigationItems, setNavigationItems] = React.useState<
@@ -118,7 +126,7 @@ export default function DrawerAppBar(): React.ReactElement {
     <Box
       sx={{
         display: 'flex',
-        height: '64px',
+        height: hasTransitFeedsRedirect ? '115px' : '64px',
         mb: { xs: 2, md: 4 },
       }}
     >
@@ -399,7 +407,32 @@ export default function DrawerAppBar(): React.ReactElement {
             )}
           </Box>
         </Toolbar>
+        {hasTransitFeedsRedirect && (
+          <Alert
+            severity='warning'
+            onClose={() => {
+              setHasTransitFeedsRedirect(false);
+              if (hasTransitFeedsRedirectParam) {
+                searchParams.delete('utm_source');
+                setSearchParams(searchParams);
+              }
+            }}
+            sx={{ '.MuiAlert-message': { pb: { xs: 0, md: 1 } } }}
+          >
+            <AlertTitle>
+              You&apos;ve been redirected from TransitFeeds
+            </AlertTitle>
+            <Box
+              component={'span'}
+              sx={{ display: { xs: 'none', md: 'block' } }}
+            >
+              This page now lives on MobilityDatabase.org, where you&apos;ll
+              find the most up-to-date transit data.
+            </Box>
+          </Alert>
+        )}
       </AppBar>
+
       <nav>
         <Drawer
           container={container}

--- a/web-app/src/app/screens/Feeds/Feeds.styles.ts
+++ b/web-app/src/app/screens/Feeds/Feeds.styles.ts
@@ -13,6 +13,7 @@ export const chipHolderStyles: SxProps<Theme> = (theme) => ({
 export const stickyHeaderStyles = (props: {
   theme: Theme;
   isSticky: boolean;
+  headerBannerVisible: boolean;
 }): SxProps => {
   const styles: SxProps = {
     display: 'flex',
@@ -20,8 +21,8 @@ export const stickyHeaderStyles = (props: {
     position: 'sticky',
     zIndex: 1,
     top: {
-      xs: '56px',
-      sm: '65px',
+      xs: props.headerBannerVisible ? '113px' : '56px',
+      md: props.headerBannerVisible ? '140px' : '65px',
     },
     background: props.theme.palette.background.default,
     transition: 'box-shadow 0.3s ease-in-out',

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -79,6 +79,9 @@ export default function Feed(): React.ReactElement {
   const feedsData = useSelector(selectFeedsData);
   const feedStatus = useSelector(selectFeedsStatus);
 
+  const hasTransitFeedsRedirectParam =
+    searchParams.get('utm_source') === 'transitfeeds';
+
   // features i/o
   const areNoDataTypesSelected =
     !selectedFeedTypes.gtfs &&
@@ -170,6 +173,9 @@ export default function Feed(): React.ReactElement {
     }
     if (isOfficialFeedSearch) {
       newSearchParams.set('official', 'true');
+    }
+    if (searchParams.get('utm_source') === 'transitfeeds') {
+      newSearchParams.set('utm_source', 'transitfeeds');
     }
     if (searchParams.toString() !== newSearchParams.toString()) {
       setSearchParams(newSearchParams, { replace: false });
@@ -318,7 +324,13 @@ export default function Feed(): React.ReactElement {
             </Typography>
           )}
         </Container>
-        <Box sx={stickyHeaderStyles({ theme, isSticky })}>
+        <Box
+          sx={stickyHeaderStyles({
+            theme,
+            isSticky,
+            headerBannerVisible: hasTransitFeedsRedirectParam,
+          })}
+        >
           <Container
             maxWidth={'xl'}
             component='form'


### PR DESCRIPTION
**Summary:**

closes #1508 

When redirecting users from Transitfeeds we will want to display a banner on the mobilitydatabase page telling the user what happened

**Expected behavior:** 

When there is a url containing `utm_source=transitfeeds` it will display a banner on the mobilitydatabase page (see screenshot). The user will be able to close the banner to hide it. Once they navigate to a different page, that query parameter is lost and the banner will disappear 

**Testing tips:**

pick a feed page / feed search page add `?utm_medium=redirect&utm_campaign=site_migration` to the end of the url
ex
`http://localhost:3000/feeds/gtfs/tfs-410?utm_medium=redirect&utm_campaign=site_migration`

this should display the banner 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)

<img width="2239" height="592" alt="Screenshot 2025-12-05 at 09 35 03" src="https://github.com/user-attachments/assets/c1f5227d-5470-4534-9723-92405d75ced4" />
<img width="1025" height="542" alt="Screenshot 2025-12-05 at 09 35 15" src="https://github.com/user-attachments/assets/48b4d418-394f-4b4f-adef-601b3232740b" />
<img width="1036" height="516" alt="Screenshot 2025-12-05 at 09 35 30" src="https://github.com/user-attachments/assets/805cbbd9-bae7-404a-8fb7-ce4478a6839d" />
<img width="560" height="479" alt="Screenshot 2025-12-05 at 09 35 44" src="https://github.com/user-attachments/assets/3d22c5e4-27ae-428b-bbaa-9de00c87a233" />
<img width="1323" height="645" alt="Screenshot 2025-12-05 at 09 36 14" src="https://github.com/user-attachments/assets/f8010c70-f19b-47d0-a34c-3faaf4fd155a" />

