### PR TITLE
feat: add datasets MD5 hash

### DIFF
--- a/api/src/shared/db_models/gtfs_dataset_impl.py
+++ b/api/src/shared/db_models/gtfs_dataset_impl.py
@@ -47,6 +47,7 @@ class GtfsDatasetImpl(GtfsDataset):
             note=gtfs_dataset.note,
             downloaded_at=gtfs_dataset.downloaded_at,
             hash=gtfs_dataset.hash,
+            hash_md5=gtfs_dataset.hash_md5,
             bounding_box=BoundingBoxImpl.from_orm(gtfs_dataset.bounding_box),
             validation_report=cls.from_orm_latest_validation_report(gtfs_dataset.validation_reports),
             service_date_range_start=gtfs_dataset.service_date_range_start,

--- a/api/src/shared/db_models/latest_dataset_impl.py
+++ b/api/src/shared/db_models/latest_dataset_impl.py
@@ -48,6 +48,7 @@ class LatestDatasetImpl(LatestDataset):
             service_date_range_end=dataset.service_date_range_end,
             agency_timezone=dataset.agency_timezone,
             hash=dataset.hash,
+            hash_md5=dataset.hash_md5,
             validation_report=validation_report,
             unzipped_folder_size_mb=round(dataset.unzipped_size_bytes / 1024**2, 2)
             if dataset.unzipped_size_bytes

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -922,9 +922,13 @@ components:
           example: 2023-07-10T22:06:00Z
           format: date-time
         hash:
-          description: A hash of the dataset.
+          description: SHA-256 hash of the dataset.
           type: string
           example: ad3805c4941cd37881ff40c342e831b5f5224f3d8a9a2ec3ac197d3652c78e42
+        hash_md5:
+          description: MD5 hash of the dataset.
+          type: string
+          example: 098f6bcd4621d373cade4e832627b4f6
         service_date_range_start:
           description: The start date of the service date range for the dataset in UTC. Timing starts at 00:00:00 of the day.
           type: string
@@ -1173,9 +1177,13 @@ components:
               example: 2023-07-10T22:06:00Z
               format: date-time
             hash:
-              description: A hash of the dataset.
+              description: SHA-256 hash of the dataset.
               type: string
               example: 6497e85e34390b8b377130881f2f10ec29c18a80dd6005d504a2038cdd00aa71
+            hash_md5:
+              description: MD5 hash of the dataset.
+              type: string
+              example: 098f6bcd4621d373cade4e832627b4f6
             bounding_box:
               $ref: "#/components/schemas/BoundingBox"
             validation_report:

--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -859,9 +859,13 @@ components:
           example: 2023-07-10T22:06:00Z
           format: date-time
         hash:
-          description: A hash of the dataset.
+          description: SHA-256 hash of the dataset.
           type: string
           example: ad3805c4941cd37881ff40c342e831b5f5224f3d8a9a2ec3ac197d3652c78e42
+        hash_md5:
+          description: MD5 hash of the dataset.
+          type: string
+          example: 098f6bcd4621d373cade4e832627b4f6
         service_date_range_start:
           description: The start date of the service date range for the dataset in UTC. Timing starts at 00:00:00 of the day.
           type: string
@@ -1103,9 +1107,13 @@ components:
               example: 2023-07-10T22:06:00Z
               format: date-time
             hash:
-              description: A hash of the dataset.
+              description: SHA-256 hash of the dataset.
               type: string
               example: 6497e85e34390b8b377130881f2f10ec29c18a80dd6005d504a2038cdd00aa71
+            hash_md5:
+              description: MD5 hash of the dataset.
+              type: string
+              example: 098f6bcd4621d373cade4e832627b4f6
             bounding_box:
               $ref: "#/components/schemas/BoundingBox"
             validation_report:
@@ -1495,6 +1503,7 @@ components:
 
 
 
+
                 * vp - vehicle positions
                 * tu - trip updates
                 * sa - service alerts
@@ -1617,6 +1626,7 @@ components:
 
 
 
+
                 * vp - vehicle positions
                 * tu - trip updates
                 * sa - service alerts
@@ -1696,6 +1706,7 @@ components:
 
 
 
+
           * `active` Feed should be used in public trip planners.
           * `deprecated` Feed is explicitly deprecated and should not be used in public trip planners.
           * `inactive` Feed hasn't been recently updated and should be used at risk of providing outdated information.
@@ -1713,6 +1724,7 @@ components:
       x-operation: true
       description: >
         Describes data type of a feed. Should be one of
+
 
 
 

--- a/functions-python/batch_process_dataset/src/main.py
+++ b/functions-python/batch_process_dataset/src/main.py
@@ -65,6 +65,7 @@ class DatasetFile:
     stable_id: str
     extracted_files: List[Gtfsfile] = None
     file_sha256_hash: Optional[str] = None
+    file_md5_hash: Optional[str] = None
     hosted_url: Optional[str] = None
     zipped_size: Optional[int] = None
 
@@ -156,9 +157,10 @@ class DatasetProcessor:
         source_file_path,
         dataset_stable_id,
         public=True,
-    ):
+    ) -> Optional[str]:
         """
         Uploads the dataset zip file to GCP storage as latest.zip and versioned zip.
+        Returns the MD5 hash (hex) of the uploaded file as provided by GCS.
         """
         bucket = storage.Client().get_bucket(self.bucket_name)
         target_paths = [
@@ -166,12 +168,16 @@ class DatasetProcessor:
             f"{self.feed_stable_id}/{dataset_stable_id}/{dataset_stable_id}.zip",
         ]
 
+        md5_hash_hex = None
         for target_path in target_paths:
             blob = bucket.blob(target_path)
             blob.upload_from_filename(source_file_path)
             if public:
                 blob.make_public()
             self.logger.info(f"Uploaded {blob.public_url}")
