### PR TITLE
feat: increase the number of task executor instances

### DIFF
--- a/functions-python/tasks_executor/function_config.json
+++ b/functions-python/tasks_executor/function_config.json
@@ -26,7 +26,7 @@
   ],
   "ingress_settings": "ALLOW_ALL",
   "max_instance_request_concurrency": 1,
-  "max_instance_count": 1,
+  "max_instance_count": 200,
   "min_instance_count": 0,
   "available_cpu": 2
 }


### PR DESCRIPTION
**Summary:**

This PR increases the number of instances that can run concurrently with the task executor function. As the task executor function is a `generic` cloud run function, there is no point in limiting how many instances can be run at a single point in time. I set it to a high number(200), to avoid over-billing in case of a code error on the caller.

**Expected behavior:** 

The number of max instances must be set to 200.

**Testing tips:**
Just check the DEV environment settings.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
