### PR TITLE
chore: add missing pytz dependency

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -49,3 +49,4 @@ PyJWT
 shapely
 google-cloud-pubsub
 pycountry
+pytz


### PR DESCRIPTION
**Summary:**

The pytz package is no longer available in the latest Python runtime on GitHub Actions. This PR adds the dependency.
This fixing actions like: https://github.com/MobilityData/mobility-feed-api/actions/runs/21216247449/job/61040991169

**Expected behavior:** 

GitHub actions pass without incident.

**Testing tips:**

Build must pass.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
