### PR TITLE
fix: undefined is not an object (evaluating 'r["@context"].toLowerCase')

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobility-database",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.13.0",

--- a/web-app/src/app/screens/Feed/StructuredData.functions.ts
+++ b/web-app/src/app/screens/Feed/StructuredData.functions.ts
@@ -251,8 +251,8 @@ export default function generateFeedStructuredData(
   // For gtfs rt
   relatedFeeds?: AllFeedType[],
   relatedGtfsFeeds?: GTFSFeedType[],
-): StructureDataInterface {
-  let structuredData: StructureDataInterface = {};
+): StructureDataInterface | undefined {
+  let structuredData: StructureDataInterface | undefined;
   if (feed?.data_type === 'gtfs') {
     structuredData = getGtfsStructuredData(feed as GTFSFeedType, description);
   } else if (feed?.data_type === 'gbfs') {


### PR DESCRIPTION
**Summary**
I have fixed the issue where an empty JSON-LD script tag was causing crashes in Safari.

**Expected Behaviour**
On Safari if the structuredData is empty, it should not return an unhandled error and should not create the structured data object

Reason this works

```
// Feed/index.tsx
{structuredData != undefined && (
  <script type='application/ld+json'>
    {JSON.stringify(structuredData)}
  </script>
)}
```
initially the empty object was {} and going through

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
