### PR TITLE
fix: duplicate some Cloud Run IAM grants to functions-python module

### DIFF
--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -42,6 +42,10 @@ locals {
   retention_duration_seconds = lower(var.environment) == "prod" ? 2678400 : 604800
 
   deployment_timestamp = formatdate("YYYYMMDDhhmmss", timestamp())
+
+  function_pmtiles_builder_config = jsondecode(file("${path.module}/../../functions-python/pmtiles_builder/function_config.json"))
+
+  function_gtfs_datasets_comparer_config = jsondecode(file("${path.module}/../../functions-python/gtfs_datasets_comparer/function_config.json"))
 }
 
 data "google_vpc_access_connector" "vpc_connector" {
@@ -479,5 +483,21 @@ resource "google_compute_global_forwarding_rule" "files_http_lb_rule_ipv4" {
   port_range            = "443"
   ip_address            = data.google_compute_global_address.files_http_lb_ipv4.address
   load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_cloud_run_service_iam_member" "pmtiles_builder_invoker" {
+  project  = var.project_id
+  location = var.gcp_region
+  service  = "${local.function_pmtiles_builder_config.name}-${var.environment}"
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.functions_service_account.email}"
+}
+
+resource "google_cloud_run_service_iam_member" "gtfs_datasets_comparer_invoker" {
+  project  = var.project_id
+  location = var.gcp_region
+  service  = "${local.function_gtfs_datasets_comparer_config.name}-${var.environment}"
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.functions_service_account.email}"
 }
 

--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -42,10 +42,6 @@ locals {
   retention_duration_seconds = lower(var.environment) == "prod" ? 2678400 : 604800
 
   deployment_timestamp = formatdate("YYYYMMDDhhmmss", timestamp())
-
-  function_pmtiles_builder_config = jsondecode(file("${path.module}/../../functions-python/pmtiles_builder/function_config.json"))
-
-  function_gtfs_datasets_comparer_config = jsondecode(file("${path.module}/../../functions-python/gtfs_datasets_comparer/function_config.json"))
 }
 
 data "google_vpc_access_connector" "vpc_connector" {
@@ -485,18 +481,3 @@ resource "google_compute_global_forwarding_rule" "files_http_lb_rule_ipv4" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
-resource "google_cloud_run_service_iam_member" "pmtiles_builder_invoker" {
-  project  = var.project_id
-  location = var.gcp_region
-  service  = "${local.function_pmtiles_builder_config.name}-${var.environment}"
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.functions_service_account.email}"
-}
-
-resource "google_cloud_run_service_iam_member" "gtfs_datasets_comparer_invoker" {
-  project  = var.project_id
-  location = var.gcp_region
-  service  = "${local.function_gtfs_datasets_comparer_config.name}-${var.environment}"
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.functions_service_account.email}"
-}

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1036,6 +1036,14 @@ resource "google_cloudfunctions2_function_iam_member" "pmtiles_builder_invoker_b
   member         = "serviceAccount:${local.batchfunctions_sa_email}"
 }
 
+resource "google_cloud_run_service_iam_member" "pmtiles_builder_cloud_run_invoker" {
+  project  = var.project_id
+  location = var.gcp_region
+  service  = google_cloudfunctions2_function.pmtiles_builder.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${local.batchfunctions_sa_email}"
+}
+
 # Grant execution permission to the service account to the pmtiles_builder function
 resource "google_cloudfunctions2_function_iam_member" "pmtiles_builder_invoker" {
   project        = var.project_id
@@ -1052,6 +1060,14 @@ resource "google_cloudfunctions2_function_iam_member" "gtfs_datasets_comparer_in
   cloud_function = google_cloudfunctions2_function.gtfs_datasets_comparer.name
   role           = "roles/cloudfunctions.invoker"
   member         = "serviceAccount:${local.batchfunctions_sa_email}"
+}
+
+resource "google_cloud_run_service_iam_member" "gtfs_datasets_comparer_cloud_run_invoker" {
+  project  = var.project_id
+  location = var.gcp_region
+  service  = google_cloudfunctions2_function.gtfs_datasets_comparer.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${local.batchfunctions_sa_email}"
 }
 
 # Grant execution permission to the functions service account to the gtfs_datasets_comparer function


### PR DESCRIPTION
 ### Problem
This was a new error that happened after merging #1737 

 The `datasets-batch-deployer-dev` workflow was failing with:

Error 404: Resource 'gtfs-datasets-comparer-dev' of kind 'SERVICE' ... does not exist.

 `infra/batch/main.tf` had two `google_cloud_run_service_iam_member` resources that granted `roles/run.invoker` on the `pmtiles-builder-dev` and `gtfs-datasets-comparer-dev` Cloud Run services by **hardcoded name**. These services are deployed by a separate workflow (`api-dev`/`infra/functions-python`), so if they don't exist yet — as was the case after renaming `gtfs-change-tracker` → `gtfs-datasets-comparer` — Terraform fails trying to set IAM on a non-existent resource.
 
 ### Solution
 Moved the two `google_cloud_run_service_iam_member` resources from `infra/batch/main.tf` into `infra/functions-python/main.tf`, co-located with the `google_cloudfunctions2_function` resources that actually create those services. Using `google_cloudfunctions2_function.X.name` as the `service` reference creates an implicit dependency, ensuring the Cloud Run service exists before IAM is applied. This follows the same pattern already used for the `tokens` and `operations_api` functions.
 
 Also removed the now-unused `function_pmtiles_builder_config` and `function_gtfs_datasets_comparer_config` locals from `infra/batch/main.tf`.
 
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
