### PR TITLE
feat: filter by license id

### DIFF
--- a/web-app/src/app/screens/Feeds/AdvancedSearchTable.tsx
+++ b/web-app/src/app/screens/Feeds/AdvancedSearchTable.tsx
@@ -31,6 +31,43 @@ export interface AdvancedSearchTableProps {
   selectedGbfsVersions: string[] | undefined;
 }
 
+interface DetailsContainerProps {
+  children: React.ReactNode;
+  feedSearchItem: SearchFeedItem;
+}
+
+const DetailsContainer = ({
+  children,
+  feedSearchItem,
+}: DetailsContainerProps): React.ReactElement => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'end',
+        flexWrap: { xs: 'wrap', lg: 'nowrap' },
+      }}
+    >
+      <Box sx={{ width: 'calc(100% - 100px' }}>{children}</Box>
+      <Tooltip title={'Feed License'} placement={'top-end'}>
+        <Typography
+          variant='caption'
+          sx={{
+            opacity: 0.7,
+            ml: { xs: 0, lg: 2 },
+            minWidth: { xs: '100%', lg: '100px' },
+            textAlign: 'right',
+            pt: { xs: 1, lg: 0 },
+          }}
+        >
+          {feedSearchItem.source_info?.license_id}
+        </Typography>
+      </Tooltip>
+    </Box>
+  );
+};
+
 const renderGTFSDetails = (
   gtfsFeed: SearchFeedItem,
   selectedFeatures: string[],
@@ -39,7 +76,7 @@ const renderGTFSDetails = (
   const feedFeatures =
     gtfsFeed?.latest_dataset?.validation_report?.features ?? [];
   return (
-    <>
+    <DetailsContainer feedSearchItem={gtfsFeed}>
       {gtfsFeed?.feed_name != null && (
         <Typography
           variant='body1'
@@ -75,7 +112,7 @@ const renderGTFSDetails = (
           },
         )}
       </Box>
-    </>
+    </DetailsContainer>
   );
 };
 
@@ -83,10 +120,12 @@ const renderGTFSRTDetails = (
   gtfsRtFeed: SearchFeedItem,
 ): React.ReactElement => {
   return (
-    <GtfsRtEntities
-      entities={gtfsRtFeed?.entity_types}
-      includeName={true}
-    ></GtfsRtEntities>
+    <DetailsContainer feedSearchItem={gtfsRtFeed}>
+      <GtfsRtEntities
+        entities={gtfsRtFeed?.entity_types}
+        includeName={true}
+      ></GtfsRtEntities>
+    </DetailsContainer>
   );
 };
 
@@ -96,7 +135,7 @@ const renderGBFSDetails = (
 ): JSX.Element => {
   const theme = useTheme();
   return (
-    <Box>
+    <DetailsContainer feedSearchItem={gbfsFeedSearchElement}>
       {gbfsFeedSearchElement.versions?.map((version: string, index: number) => (
         <Chip
           label={'v' + version}
@@ -112,7 +151,7 @@ const renderGBFSDetails = (
           }}
         />
       ))}
-    </Box>
+    </DetailsContainer>
   );
 };
 

