### PR TITLE
bug: cast to str before calling split

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -168,7 +168,7 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
                 continue
             feed = self.query_feed_by_stable_id(session, stable_id, None)
             raw_comments = row.get("redirect.comment", None)
-            comments = raw_comments.split("|") if raw_comments is not None else []
+            comments = str(raw_comments).split("|") if raw_comments is not None else []
             if len(redirects_ids) != len(comments) and len(comments) > 0:
                 self.logger.warning(f"Number of redirect ids and redirect comments differ for feed {stable_id}")
             for redirect_id in redirects_ids:


### PR DESCRIPTION
**Summary:**

Closes #1585: the workflow failure in script populate_db_gtfs.py where split is called on a non-string type.

**Expected behavior:** 

It should not throw an exception in the case redirect.comment is not a string. This is already done similarly on line 166 with redirect.id so the same is done for redirect.comment.

**Testing tips:**

Build must pass

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
