### PR TITLE
fix: set JBDA feeds to published on import

### DIFF
--- a/functions-python/tasks_executor/src/tasks/data_import/jbda/import_jbda_feeds.py
+++ b/functions-python/tasks_executor/src/tasks/data_import/jbda/import_jbda_feeds.py
@@ -150,7 +150,7 @@ def _update_common_feed_fields(
         else None
     )
     feed.status = "active"
-    feed.operational_status = "wip"
+    feed.operational_status = "published"
     feed.note = list_item.get("feed_memo")
 
     # Ensure a JBDA external id exists; only append if missing.


### PR DESCRIPTION
**Summary:**

This PR set the operational_status to published on imported feeds from jbda source. For historical reasons, the operational status was set to WIP while importing due to the delayed process of making all JBDA feeds available; this is not the case anymore.

**Expected behavior:** 

The operational status for the newly created JBDA feeds is set to published.

**Testing tips:**

Execute the JBDA script in DEV and verify that the operational status for the newly created feeds is set to published.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
