### PR TITLE
fix: bounding box not saved when reverse location fails

### DIFF
--- a/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
+++ b/functions-python/reverse_geolocation/src/reverse_geolocation_processor.py
@@ -359,7 +359,7 @@ def reverse_geolocation_process(
             stops_df=stops_df,
             db_session=db_session,
         )
-        # Commit the bounding box update to the database before proceeding with reverse geolocation processing
+        # Commit the bounding box update to the database before the reverse geolocation extraction.
         # This ensures that the bounding box is updated even if the reverse geolocation processing fails.
         db_session.commit()
 


### PR DESCRIPTION
**Summary:**

This PR adds a commit statement just after the bounding box is computed, before proceeding with reverse geolocation. This ensures that the bounding box is updated even if the reverse geolocation processing fails.

**Expected behavior:** 
The bounding box is committed, even if the reverse location fails

## From our AI friend
This pull request makes a small but important change to the `reverse_geolocation_processor.py` file. The update ensures that the bounding box changes are committed to the database before starting the reverse geolocation process, so that these updates are not lost if the subsequent processing fails.

* Added a `db_session.commit()` call after updating the bounding box and before running the reverse geolocation logic, ensuring that bounding box updates are persisted even if later steps fail.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
