### PR TITLE
fix: rebuild validation reports env var name

### DIFF
--- a/functions-python/tasks_executor/src/tasks/validation_reports/rebuild_missing_validation_reports.py
+++ b/functions-python/tasks_executor/src/tasks/validation_reports/rebuild_missing_validation_reports.py
@@ -41,7 +41,7 @@ from shared.helpers.validation_report.validation_report_update import execute_wo
 QUERY_LIMIT: Final[int] = 100
 TASK_NAME: Final[str] = "gtfs_validation"
 
-env = os.getenv("ENV", "dev").lower()
+env = os.getenv("ENVIRONMENT", "dev").lower()
 datasets_bucket_name = f"mobilitydata-datasets-{env}"
 
 
@@ -325,7 +325,7 @@ def get_parameters(payload):
         Tuple of (dry_run, filter_after_in_days, filter_statuses, prod_env,
                   validator_endpoint, force_update, limit)
     """
-    prod_env = os.getenv("ENV", "").lower() == "prod"
+    prod_env = os.getenv("ENVIRONMENT", "").lower() == "prod"
     default_endpoint = get_gtfs_validator_url(prod_env)
 
     dry_run = payload.get("dry_run", True)


### PR DESCRIPTION
**Summary:**

This pull request updates environment variable usage in the `rebuild_missing_validation_reports.py` script to improve consistency and clarity. The main change is replacing the use of the `ENV` environment variable with `ENVIRONMENT` throughout the file.

Environment variable consistency:

* Changed all references from `ENV` to `ENVIRONMENT` for determining the runtime environment, both when setting the `env` variable and when checking for the production environment. (`functions-python/tasks_executor/src/tasks/validation_reports/rebuild_missing_validation_reports.py`) [[1]](diffhunk://#diff-ca2726255ef3febf080221113df2e1ac890940ba59fa6dbfd7dd960a149f6dbfL44-R44) [[2]](diffhunk://#diff-ca2726255ef3febf080221113df2e1ac890940ba59fa6dbfd7dd960a149f6dbfL328-R328)

**Expected behavior:** 

Python variable is named ENVIRONMENT.

**Testing tips:**

Tested in QA.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