--- a/web-app/src/app/screens/Feeds/SearchFilters.tsx
+++ b/web-app/src/app/screens/Feeds/SearchFilters.tsx
@@ -25,10 +25,12 @@ interface SearchFiltersProps {
   isOfficialFeedSearch: boolean;
   selectedFeatures: string[];
   selectedGbfsVersions: string[];
+  selectedLicenses: string[];
   setSelectedFeedTypes: (selectedFeedTypes: Record<string, boolean>) => void;
   setIsOfficialFeedSearch: (isOfficialFeedSearch: boolean) => void;
   setSelectedFeatures: (selectedFeatures: string[]) => void;
   setSelectedGbfsVerions: (selectedVersions: string[]) => void;
+  setSelectedLicenses: (selectedLicenses: string[]) => void;
   isOfficialTagFilterEnabled: boolean;
   areFeatureFiltersEnabled: boolean;
   areGBFSFiltersEnabled: boolean;
@@ -39,10 +41,12 @@ export function SearchFilters({
   isOfficialFeedSearch,
   selectedFeatures,
   selectedGbfsVersions,
+  selectedLicenses,
   setSelectedFeedTypes,
   setIsOfficialFeedSearch,
   setSelectedFeatures,
   setSelectedGbfsVerions,
+  setSelectedLicenses,
   isOfficialTagFilterEnabled,
   areFeatureFiltersEnabled,
   areGBFSFiltersEnabled,
@@ -58,6 +62,7 @@ export function SearchFilters({
     features: areFeatureFiltersEnabled,
     tags: isOfficialTagFilterEnabled,
     gbfsVersions: true,
+    licenses: true,
   });
   const [featureCheckboxData, setFeatureCheckboxData] = useState<
     CheckboxStructure[]
@@ -272,6 +277,75 @@ export function SearchFilters({
                 }
               });
               setSelectedGbfsVerions([...selectedVersions]);
+            }}
+          ></NestedCheckboxList>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion
+        disableGutters
+        variant={'outlined'}
+        sx={{
+          border: 0,
+          '&::before': {
+            display: 'none',
+          },
+        }}
+        expanded={expandedCategories.licenses}
+        onChange={() => {
+          setExpandedCategories({
+            ...expandedCategories,
+            licenses: !expandedCategories.licenses,
+          });
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls='panel-licenses-content'
+          sx={{
+            px: 0,
+          }}
+        >
+          <SearchHeader variant='h6'>Licenses</SearchHeader>
+        </AccordionSummary>
+        <AccordionDetails sx={{ p: 0, m: 0, border: 0 }}>
+          <NestedCheckboxList
+            debounceTime={500}
+            checkboxData={[
+              {
+                title: 'CC-BY-4.0',
+                checked: selectedLicenses.includes('CC-BY-4.0'),
+                type: 'checkbox',
+              },
+              {
+                title: 'etalab-2.0',
+                checked: selectedLicenses.includes('etalab-2.0'),
+                type: 'checkbox',
+              },
+              {
+                title: 'CC0-1.0',
+                checked: selectedLicenses.includes('CC0-1.0'),
+                type: 'checkbox',
+              },
+              {
+                title: 'ODbL-1.0',
+                checked: selectedLicenses.includes('ODbL-1.0'),
+                type: 'checkbox',
+              },
+              {
+                title: 'OGL-UK-3.0',
+                checked: selectedLicenses.includes('OGL-UK-3.0'),
+                type: 'checkbox',
+              },
+            ]}
+            onCheckboxChange={(checkboxData) => {
+              const selectedLicenseIds: string[] = [];
+              checkboxData.forEach((checkbox) => {
+                if (checkbox.checked) {
+                  selectedLicenseIds.push(checkbox.title);
+                }
+              });
+              setSelectedLicenses([...selectedLicenseIds]);
             }}
           ></NestedCheckboxList>
         </AccordionDetails>

--- a/web-app/src/app/screens/Feeds/index.tsx
+++ b/web-app/src/app/screens/Feeds/index.tsx
@@ -66,6 +66,9 @@ export default function Feed(): React.ReactElement {
   const [selectGbfsVersions, setSelectGbfsVersions] = useState<string[]>(
     searchParams.get('gbfs_versions')?.split(',') ?? [],
   );
+  const [selectedLicenses, setSelectedLicenses] = useState<string[]>(
+    searchParams.get('licenses')?.split(',') ?? [],
+  );
   const [activePagination, setActivePagination] = useState(
     searchParams.get('o') !== null ? Number(searchParams.get('o')) : 1,
   );
@@ -127,6 +130,10 @@ export default function Feed(): React.ReactElement {
             version: areGBFSFiltersEnabled
               ? selectGbfsVersions.join(',').replaceAll('v', '')
               : undefined,
+            license_ids:
+              selectedLicenses.length > 0
+                ? selectedLicenses.join(',')
+                : undefined,
           },
         },
       }),
