### PR TITLE
Create Location Continent Table

### DIFF
--- a/liquibase/changes/feat_1608.sql
+++ b/liquibase/changes/feat_1608.sql
@@ -1,0 +1,11 @@
+-- create location continent table which has fk reference to location table country code
+CREATE TABLE LOCATION_CONTINENT (
+    continent VARCHAR(255),
+    country_code VARCHAR(3) PRIMARY KEY,
+    CONSTRAINT loc_cont_fk
+        FOREIGN KEY(country_code)
+        REFERENCES LOCATION(country_code)
+);
+
+-- remove the previously created location_view
+DROP VIEW IF EXISTS LOCATION_VIEW;


### PR DESCRIPTION
**Summary:**

Create Location Continent Table and drop the incorrectly created Location View. 

**Expected behavior:** 

Location Continent table has a FK (country_code) to parent Location table. The issue is that Location.country_code is **not** a PK or even a unique key so this relation will not work (FK has to reference the parent table's PK).

The expected behaviour is that I should be able to INSERT a record into the Location Continent table with a country_code present in the Location table. _**Also to consider: Should we make the Location Continent table the parent and the Location table the child in this case?**_

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
