### PR TITLE
Fix: updated transitfeeds source

### DIFF
--- a/web-app/src/app/screens/Feed/components/ExternalIds.tsx
+++ b/web-app/src/app/screens/Feed/components/ExternalIds.tsx
@@ -45,25 +45,40 @@ export default function ExternalIds({
               key={idx}
               sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
             >
-              <Button
-                variant='text'
-                sx={{
-                  fontWeight: 700,
-                  minWidth: 'auto',
-                  color: 'text.primary',
-                  textTransform: 'none',
-                  p: 0,
-                  px: 1.5,
-                  ml: -1.5,
-                  fontSize: 'medium',
-                }}
-                component={Link}
-                href={info.docsUrl}
-                target='_blank'
-                rel='noopener noreferrer'
-              >
-                {info?.label ?? externalId.source}
-              </Button>
+              {info.docsUrl != null ? (
+                <Button
+                  variant='text'
+                  sx={{
+                    fontWeight: 700,
+                    minWidth: 'auto',
+                    color: 'text.primary',
+                    textTransform: 'none',
+                    p: 0,
+                    px: 1.5,
+                    ml: -1.5,
+                    fontSize: 'medium',
+                  }}
+                  component={Link}
+                  href={info.docsUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {info?.label ?? externalId.source}
+                </Button>
+              ) : (
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    minWidth: 'auto',
+                    color: 'text.primary',
+                    pr: 1.5,
+                    fontSize: 'medium',
+                  }}
+                >
+                  {info?.label ?? externalId.source}
+                </Typography>
+              )}
+
               <Typography
                 variant='body1'
                 sx={{ wordBreak: 'break-all', lineHeight: 1.2 }}

--- a/web-app/src/app/utils/externalIds.spec.ts
+++ b/web-app/src/app/utils/externalIds.spec.ts
@@ -52,7 +52,7 @@ describe('filterFeedExternalIdsToSourceMap', () => {
   it('externalIdSourceMap should contain expected keys', () => {
     // ensure the map includes the keys we depend on
     expect(Object.keys(externalIdSourceMap)).toEqual(
-      expect.arrayContaining(['jbda', 'tdg', 'ntd', 'tfs', 'tld']),
+      expect.arrayContaining(['jbda', 'tdg', 'ntd', 'transitfeeds', 'tld']),
     );
   });
 });

--- a/web-app/src/app/utils/externalIds.ts
+++ b/web-app/src/app/utils/externalIds.ts
@@ -23,7 +23,7 @@ export const externalIdSourceMap: Record<
     docsUrl:
       'https://www.transit.dot.gov/ntd/data-product/2023-annual-database-general-transit-feed-specification-gtfs-weblinks',
   },
-  tfs: {
+  transitfeeds: {
     label: 'TransitFeeds',
     translationKey: 'externalIds.tooltips.tfs',
   },


### PR DESCRIPTION
**Summary:**

- Updated transit feed source id from `tfs` to `transitfeeds`
- Updated external id styling to a label (not a button) if the external id has no doc (ex: transitfeeds)

**Testing tips:**

Go on a transitfeeds feed and see the external id

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)


<img width="852" height="740" alt="Screenshot 2025-12-10 at 13 23 07" src="https://github.com/user-attachments/assets/01f86d6d-385d-4685-af5c-9968bcf1e816" />
