### PR TITLE
feat: add DB table to store GTFS feed availability checks

### DIFF
--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -109,6 +109,8 @@
     <include file="changes/feat_task_execution_log.sql" relativeToChangelogFile="true"/>
     <!-- Add MD5 hash column to GTFSDataset table. -->
     <include file="changes/feat_1657.sql" relativeToChangelogFile="true"/>
+    <!-- Add table to store GTFS feed availability check results. -->
+    <include file="changes/feat_1700.sql" relativeToChangelogFile="true"/>
     <!-- Keep this at the very end to ensure all table and schema changes
          are applied before materialized views are (re)created. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/feat_1700.sql
+++ b/liquibase/changes/feat_1700.sql
@@ -1,12 +1,18 @@
 -- Add table to store GTFS feed availability check results (issue #1700).
 -- Supports feed availability analysis as described in epic #1699.
-CREATE TABLE IF NOT EXISTS gtfsfeedavailabilitycheck (
+CREATE TYPE availability_check_request_type AS ENUM (
+    'http_head',
+    'http_get'
+);
+
+CREATE TABLE IF NOT EXISTS gtfs_feed_availability_check (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
     feed_id      VARCHAR(255) NOT NULL,
     checked_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
 
     request_url  TEXT NOT NULL,
+    request_type availability_check_request_type NOT NULL,
     status_code  INTEGER,
     latency_ms   DOUBLE PRECISION,
 
@@ -17,17 +23,17 @@ CREATE TABLE IF NOT EXISTS gtfsfeedavailabilitycheck (
 
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
 
-    CONSTRAINT gtfsfeedavailabilitycheck_feed_id_fkey
+    CONSTRAINT gtfs_feed_availability_check_feed_id_fkey
         FOREIGN KEY (feed_id)
         REFERENCES gtfsfeed(id)
         ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_feed_checked_at
-    ON gtfsfeedavailabilitycheck (feed_id, checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gtfs_feed_availability_check_feed_checked_at
+    ON gtfs_feed_availability_check (feed_id, checked_at DESC);
 
-CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_checked_at
-    ON gtfsfeedavailabilitycheck (checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gtfs_feed_availability_check_checked_at
+    ON gtfs_feed_availability_check (checked_at DESC);
 
-CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_feed_success_checked_at
-    ON gtfsfeedavailabilitycheck (feed_id, success, checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gtfs_feed_availability_check_feed_success_checked_at
+    ON gtfs_feed_availability_check (feed_id, success, checked_at DESC);

--- a/liquibase/changes/feat_1700.sql
+++ b/liquibase/changes/feat_1700.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS gtfs_feed_availability_check (
     request_url  TEXT NOT NULL,
     request_type availability_check_request_type NOT NULL,
     status_code  INTEGER,
-    latency_ms   DOUBLE PRECISION,
+    latency_ms   INTEGER,
 
     error_message TEXT,
     error_type   VARCHAR(255),

--- a/liquibase/changes/feat_1700.sql
+++ b/liquibase/changes/feat_1700.sql
@@ -1,0 +1,33 @@
+-- Add table to store GTFS feed availability check results (issue #1700).
+-- Supports feed availability analysis as described in epic #1699.
+CREATE TABLE IF NOT EXISTS gtfsfeedavailabilitycheck (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    feed_id      VARCHAR(255) NOT NULL,
+    checked_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    request_url  TEXT NOT NULL,
+    status_code  INTEGER,
+    latency_ms   DOUBLE PRECISION,
+
+    error_message TEXT,
+    error_type   VARCHAR(255),
+
+    success      BOOLEAN NOT NULL,
+
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT gtfsfeedavailabilitycheck_feed_id_fkey
+        FOREIGN KEY (feed_id)
+        REFERENCES gtfsfeed(id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_feed_checked_at
+    ON gtfsfeedavailabilitycheck (feed_id, checked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_checked_at
+    ON gtfsfeedavailabilitycheck (checked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gtfsfeedavailabilitycheck_feed_success_checked_at
+    ON gtfsfeedavailabilitycheck (feed_id, success, checked_at DESC);


### PR DESCRIPTION
**Summary:**

This pull request introduces a new database table and supporting type to store the results of GTFS feed availability checks. This change supports feed availability analysis and tracking by recording the outcome and details of each check.

**Database schema changes:**

* Added a new enum type `availability_check_request_type` to distinguish between HTTP request methods used in feed availability checks.
* Created a new table `gtfs_feed_availability_check` to store detailed results of each GTFS feed availability check, including metadata such as request type, status code, latency, error information, and success flag. The table includes a foreign key to the `gtfsfeed` table and relevant indexes to optimize common queries.
* Updated `liquibase/changelog.xml` to include the new schema migration file `feat_1700.sql` so that the changes are applied during database migrations.

**Expected behavior:** 
The `gtfsfeedavailabilitycheck` table is added to the DB.

**Testing tips:**

- Execute locally:
```sh
./scripts/docker-localdb-rebuild-data.sh
```
- expect that gtfsfeedavailabilitycheck is present locally

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
