### PR TITLE
feat: seed api.announcements notification type

### DIFF
--- a/liquibase/changelog_user.xml
+++ b/liquibase/changelog_user.xml
@@ -15,4 +15,6 @@
     <include file="changes_user/feat_1684.sql" relativeToChangelogFile="true"/>
     <!-- Add feature_flag and user_feature_flag tables -->
     <include file="changes_user/feat_1694.sql" relativeToChangelogFile="true"/>
+    <!-- Seed 'api.announcements' notification type (issue #1729). -->
+    <include file="changes_user/feat_1729.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase/changes_user/feat_1729.sql
+++ b/liquibase/changes_user/feat_1729.sql
@@ -2,3 +2,14 @@
 INSERT INTO notification_type (id, description)
 VALUES ('api.announcements', 'API announcements')
 ON CONFLICT (id) DO NOTHING;
+
+-- Backfill subscriptions for users already opted in (idempotent).
+INSERT INTO notification_subscription (id, user_id, notification_type_id)
+SELECT gen_random_uuid()::text, u.id, 'api.announcements'
+FROM app_user u
+WHERE u.is_registered_to_receive_api_announcements
+  AND NOT EXISTS (
+      SELECT 1 FROM notification_subscription s
+      WHERE s.user_id = u.id
+        AND s.notification_type_id = 'api.announcements'
+  );

--- a/liquibase/changes_user/feat_1729.sql
+++ b/liquibase/changes_user/feat_1729.sql
@@ -1,0 +1,4 @@
+-- Seed 'api.announcements' notification type (idempotent).
+INSERT INTO notification_type (id, description)
+VALUES ('api.announcements', 'API announcements')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
**Summary:**
This pull request introduces a new notification type for API announcements and ensures that existing users who have opted in are properly subscribed. The main changes are:

* Created `liquibase/changes_user/feat_1729.sql` to:
  - Seed the `notification_type` table with a new 'api.announcements' type.
  - Backfill the `notification_subscription` table for users already opted in, ensuring no duplicate subscriptions are created.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