+            if blob.md5_hash:
+                md5_hash_hex = base64.b64decode(blob.md5_hash).hex()
+        return md5_hash_hex
 
     def _extract_and_upload_single_file(
         self,
@@ -320,7 +326,7 @@ class DatasetProcessor:
                 self.logger.info(
                     f"Creating file {dataset_full_path} in bucket {self.bucket_name}"
                 )
-                self.upload_dataset_zip_to_storage(
+                file_md5_hash = self.upload_dataset_zip_to_storage(
                     temp_file_path,
                     dataset_stable_id,
                     public=public,
@@ -336,6 +342,7 @@ class DatasetProcessor:
                 return DatasetFile(
                     stable_id=dataset_stable_id,
                     file_sha256_hash=file_sha256_hash,
+                    file_md5_hash=file_md5_hash,
                     hosted_url=f"{self.public_hosted_datasets_url}/{dataset_full_path}",
                     extracted_files=extracted_files,
                     zipped_size=(
@@ -459,6 +466,7 @@ class DatasetProcessor:
                     bounding_box=None,
                     note=None,
                     hash=dataset_file.file_sha256_hash,
+                    hash_md5=dataset_file.file_md5_hash,
                     downloaded_at=func.now(),
                     hosted_url=dataset_file.hosted_url,
                     gtfsfiles=(

--- a/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
+++ b/functions-python/batch_process_dataset/tests/test_batch_process_dataset_main.py
@@ -72,12 +72,8 @@ class TestDatasetProcessor(unittest.TestCase):
         """
         Test upload_dataset method of DatasetProcessor class with different hash from the latest one
         """
-        mock_blob = MagicMock()
-        mock_blob.public_url = public_url
-        mock_blob.path = public_url
-
-        # Mock the new methods used in transfer_dataset
-        mock_upload_dataset_zip.return_value = mock_blob
+        mock_md5_hex = "098f6bcd4621d373cade4e832627b4f6"
+        mock_upload_dataset_zip.return_value = mock_md5_hex
         mock_extracted_files = []  # Empty list of extracted files
         mock_extract_and_upload.return_value = mock_extracted_files
         mock_download_url_content.return_value = file_hash, True
@@ -105,6 +101,7 @@ class TestDatasetProcessor(unittest.TestCase):
             f"/feed_stable_id-mocked_timestamp.zip",
         )
         self.assertEqual(result.file_sha256_hash, file_hash)
+        self.assertEqual(result.file_md5_hash, mock_md5_hex)
         # Verify the new methods were called
         self.assertEqual(mock_upload_dataset_zip.call_count, 1)
         self.assertEqual(mock_extract_and_upload.call_count, 1)
@@ -905,3 +902,77 @@ class TestDatasetProcessor(unittest.TestCase):
             self.assertIsNone(result_dataset.unzipped_size_bytes)  # None when no files
 
             mock_refresh_task.assert_called_once()
+
+
+class TestUploadDatasetZipToStorage(unittest.TestCase):
+    @patch("main.storage.Client")
+    def test_md5_hash_read_from_gcs_blob_after_upload(self, mock_storage_client):
+        """
+        upload_dataset_zip_to_storage should return the hex MD5 hash read from the GCS
+        blob's md5_hash attribute (base64-encoded) after upload.
+        """
+        import base64
+        import tempfile
+
+        raw_md5 = b"\x09\x8f\x6b\xcd\x46\x21\xd3\x73\xca\xde\x4e\x83\x26\x27\xb4\xf6"
+        b64_md5 = base64.b64encode(raw_md5).decode()
+        expected_hex = raw_md5.hex()
+
+        mock_blob = MagicMock()
+        mock_blob.md5_hash = b64_md5
+        mock_blob.public_url = "https://storage.googleapis.com/bucket/path.zip"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_storage_client.return_value.get_bucket.return_value = mock_bucket
+
+        processor = DatasetProcessor(
+            producer_url="https://example.com/feed.zip",
+            feed_id="feed_id",
+            feed_stable_id="feed_stable",
+            execution_id="exec_id",
+            latest_hash="hash",
+            bucket_name="test-bucket",
+            authentication_type=0,
+            api_key_parameter_name=None,
+            public_hosted_datasets_url="https://public.example.com",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
+            result = processor.upload_dataset_zip_to_storage(
+                tmp.name, "dataset_stable_id"
+            )
+
+        self.assertEqual(result, expected_hex)
+
+    @patch("main.storage.Client")
+    def test_md5_hash_none_when_blob_has_no_md5(self, mock_storage_client):
+        """
+        upload_dataset_zip_to_storage should return None if the GCS blob provides no md5_hash.
+        """
+        import tempfile
+
+        mock_blob = MagicMock()
+        mock_blob.md5_hash = None
+        mock_blob.public_url = "https://storage.googleapis.com/bucket/path.zip"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_storage_client.return_value.get_bucket.return_value = mock_bucket
+
+        processor = DatasetProcessor(
+            producer_url="https://example.com/feed.zip",
+            feed_id="feed_id",
+            feed_stable_id="feed_stable",
+            execution_id="exec_id",
+            latest_hash="hash",
+            bucket_name="test-bucket",
+            authentication_type=0,
+            api_key_parameter_name=None,
+            public_hosted_datasets_url="https://public.example.com",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
+            result = processor.upload_dataset_zip_to_storage(
+                tmp.name, "dataset_stable_id"
+            )
+
+        self.assertIsNone(result)

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -93,6 +93,27 @@ To populate licenses:
 }
 ```
 
+To backfill MD5 hashes for existing GTFS datasets (reads the MD5 from the GCS object metadata):
+
+```json
+{
+  "task": "backfill_dataset_hash_md5",
+  "payload": {
+    "dry_run": true,
+    "only_latest": true,
+    "only_missing_hashes": true,
+    "limit": 10
+  }
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `dry_run` | bool | `true` | Log changes without writing to the database |
+| `only_latest` | bool | `true` | Process only datasets that are the current latest for their feed |
+| `only_missing_hashes` | bool | `true` | Skip datasets that already have `hash_md5` set |
+| `limit` | int \| null | `10` | Maximum number of datasets to process; omit or pass `null` for no limit |
+
 ## Response Content Type
 
 When the request includes the header `Accept: text/csv`, the server returns the response as a CSV file generated from the handler’s output.

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -29,6 +29,9 @@ from tasks.data_import.transportdatagouv.update_tdg_redirects import (
 from tasks.dataset_files.rebuild_missing_dataset_files import (
     rebuild_missing_dataset_files_handler,
 )
+from tasks.dataset_files.backfill_dataset_hash_md5 import (
+    backfill_dataset_hash_md5_handler,
+)
 from tasks.licenses.license_matcher import match_license_handler
 from tasks.missing_bounding_boxes.rebuild_missing_bounding_boxes import (
     rebuild_missing_bounding_boxes_handler,
@@ -108,6 +111,14 @@ tasks = {
     "rebuild_missing_dataset_files": {
         "description": "Rebuilds missing dataset files for GTFS datasets.",
         "handler": rebuild_missing_dataset_files_handler,
+    },
+    "backfill_dataset_hash_md5": {
+        "description": (
+            "Backfills the MD5 hash for existing GTFS datasets by reading it from GCS blob metadata. "
+            "Parameters: dry_run (default true), only_latest (default true), "
+            "only_missing_hashes (default true), limit (default 10)."
+        ),
+        "handler": backfill_dataset_hash_md5_handler,
     },
     "update_geojson_files": {
         "description": "Iterate over bucket looking for {feed_stable_id}/geolocation.geojson and update precision.",

--- a/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
@@ -1,0 +1,229 @@
+import base64
+import logging
+import os
+from urllib.parse import urlparse, unquote
+
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+from sqlalchemy.orm import Session, joinedload
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import Gtfsdataset, Gtfsfeed
+
+BATCH_COMMIT_SIZE = 50
+
+
+def backfill_dataset_hash_md5_handler(payload) -> dict:
+    """
+    Entry point for backfilling the MD5 hash on existing GTFS datasets.
+
+    Args:
+        payload (dict): Task parameters.
+            dry_run (bool): If True, log changes without writing to DB. Default: True.
+            only_latest (bool): Process only datasets that are the latest for their feed. Default: True.
+            only_missing_hashes (bool): Skip datasets that already have hash_md5 set. Default: True.
+            limit (int | None): Maximum number of datasets to process.
+                Omit or pass null to process all matching datasets without a limit. Default: 10.
+
+    Returns:
+        dict: Result summary.
+    """
+    dry_run = payload.get("dry_run", True)
+    only_latest = payload.get("only_latest", True)
+    only_missing_hashes = payload.get("only_missing_hashes", True)
+
+    limit = None
+    raw_limit = payload.get("limit", 10)
+    if raw_limit is not None:
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            logging.warning("Invalid limit value %r, using no limit.", raw_limit)
+
+    return backfill_dataset_hash_md5(
+        dry_run=dry_run,
+        only_latest=only_latest,
+        only_missing_hashes=only_missing_hashes,
+        limit=limit,
+    )
+
+
+def _get_blob_path_from_hosted_url(hosted_url: str, bucket_name: str) -> str | None:
+    """
+    Derives the GCS blob path from a hosted_url.
+
+    Supports three URL formats:
+    1. Standard GCS: https://storage.googleapis.com/{bucket_name}/{blob_path}
+    2. Storage API:  https://storage.googleapis.com/storage/v1/b/{bucket}/o/{blob}?alt=media
+    3. Custom CDN/domain (PUBLIC_HOSTED_DATASETS_URL env var prefix stripped)
+
+    Args:
+        hosted_url: The public URL of the dataset hosted on GCS.
+        bucket_name: The GCS bucket name.
+
+    Returns:
+        The blob path (e.g. "mdb-10/mdb-10-202402080058/mdb-10-202402080058.zip"),
+        or None if the URL cannot be parsed.
+    """
+    try:
+        parsed = urlparse(hosted_url)
+
+        # Standard GCS URL: https://storage.googleapis.com/{bucket_name}/{blob_path}
+        prefix = f"/{bucket_name}/"
+        if parsed.path.startswith(prefix):
+            return parsed.path[len(prefix) :]
+
+        # Storage API URL: .../b/{bucket}/o/{blob}?alt=media
+        if "/b/" in parsed.path and "/o/" in parsed.path:
+            blob_part = parsed.path.split("/o/", 1)[1]
+            return unquote(blob_part)
+
+        # Custom CDN/domain: strip the PUBLIC_HOSTED_DATASETS_URL prefix
+        public_url = os.environ.get("PUBLIC_HOSTED_DATASETS_URL", "").rstrip("/")
+        if public_url and hosted_url.startswith(public_url + "/"):
+            return hosted_url[len(public_url) + 1 :]
+    except Exception:
+        pass
+    return None
+
+
+def _read_md5_from_gcs(bucket, blob_path: str) -> str | None:
+    """
+    Reads the MD5 hash from a GCS blob and returns it as a hex string.
+
+    Args:
+        bucket: GCS bucket object.
+        blob_path: Path to the blob within the bucket.
+
+    Returns:
+        Hex-encoded MD5 string, or None if the blob is missing or has no MD5.
+    """
+    try:
+        blob = bucket.blob(blob_path)
+        blob.reload()
+        if blob.md5_hash:
+            return base64.b64decode(blob.md5_hash).hex()
+    except NotFound:
+        logging.warning("GCS blob not found: %s", blob_path)
+    except Exception as e:
+        logging.warning("Failed to read MD5 from GCS blob %s: %s", blob_path, e)
+    return None
+
+
+def _build_query(db_session: Session, only_latest: bool, only_missing_hashes: bool):
+    """Build the SQLAlchemy query for datasets to backfill."""
+    query = db_session.query(Gtfsdataset).filter(~Gtfsdataset.hosted_url.is_(None))
+
+    if only_latest:
+        query = query.join(Gtfsfeed, Gtfsfeed.latest_dataset_id == Gtfsdataset.id)
+
+    if only_missing_hashes:
+        query = query.filter(Gtfsdataset.hash_md5.is_(None))
+
+    return query.options(joinedload(Gtfsdataset.feed))
+
+
+@with_db_session
+def backfill_dataset_hash_md5(
+    db_session: Session,
+    dry_run: bool = True,
+    only_latest: bool = True,
+    only_missing_hashes: bool = True,
+    limit: int | None = 10,
+) -> dict:
+    """
+    Backfills the MD5 hash for existing GTFS datasets by reading it from GCS blob metadata.
+
+    Commits progress in batches of BATCH_COMMIT_SIZE so partial progress is preserved
+    if the function fails mid-run.
+
+    Args:
+        db_session: SQLAlchemy DB session.
+        dry_run: If True, log changes without writing to DB.
+        only_latest: Process only datasets that are the latest for their feed.
+        only_missing_hashes: Skip datasets that already have hash_md5 set.
+        limit: Maximum number of datasets to process. None means no limit.
+
+    Returns:
+        dict: Result summary.
+    """
+    bucket_name = os.environ.get("DATASETS_BUCKET_NAME")
+
+    query = _build_query(db_session, only_latest, only_missing_hashes)
+    total_candidates = query.count()
+
+    if dry_run:
+        logging.info(
+            "Dry run: %d datasets eligible for MD5 backfill (limit=%s).",
+            total_candidates,
+            limit if limit is not None else "none",
+        )
+        return {
+            "message": f"Dry run: {total_candidates} datasets eligible for MD5 backfill.",
+            "total_candidates": total_candidates,
+            "limit": limit,
+            "params": {
+                "dry_run": dry_run,
+                "only_latest": only_latest,
+                "only_missing_hashes": only_missing_hashes,
+            },
+        }
+
+    datasets = (query.limit(limit) if limit is not None else query).all()
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+
+    total_updated = 0
+    total_skipped = 0
+    pending_commit: list[Gtfsdataset] = []
+
+    for dataset in datasets:
+        blob_path = _get_blob_path_from_hosted_url(dataset.hosted_url, bucket_name)
+        if not blob_path:
+            logging.warning(
+                "Could not derive blob path from hosted_url for dataset %s: %s",
+                dataset.stable_id,
+                dataset.hosted_url,
+            )
+            total_skipped += 1
+            continue
+
+        md5_hex = _read_md5_from_gcs(bucket, blob_path)
+        if not md5_hex:
+            logging.warning(
+                "No MD5 found in GCS for dataset %s (blob: %s).",
+                dataset.stable_id,
+                blob_path,
+            )
+            total_skipped += 1
+            continue
+
+        dataset.hash_md5 = md5_hex
+        pending_commit.append(dataset)
+        total_updated += 1
+        logging.info("Dataset %s: MD5 set to %s", dataset.stable_id, md5_hex)
+
+        if len(pending_commit) >= BATCH_COMMIT_SIZE:
+            db_session.commit()
+            logging.info("Committed batch of %d datasets.", len(pending_commit))
+            pending_commit = []
+
+    # Commit any remaining datasets
+    if pending_commit:
+        db_session.commit()
+        logging.info("Committed final batch of %d datasets.", len(pending_commit))
+
+    result = {
+        "message": "MD5 hash backfill completed.",
+        "total_updated": total_updated,
+        "total_skipped": total_skipped,
+        "params": {
+            "dry_run": dry_run,
+            "only_latest": only_latest,
+            "only_missing_hashes": only_missing_hashes,
+            "limit": limit,
+            "bucket_name": bucket_name,
+        },
+    }
+    logging.info("Task summary: %s", result)
+    return result

--- a/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
@@ -10,6 +10,7 @@ from shared.database.database import with_db_session
 from shared.database_gen.sqlacodegen_models import Gtfsdataset, Gtfsfeed
 
 BATCH_COMMIT_SIZE = 50
+DEFAULT_LIMIT = 10
 
 
 def backfill_dataset_hash_md5_handler(payload) -> dict:
@@ -32,12 +33,17 @@ def backfill_dataset_hash_md5_handler(payload) -> dict:
     only_missing_hashes = payload.get("only_missing_hashes", True)
 
     limit = None
-    raw_limit = payload.get("limit", 10)
+    raw_limit = payload.get("limit", DEFAULT_LIMIT)
     if raw_limit is not None:
         try:
             limit = int(raw_limit)
         except (TypeError, ValueError):
-            logging.warning("Invalid limit value %r, using no limit.", raw_limit)
+            logging.warning(
+                "Invalid limit value %r, using default value %s.",
+                raw_limit,
+                DEFAULT_LIMIT,
+            )
+            limit = DEFAULT_LIMIT
 
     return backfill_dataset_hash_md5(
         dry_run=dry_run,

--- a/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/src/tasks/dataset_files/backfill_dataset_hash_md5.py
@@ -1,7 +1,6 @@
 import base64
 import logging
 import os
-from urllib.parse import urlparse, unquote
 
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
@@ -48,43 +47,9 @@ def backfill_dataset_hash_md5_handler(payload) -> dict:
     )
 
 
-def _get_blob_path_from_hosted_url(hosted_url: str, bucket_name: str) -> str | None:
-    """
-    Derives the GCS blob path from a hosted_url.
-
-    Supports three URL formats:
-    1. Standard GCS: https://storage.googleapis.com/{bucket_name}/{blob_path}
-    2. Storage API:  https://storage.googleapis.com/storage/v1/b/{bucket}/o/{blob}?alt=media
-    3. Custom CDN/domain (PUBLIC_HOSTED_DATASETS_URL env var prefix stripped)
-
-    Args:
-        hosted_url: The public URL of the dataset hosted on GCS.
-        bucket_name: The GCS bucket name.
-
-    Returns:
-        The blob path (e.g. "mdb-10/mdb-10-202402080058/mdb-10-202402080058.zip"),
-        or None if the URL cannot be parsed.
-    """
-    try:
-        parsed = urlparse(hosted_url)
-
-        # Standard GCS URL: https://storage.googleapis.com/{bucket_name}/{blob_path}
-        prefix = f"/{bucket_name}/"
-        if parsed.path.startswith(prefix):
-            return parsed.path[len(prefix) :]
-
-        # Storage API URL: .../b/{bucket}/o/{blob}?alt=media
-        if "/b/" in parsed.path and "/o/" in parsed.path:
-            blob_part = parsed.path.split("/o/", 1)[1]
-            return unquote(blob_part)
-
-        # Custom CDN/domain: strip the PUBLIC_HOSTED_DATASETS_URL prefix
-        public_url = os.environ.get("PUBLIC_HOSTED_DATASETS_URL", "").rstrip("/")
-        if public_url and hosted_url.startswith(public_url + "/"):
-            return hosted_url[len(public_url) + 1 :]
-    except Exception:
-        pass
-    return None
+def _build_blob_path(feed_stable_id: str, dataset_stable_id: str) -> str:
+    """Returns the GCS blob path for a dataset ZIP file."""
+    return f"{feed_stable_id}/{dataset_stable_id}/{dataset_stable_id}.zip"
 
 
 def _read_md5_from_gcs(bucket, blob_path: str) -> str | None:
@@ -112,7 +77,7 @@ def _read_md5_from_gcs(bucket, blob_path: str) -> str | None:
 
 def _build_query(db_session: Session, only_latest: bool, only_missing_hashes: bool):
     """Build the SQLAlchemy query for datasets to backfill."""
-    query = db_session.query(Gtfsdataset).filter(~Gtfsdataset.hosted_url.is_(None))
+    query = db_session.query(Gtfsdataset)
 
     if only_latest:
         query = query.join(Gtfsfeed, Gtfsfeed.latest_dataset_id == Gtfsdataset.id)
@@ -178,16 +143,7 @@ def backfill_dataset_hash_md5(
     pending_commit: list[Gtfsdataset] = []
 
     for dataset in datasets:
-        blob_path = _get_blob_path_from_hosted_url(dataset.hosted_url, bucket_name)
-        if not blob_path:
-            logging.warning(
-                "Could not derive blob path from hosted_url for dataset %s: %s",
-                dataset.stable_id,
-                dataset.hosted_url,
-            )
-            total_skipped += 1
-            continue
-
+        blob_path = _build_blob_path(dataset.feed.stable_id, dataset.stable_id)
         md5_hex = _read_md5_from_gcs(bucket, blob_path)
         if not md5_hex:
             logging.warning(

--- a/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
@@ -9,36 +9,21 @@ from test_shared.test_utils.database_utils import default_db_url
 from tasks.dataset_files.backfill_dataset_hash_md5 import (
     backfill_dataset_hash_md5,
     backfill_dataset_hash_md5_handler,
-    _get_blob_path_from_hosted_url,
+    _build_blob_path,
     _read_md5_from_gcs,
 )
 
 
-class TestGetBlobPathFromHostedUrl(unittest.TestCase):
-    def test_standard_gcs_url(self):
-        url = "https://storage.googleapis.com/my-bucket/feed/dataset/dataset.zip"
-        result = _get_blob_path_from_hosted_url(url, "my-bucket")
-        self.assertEqual(result, "feed/dataset/dataset.zip")
+class TestBuildBlobPath(unittest.TestCase):
+    def test_constructs_expected_path(self):
+        result = _build_blob_path("mdb-779", "mdb-779-202507082048")
+        self.assertEqual(
+            result, "mdb-779/mdb-779-202507082048/mdb-779-202507082048.zip"
+        )
 
-    def test_storage_api_url_url_decoded(self):
-        url = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/feed%2Fdataset.zip?alt=media"
-        result = _get_blob_path_from_hosted_url(url, "my-bucket")
-        self.assertEqual(result, "feed/dataset.zip")
-
-    @patch.dict(os.environ, {"PUBLIC_HOSTED_DATASETS_URL": "https://cdn.example.com"})
-    def test_custom_cdn_url(self):
-        url = "https://cdn.example.com/feed/dataset/dataset.zip"
-        result = _get_blob_path_from_hosted_url(url, "my-bucket")
-        self.assertEqual(result, "feed/dataset/dataset.zip")
-
-    def test_url_different_bucket(self):
-        url = "https://storage.googleapis.com/other-bucket/feed/dataset.zip"
-        result = _get_blob_path_from_hosted_url(url, "my-bucket")
-        self.assertIsNone(result)
-
-    def test_invalid_url(self):
-        result = _get_blob_path_from_hosted_url("not-a-url", "my-bucket")
-        self.assertIsNone(result)
+    def test_generic_feed_and_dataset(self):
+        result = _build_blob_path("feed-1", "feed-1-20240101")
+        self.assertEqual(result, "feed-1/feed-1-20240101/feed-1-20240101.zip")
 
 
 class TestReadMd5FromGcs(unittest.TestCase):
@@ -149,11 +134,10 @@ class TestBackfillDatasetHashMd5DryRun(unittest.TestCase):
 
 
 class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
-    def _make_fake_dataset(self, stable_id, hosted_url):
-        fake_feed = SimpleNamespace(stable_id="feed-stable")
+    def _make_fake_dataset(self, dataset_stable_id, feed_stable_id="mdb-1"):
+        fake_feed = SimpleNamespace(stable_id=feed_stable_id)
         return SimpleNamespace(
-            stable_id=stable_id,
-            hosted_url=hosted_url,
+            stable_id=dataset_stable_id,
             hash_md5=None,
             feed=fake_feed,
         )
@@ -188,15 +172,10 @@ class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
     def test_updates_md5_and_commits_in_batches(
         self, mock_storage_client, mock_read_md5, mock_build_query
     ):
-        bucket_name = "test-bucket"
         raw_md5 = "098f6bcd4621d373cade4e832627b4f6"
 
         datasets = [
-            self._make_fake_dataset(
-                f"ds-{i}",
-                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
-            )
-            for i in range(3)
+            self._make_fake_dataset(f"mdb-1-2024010{i}", "mdb-1") for i in range(3)
         ]
 
         mock_query = MagicMock()
@@ -225,24 +204,25 @@ class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
         # Final commit called for remaining datasets (3 < BATCH_COMMIT_SIZE=50)
         db_session.commit.assert_called_once()
 
+        # Verify blob paths are constructed from stable IDs
+        for i, ds in enumerate(datasets):
+            expected_blob = f"mdb-1/mdb-1-2024010{i}/mdb-1-2024010{i}.zip"
+            mock_read_md5.assert_any_call(mock_bucket, expected_blob)
+
     @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"}, clear=False)
     @patch("tasks.dataset_files.backfill_dataset_hash_md5._build_query")
     @patch("tasks.dataset_files.backfill_dataset_hash_md5._read_md5_from_gcs")
     @patch("tasks.dataset_files.backfill_dataset_hash_md5.storage.Client")
-    def test_skips_datasets_with_unparseable_url(
+    def test_skips_datasets_when_gcs_blob_missing(
         self, mock_storage_client, mock_read_md5, mock_build_query
     ):
-        # URL from a different bucket, no PUBLIC_HOSTED_DATASETS_URL set → can't derive blob path
-        datasets = [
-            self._make_fake_dataset(
-                "ds-bad", "https://storage.googleapis.com/wrong-bucket/feed/ds.zip"
-            ),
-        ]
+        datasets = [self._make_fake_dataset("mdb-1-20240101", "mdb-1")]
         mock_query = MagicMock()
         mock_query.count.return_value = 1
         mock_query.limit.return_value.all.return_value = datasets
         mock_build_query.return_value = mock_query
 
+        mock_read_md5.return_value = None  # blob not found in GCS
         mock_storage_client.return_value.bucket.return_value = MagicMock()
         db_session = MagicMock()
 
@@ -256,7 +236,6 @@ class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
 
         self.assertEqual(result["total_updated"], 0)
         self.assertEqual(result["total_skipped"], 1)
-        mock_read_md5.assert_not_called()
         db_session.commit.assert_not_called()
 
     @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"})
@@ -269,14 +248,10 @@ class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
         """Verify that commits happen every BATCH_COMMIT_SIZE=50 datasets."""
         from tasks.dataset_files.backfill_dataset_hash_md5 import BATCH_COMMIT_SIZE
 
-        bucket_name = "test-bucket"
         num_datasets = BATCH_COMMIT_SIZE + 10  # 60 total → 1 mid-batch commit + 1 final
 
         datasets = [
-            self._make_fake_dataset(
-                f"ds-{i}",
-                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
-            )
+            self._make_fake_dataset(f"mdb-1-2024010{i}", "mdb-1")
             for i in range(num_datasets)
         ]
 
@@ -309,13 +284,8 @@ class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
         self, mock_storage_client, mock_read_md5, mock_build_query
     ):
         """When limit=None, query.all() is called directly without .limit()."""
-        bucket_name = "test-bucket"
         datasets = [
-            self._make_fake_dataset(
-                f"ds-{i}",
-                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
-            )
-            for i in range(5)
+            self._make_fake_dataset(f"mdb-1-2024010{i}", "mdb-1") for i in range(5)
         ]
 
         mock_query = MagicMock()

--- a/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
@@ -11,6 +11,7 @@ from tasks.dataset_files.backfill_dataset_hash_md5 import (
     backfill_dataset_hash_md5_handler,
     _build_blob_path,
     _read_md5_from_gcs,
+    DEFAULT_LIMIT,
 )
 
 
@@ -111,11 +112,11 @@ class TestBackfillDatasetHashMd5Handler(unittest.TestCase):
         self.assertIsNone(kwargs["limit"])
 
     @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
-    def test_handler_invalid_limit_means_no_limit(self, mock_backfill):
+    def test_handler_invalid_limit_means_default_limit(self, mock_backfill):
         mock_backfill.return_value = {}
         backfill_dataset_hash_md5_handler({"limit": "not-a-number"})
         _, kwargs = mock_backfill.call_args
-        self.assertIsNone(kwargs["limit"])
+        self.assertIs(kwargs["limit"], DEFAULT_LIMIT)
 
 
 class TestBackfillDatasetHashMd5DryRun(unittest.TestCase):

--- a/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
+++ b/functions-python/tasks_executor/tests/tasks/dataset_files/test_backfill_dataset_hash_md5.py
@@ -1,0 +1,339 @@
+import base64
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from shared.database.database import with_db_session
+from test_shared.test_utils.database_utils import default_db_url
+from tasks.dataset_files.backfill_dataset_hash_md5 import (
+    backfill_dataset_hash_md5,
+    backfill_dataset_hash_md5_handler,
+    _get_blob_path_from_hosted_url,
+    _read_md5_from_gcs,
+)
+
+
+class TestGetBlobPathFromHostedUrl(unittest.TestCase):
+    def test_standard_gcs_url(self):
+        url = "https://storage.googleapis.com/my-bucket/feed/dataset/dataset.zip"
+        result = _get_blob_path_from_hosted_url(url, "my-bucket")
+        self.assertEqual(result, "feed/dataset/dataset.zip")
+
+    def test_storage_api_url_url_decoded(self):
+        url = "https://storage.googleapis.com/storage/v1/b/my-bucket/o/feed%2Fdataset.zip?alt=media"
+        result = _get_blob_path_from_hosted_url(url, "my-bucket")
+        self.assertEqual(result, "feed/dataset.zip")
+
+    @patch.dict(os.environ, {"PUBLIC_HOSTED_DATASETS_URL": "https://cdn.example.com"})
+    def test_custom_cdn_url(self):
+        url = "https://cdn.example.com/feed/dataset/dataset.zip"
+        result = _get_blob_path_from_hosted_url(url, "my-bucket")
+        self.assertEqual(result, "feed/dataset/dataset.zip")
+
+    def test_url_different_bucket(self):
+        url = "https://storage.googleapis.com/other-bucket/feed/dataset.zip"
+        result = _get_blob_path_from_hosted_url(url, "my-bucket")
+        self.assertIsNone(result)
+
+    def test_invalid_url(self):
+        result = _get_blob_path_from_hosted_url("not-a-url", "my-bucket")
+        self.assertIsNone(result)
+
+
+class TestReadMd5FromGcs(unittest.TestCase):
+    def test_returns_hex_md5(self):
+        raw_md5 = b"\x09\x8f\x6b\xcd\x46\x21\xd3\x73\xca\xde\x4e\x83\x26\x27\xb4\xf6"
+        b64_md5 = base64.b64encode(raw_md5).decode()
+
+        mock_blob = MagicMock()
+        mock_blob.md5_hash = b64_md5
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        result = _read_md5_from_gcs(mock_bucket, "some/path.zip")
+        self.assertEqual(result, raw_md5.hex())
+        mock_blob.reload.assert_called_once()
+
+    def test_returns_none_when_blob_not_found(self):
+        from google.cloud.exceptions import NotFound
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.reload.side_effect = NotFound("blob not found")
+        mock_bucket.blob.return_value = mock_blob
+
+        result = _read_md5_from_gcs(mock_bucket, "missing/path.zip")
+        self.assertIsNone(result)
+
+    def test_returns_none_when_md5_hash_is_none(self):
+        mock_blob = MagicMock()
+        mock_blob.md5_hash = None
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        result = _read_md5_from_gcs(mock_bucket, "some/path.zip")
+        self.assertIsNone(result)
+
+
+class TestBackfillDatasetHashMd5Handler(unittest.TestCase):
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
+    def test_handler_passes_default_params(self, mock_backfill):
+        mock_backfill.return_value = {
+            "message": "Dry run: 5 datasets eligible.",
+            "total_candidates": 5,
+        }
+        result = backfill_dataset_hash_md5_handler({})
+        mock_backfill.assert_called_once_with(
+            dry_run=True,
+            only_latest=True,
+            only_missing_hashes=True,
+            limit=10,
+        )
+        self.assertEqual(result["total_candidates"], 5)
+
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
+    def test_handler_passes_custom_params(self, mock_backfill):
+        mock_backfill.return_value = {"message": "done", "total_updated": 3}
+        backfill_dataset_hash_md5_handler(
+            {
+                "dry_run": False,
+                "only_latest": False,
+                "only_missing_hashes": False,
+                "limit": 100,
+            }
+        )
+        mock_backfill.assert_called_once_with(
+            dry_run=False,
+            only_latest=False,
+            only_missing_hashes=False,
+            limit=100,
+        )
+
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
+    def test_handler_string_limit_is_converted_to_int(self, mock_backfill):
+        mock_backfill.return_value = {}
+        backfill_dataset_hash_md5_handler({"limit": "42"})
+        _, kwargs = mock_backfill.call_args
+        self.assertEqual(kwargs["limit"], 42)
+        self.assertIsInstance(kwargs["limit"], int)
+
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
+    def test_handler_null_limit_means_no_limit(self, mock_backfill):
+        mock_backfill.return_value = {}
+        backfill_dataset_hash_md5_handler({"limit": None})
+        _, kwargs = mock_backfill.call_args
+        self.assertIsNone(kwargs["limit"])
+
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.backfill_dataset_hash_md5")
+    def test_handler_invalid_limit_means_no_limit(self, mock_backfill):
+        mock_backfill.return_value = {}
+        backfill_dataset_hash_md5_handler({"limit": "not-a-number"})
+        _, kwargs = mock_backfill.call_args
+        self.assertIsNone(kwargs["limit"])
+
+
+class TestBackfillDatasetHashMd5DryRun(unittest.TestCase):
+    @with_db_session(db_url=default_db_url)
+    def test_dry_run_returns_count_without_db_changes(self, db_session):
+        result = backfill_dataset_hash_md5(
+            db_session=db_session,
+            dry_run=True,
+            only_latest=True,
+            only_missing_hashes=True,
+            limit=10,
+        )
+        self.assertIn("Dry run", result["message"])
+        self.assertIn("total_candidates", result)
+        self.assertGreaterEqual(result["total_candidates"], 0)
+
+
+class TestBackfillDatasetHashMd5Processing(unittest.TestCase):
+    def _make_fake_dataset(self, stable_id, hosted_url):
+        fake_feed = SimpleNamespace(stable_id="feed-stable")
+        return SimpleNamespace(
+            stable_id=stable_id,
+            hosted_url=hosted_url,
+            hash_md5=None,
+            feed=fake_feed,
+        )
+
+    def _make_mock_db_session(self, datasets):
+        db_session = MagicMock()
+        query_mock = MagicMock()
+        filter1 = MagicMock()
+        filter2 = MagicMock()
+        filter3 = MagicMock()
+        options_mock = MagicMock()
+        join_mock = MagicMock()
+
+        db_session.query.return_value = query_mock
+        query_mock.filter.return_value = filter1
+        filter1.join.return_value = join_mock
+        join_mock.filter.return_value = filter2
+        filter2.filter.return_value = filter3
+        filter3.options.return_value = options_mock
+        # Support the full chain used in _build_query
+        query_mock.filter.return_value.join.return_value.filter.return_value.options.return_value = (
+            options_mock
+        )
+        options_mock.count.return_value = len(datasets)
+        options_mock.limit.return_value.all.return_value = datasets
+        return db_session, options_mock
+
+    @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"})
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._build_query")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._read_md5_from_gcs")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.storage.Client")
+    def test_updates_md5_and_commits_in_batches(
+        self, mock_storage_client, mock_read_md5, mock_build_query
+    ):
+        bucket_name = "test-bucket"
+        raw_md5 = "098f6bcd4621d373cade4e832627b4f6"
+
+        datasets = [
+            self._make_fake_dataset(
+                f"ds-{i}",
+                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
+            )
+            for i in range(3)
+        ]
+
+        mock_query = MagicMock()
+        mock_query.count.return_value = 3
+        mock_query.limit.return_value.all.return_value = datasets
+        mock_build_query.return_value = mock_query
+
+        mock_read_md5.return_value = raw_md5
+        mock_bucket = MagicMock()
+        mock_storage_client.return_value.bucket.return_value = mock_bucket
+
+        db_session = MagicMock()
+
+        result = backfill_dataset_hash_md5(
+            db_session=db_session,
+            dry_run=False,
+            only_latest=True,
+            only_missing_hashes=True,
+            limit=3,
+        )
+
+        self.assertEqual(result["total_updated"], 3)
+        self.assertEqual(result["total_skipped"], 0)
+        for ds in datasets:
+            self.assertEqual(ds.hash_md5, raw_md5)
+        # Final commit called for remaining datasets (3 < BATCH_COMMIT_SIZE=50)
+        db_session.commit.assert_called_once()
+
+    @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"}, clear=False)
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._build_query")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._read_md5_from_gcs")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.storage.Client")
+    def test_skips_datasets_with_unparseable_url(
+        self, mock_storage_client, mock_read_md5, mock_build_query
+    ):
+        # URL from a different bucket, no PUBLIC_HOSTED_DATASETS_URL set → can't derive blob path
+        datasets = [
+            self._make_fake_dataset(
+                "ds-bad", "https://storage.googleapis.com/wrong-bucket/feed/ds.zip"
+            ),
+        ]
+        mock_query = MagicMock()
+        mock_query.count.return_value = 1
+        mock_query.limit.return_value.all.return_value = datasets
+        mock_build_query.return_value = mock_query
+
+        mock_storage_client.return_value.bucket.return_value = MagicMock()
+        db_session = MagicMock()
+
+        result = backfill_dataset_hash_md5(
+            db_session=db_session,
+            dry_run=False,
+            only_latest=True,
+            only_missing_hashes=True,
+            limit=1,
+        )
+
+        self.assertEqual(result["total_updated"], 0)
+        self.assertEqual(result["total_skipped"], 1)
+        mock_read_md5.assert_not_called()
+        db_session.commit.assert_not_called()
+
+    @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"})
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._build_query")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._read_md5_from_gcs")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.storage.Client")
+    def test_commits_in_batches_of_50(
+        self, mock_storage_client, mock_read_md5, mock_build_query
+    ):
+        """Verify that commits happen every BATCH_COMMIT_SIZE=50 datasets."""
+        from tasks.dataset_files.backfill_dataset_hash_md5 import BATCH_COMMIT_SIZE
+
+        bucket_name = "test-bucket"
+        num_datasets = BATCH_COMMIT_SIZE + 10  # 60 total → 1 mid-batch commit + 1 final
+
+        datasets = [
+            self._make_fake_dataset(
+                f"ds-{i}",
+                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
+            )
+            for i in range(num_datasets)
+        ]
+
+        mock_query = MagicMock()
+        mock_query.count.return_value = num_datasets
+        mock_query.limit.return_value.all.return_value = datasets
+        mock_build_query.return_value = mock_query
+
+        mock_read_md5.return_value = "abc123"
+        mock_storage_client.return_value.bucket.return_value = MagicMock()
+        db_session = MagicMock()
+
+        result = backfill_dataset_hash_md5(
+            db_session=db_session,
+            dry_run=False,
+            only_latest=True,
+            only_missing_hashes=True,
+            limit=num_datasets,
+        )
+
+        self.assertEqual(result["total_updated"], num_datasets)
+        # 1 mid-batch commit (at 50) + 1 final commit (remaining 10) = 2 total
+        self.assertEqual(db_session.commit.call_count, 2)
+
+    @patch.dict(os.environ, {"DATASETS_BUCKET_NAME": "test-bucket"})
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._build_query")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5._read_md5_from_gcs")
+    @patch("tasks.dataset_files.backfill_dataset_hash_md5.storage.Client")
+    def test_no_limit_processes_all_datasets(
+        self, mock_storage_client, mock_read_md5, mock_build_query
+    ):
+        """When limit=None, query.all() is called directly without .limit()."""
+        bucket_name = "test-bucket"
+        datasets = [
+            self._make_fake_dataset(
+                f"ds-{i}",
+                f"https://storage.googleapis.com/{bucket_name}/feed/ds-{i}/ds-{i}.zip",
+            )
+            for i in range(5)
+        ]
+
+        mock_query = MagicMock()
+        mock_query.count.return_value = 5
+        mock_query.all.return_value = datasets
+        mock_build_query.return_value = mock_query
+
+        mock_read_md5.return_value = "abc123"
+        mock_storage_client.return_value.bucket.return_value = MagicMock()
+        db_session = MagicMock()
+
+        result = backfill_dataset_hash_md5(
+            db_session=db_session,
+            dry_run=False,
+            limit=None,
+        )
+
+        self.assertEqual(result["total_updated"], 5)
+        # .limit() should NOT be called when limit is None
+        mock_query.limit.assert_not_called()
+        mock_query.all.assert_called_once()

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -107,6 +107,8 @@
          Views are rebuilt from source SQL files using runOnChange. -->
     <!-- Generic task run and execution log tables for orchestration tracking. -->
     <include file="changes/feat_task_execution_log.sql" relativeToChangelogFile="true"/>
+    <!-- Add MD5 hash column to GTFSDataset table. -->
+    <include file="changes/feat_1657.sql" relativeToChangelogFile="true"/>
     <!-- Keep this at the very end to ensure all table and schema changes
          are applied before materialized views are (re)created. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/feat_1657.sql
+++ b/liquibase/changes/feat_1657.sql
@@ -1,0 +1,5 @@
+-- Add MD5 hash column to GTFSDataset table (issue #1657)
+-- Many clients rely on MD5 as it is a common hash algorithm for cloud and storage services.
+-- The SHA-256 hash is already stored in the `hash` column.
+ALTER TABLE Gtfsdataset
+    ADD COLUMN IF NOT EXISTS hash_md5 VARCHAR(255);

--- a/web-app/src/app/services/feeds/types.ts
+++ b/web-app/src/app/services/feeds/types.ts
@@ -485,10 +485,15 @@ export interface components {
        */
       downloaded_at?: string;
       /**
-       * @description A hash of the dataset.
+       * @description SHA-256 hash of the dataset.
        * @example ad3805c4941cd37881ff40c342e831b5f5224f3d8a9a2ec3ac197d3652c78e42
        */
       hash?: string;
+      /**
+       * @description MD5 hash of the dataset.
+       * @example 098f6bcd4621d373cade4e832627b4f6
+       */
+      hash_md5?: string;
       /**
        * Format: date-time
        * @description The start date of the service date range for the dataset in UTC. Timing starts at 00:00:00 of the day.
@@ -685,10 +690,15 @@ export interface components {
        */
       downloaded_at?: string;
       /**
-       * @description A hash of the dataset.
+       * @description SHA-256 hash of the dataset.
        * @example 6497e85e34390b8b377130881f2f10ec29c18a80dd6005d504a2038cdd00aa71
        */
       hash?: string;
+      /**
+       * @description MD5 hash of the dataset.
+       * @example 098f6bcd4621d373cade4e832627b4f6
+       */
+      hash_md5?: string;
       bounding_box?: components['schemas']['BoundingBox'];
       validation_report?: components['schemas']['ValidationReport'];
       /**


### PR DESCRIPTION
**Summary:**

This pull request adds support for storing and handling MD5 hashes (`hash_md5`) for GTFS datasets, alongside the existing SHA-256 hashes. It updates the data models, OpenAPI specs, batch processing pipeline, and introduces a new task for backfilling MD5 hashes for existing datasets. The changes also include tests to verify the new functionality.

**MD5 hash support for GTFS datasets:**

* The `hash_md5` field is added to relevant data models (`GtfsDataset`, `LatestDataset`, and `DatasetFile`) and is now populated and returned alongside the SHA-256 hash throughout the API and batch processing pipeline. [[1]](diffhunk://#diff-99004b6b8d6ead0c42524b029efa9422c7cc710ce4bb071e5311bae6a6856f64R50) [[2]](diffhunk://#diff-32fed720316d6d9e26eb0cc5d499ac4f77d49211fbf00b122ac7a597de9e900bR51) [[3]](diffhunk://#diff-00de0f2d6f477a9e5f0e0b86290d41c95a8fc1767527bebbc850f52649f8143aR68) [[4]](diffhunk://#diff-00de0f2d6f477a9e5f0e0b86290d41c95a8fc1767527bebbc850f52649f8143aR469) [[5]](diffhunk://#diff-00de0f2d6f477a9e5f0e0b86290d41c95a8fc1767527bebbc850f52649f8143aR345)
* The OpenAPI specifications in `docs/DatabaseCatalogAPI.yaml` and `docs/OperationsAPI.yaml` are updated to document the new `hash_md5` field and clarify that the `hash` field is a SHA-256 hash. [[1]](diffhunk://#diff-5c03d3e6cdf1372d1fcf8d8f052a511df313c60e8adf41d8b38aecb79f3500ecL925-R931) [[2]](diffhunk://#diff-5c03d3e6cdf1372d1fcf8d8f052a511df313c60e8adf41d8b38aecb79f3500ecL1176-R1186) [[3]](diffhunk://#diff-dc686f899f1eed128145e09835ecd624b366ea49b8b9011753fd04bd7c8a0b61L862-R868) [[4]](diffhunk://#diff-dc686f899f1eed128145e09835ecd624b366ea49b8b9011753fd04bd7c8a0b61L1106-R1116)

**Batch processing and tests:**

* The batch processing pipeline now calculates and stores the MD5 hash of uploaded dataset files, reading it from the GCS blob metadata after upload. Unit tests are added to verify correct extraction and propagation of the MD5 hash. [[1]](diffhunk://#diff-00de0f2d6f477a9e5f0e0b86290d41c95a8fc1767527bebbc850f52649f8143aL159-R180) [[2]](diffhunk://#diff-00de0f2d6f477a9e5f0e0b86290d41c95a8fc1767527bebbc850f52649f8143aL323-R329) [[3]](diffhunk://#diff-3ebe8982d49d5e604e05e65e93fbb1e55919dd64f09129600f24b921244020ecL75-R76) [[4]](diffhunk://#diff-3ebe8982d49d5e604e05e65e93fbb1e55919dd64f09129600f24b921244020ecR104) [[5]](diffhunk://#diff-3ebe8982d49d5e604e05e65e93fbb1e55919dd64f09129600f24b921244020ecR905-R978)

**Backfill support for existing datasets:**

* A new task, `backfill_dataset_hash_md5`, is introduced to backfill MD5 hashes for existing GTFS datasets by reading the hash from GCS blob metadata. Documentation and handler registration for this task are included. [[1]](diffhunk://#diff-722eefb8ec00d2bc8c95d04aa4cdeab2c5674944f1c7122331b03b4d132ab491R96-R116) [[2]](diffhunk://#diff-36efb135e8632484bb21565d09f979e1e20a6c179e2c09d586748dd96de0ef99R32-R34) [[3]](diffhunk://#diff-36efb135e8632484bb21565d09f979e1e20a6c179e2c09d586748dd96de0ef99R115-R122)

**Database migration:**

* Liquibase changelog is updated to add the `hash_md5` column to the `GTFSDataset` table.

**Other documentation and spec improvements:**

* Minor improvements to OpenAPI documentation, such as clarifying hash descriptions and adding example values. [[1]](diffhunk://#diff-5c03d3e6cdf1372d1fcf8d8f052a511df313c60e8adf41d8b38aecb79f3500ecL925-R931) [[2]](diffhunk://#diff-dc686f899f1eed128145e09835ecd624b366ea49b8b9011753fd04bd7c8a0b61L862-R868)

These changes ensure that both SHA-256 and MD5 hashes are consistently tracked and available for all GTFS datasets, improving data integrity and compatibility with external systems.

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
