### PR TITLE
Fix the populate_license_rules call

### DIFF
--- a/scripts/populate-licenses.sh
+++ b/scripts/populate-licenses.sh
@@ -92,8 +92,8 @@ if [[ "$DRY_RUN" == "true" ]]; then PY_DRY=True; else PY_DRY=False; fi
 
 echo "INFO: Running populate_license_rules (dry_run=${DRY_RUN})"
 "$PYTHON_BIN" - <<PYCODE
-from tasks.licenses.populate_license_rules import populate_license_rules_task
-populate_license_rules_task(dry_run=${PY_DRY})
+from tasks.licenses.populate_license_rules import populate_license_rules
+populate_license_rules(dry_run=${PY_DRY})
 PYCODE
 
 echo "INFO: Running populate_licenses (dry_run=${DRY_RUN})"


### PR DESCRIPTION
**Summary:**

Noticed the populate_license_rules was mis-named with populate_license_rules_task which does not exist. Noticed this when trying to rebuild the test db and it gave the error saying that licenses were not populated yet.

**Expected behavior:** 

I think the correct behaviour should be: populate_license_rules should be called in the popualte-licenses.sh script (and upstream in the docker-localdb-rebuild-data.sh script). 

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