@@ -140,6 +147,7 @@ export default function Feed(): React.ReactElement {
     isOfficialFeedSearch,
     selectedFeatures,
     selectGbfsVersions,
+    selectedLicenses,
   ]);
 
   useEffect(() => {
@@ -166,6 +174,9 @@ export default function Feed(): React.ReactElement {
     if (selectGbfsVersions.length > 0) {
       newSearchParams.set('gbfs_versions', selectGbfsVersions.join(','));
     }
+    if (selectedLicenses.length > 0) {
+      newSearchParams.set('licenses', selectedLicenses.join(','));
+    }
     if (isOfficialFeedSearch) {
       newSearchParams.set('official', 'true');
     }
@@ -181,6 +192,7 @@ export default function Feed(): React.ReactElement {
     selectedFeedTypes,
     selectedFeatures,
     selectGbfsVersions,
+    selectedLicenses,
     isOfficialFeedSearch,
   ]);
 
@@ -206,6 +218,11 @@ export default function Feed(): React.ReactElement {
     const newGbfsVersions = searchParams.get('gbfs_versions')?.split(',') ?? [];
     if (newGbfsVersions.join(',') !== selectGbfsVersions.join(',')) {
       setSelectGbfsVersions([...newGbfsVersions]);
+    }
+
+    const newLicenses = searchParams.get('licenses')?.split(',') ?? [];
+    if (newLicenses.join(',') !== selectedLicenses.join(',')) {
+      setSelectedLicenses([...newLicenses]);
     }
 
     const newSearchOfficial = Boolean(searchParams.get('official')) ?? false;
@@ -259,6 +276,7 @@ export default function Feed(): React.ReactElement {
     });
     setSelectedFeatures([]);
     setSelectGbfsVersions([]);
+    setSelectedLicenses([]);
     setIsOfficialFeedSearch(false);
   }
 
@@ -396,6 +414,7 @@ export default function Feed(): React.ReactElement {
                 isOfficialFeedSearch={isOfficialFeedSearch}
                 selectedFeatures={selectedFeatures}
                 selectedGbfsVersions={selectGbfsVersions}
+                selectedLicenses={selectedLicenses}
                 setSelectedFeedTypes={(feedTypes) => {
                   setActivePagination(1);
                   setSelectedFeedTypes(feedTypes);
@@ -411,6 +430,10 @@ export default function Feed(): React.ReactElement {
                 setSelectedGbfsVerions={(versions) => {
                   setSelectGbfsVersions(versions);
                   setActivePagination(1);
+                }}
+                setSelectedLicenses={(licenses) => {
+                  setActivePagination(1);
+                  setSelectedLicenses(licenses);
                 }}
                 isOfficialTagFilterEnabled={isOfficialTagFilterEnabled}
                 areFeatureFiltersEnabled={areFeatureFiltersEnabled}
@@ -511,8 +534,24 @@ export default function Feed(): React.ReactElement {
                     />
                   ))}
 
+                {selectedLicenses.map((license) => (
+                  <Chip
+                    color='primary'
+                    variant='outlined'
+                    size='small'
+                    label={license}
+                    key={license}
+                    onDelete={() => {
+                      setSelectedLicenses([
+                        ...selectedLicenses.filter((sl) => sl !== license),
+                      ]);
+                    }}
+                  />
+                ))}
+
                 {(selectedFeatures.length > 0 ||
                   selectGbfsVersions.length > 0 ||
+                  selectedLicenses.length > 0 ||
                   isOfficialFeedSearch ||
                   selectedFeedTypes.gtfs_rt ||
                   selectedFeedTypes.gtfs ||


### PR DESCRIPTION
closes #1563 

**Summary:**

Ability to search feeds by the top 5 licenses

**Expected behavior:** 

When filtering by license, it should display the licenses in an OR method. It should also display a chip with the ability to clear it and have the license in the URL. It should also display the license in the search row

**Testing tips:**

Go on the feeds search page and play around with license filtering

**Design Assumption**

I filter / display the license exclusively by their ID as the real name is very long and cluttering. This is done with the assumption that people who will be interested in license data will be familiar with the abbreviations (ex: CC-BY-4.0). 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

<img width="1320" height="521" alt="Screenshot 2026-02-10 at 14 36 45" src="https://github.com/user-attachments/assets/0992aedb-b51e-48bc-a362-b96b09052581" />

<img width="1563" height="984" alt="Screenshot 2026-02-10 at 14 36 54" src="https://github.com/user-attachments/assets/83614888-0b84-413d-a2dd-f75d5a9f8146" />

