### PR TITLE
feat: backfill changelog records for existing datasets

### DIFF
--- a/api/src/shared/database/database.py
+++ b/api/src/shared/database/database.py
@@ -98,8 +98,8 @@ cascade_entities = {
     ],
     Gtfsdataset: [
         Gtfsdataset.gtfsfiles,
-        Gtfsdataset.gtfs_dataset_changelogs,  # current_dataset FK
-        Gtfsdataset.gtfs_dataset_changelogs_,  # previous_dataset FK
+        Gtfsdataset.gtfs_dataset_changelogs,  # base_dataset FK
+        Gtfsdataset.gtfs_dataset_changelogs_,  # new_dataset FK
     ],
 }
 

--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -52,13 +52,13 @@ def get_changed_files(
 ) -> List[str]:
     """
     Return the subset of `file_names` whose content hash changed compared to the
-    previous dataset for the same feed.
-      - If there is no previous dataset → any file that exists in the new dataset is considered "changed".
+    base dataset for the same feed.
+      - If there is no base dataset → any file that exists in the new dataset is considered "changed".
       - If the file existed before and now is missing → NOT considered changed.
       - If the file did not exist before but exists now → considered changed.
       - If hashes differ → considered changed.
     """
-    previous_dataset = (
+    base_dataset = (
         db_session.query(Gtfsdataset)
         .filter(
             Gtfsdataset.feed_id == dataset.feed_id,
@@ -70,12 +70,12 @@ def get_changed_files(
 
     new_files = list(dataset.gtfsfiles)
 
-    # No previous dataset -> everything that exists now is "changed"
-    if not previous_dataset:
+    # No base dataset -> everything that exists now is "changed"
+    if not base_dataset:
         return [f.file_name for f in new_files]
 
     prev_map = {
-        f.file_name: getattr(f, "hash", None) for f in previous_dataset.gtfsfiles
+        f.file_name: getattr(f, "hash", None) for f in base_dataset.gtfsfiles
     }
 
     changed_files = []
@@ -141,8 +141,8 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
             f" and changed files: {changed_files}"
         )
 
-    # Create GTFS change tracker task when a previous dataset exists
-    previous_dataset = (
+    # Create GTFS change tracker task when a base dataset exists
+    base_dataset = (
         db_session.query(Gtfsdataset)
         .filter(
             Gtfsdataset.feed_id == dataset.feed_id,
@@ -151,7 +151,7 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
         .order_by(Gtfsdataset.downloaded_at.desc())
         .first()
     )
-    if previous_dataset:
+    if base_dataset:
         # Check the DB for an existing changelog record rather than the GCS blob presence.
         # The unique constraint on (base_dataset_id, new_dataset_id) makes this the
         # authoritative idempotency check. GCS blob presence could be used instead, but that
@@ -160,7 +160,7 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
         changelog_exists = (
             db_session.query(GtfsDatasetChangelog)
             .filter_by(
-                base_dataset_id=previous_dataset.id,
+                base_dataset_id=base_dataset.id,
                 new_dataset_id=dataset.id,
             )
             .first()
@@ -174,11 +174,11 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
         else:
             create_http_gtfs_datasets_comparer_task(
                 feed_stable_id=stable_id,
-                base_dataset_stable_id=previous_dataset.stable_id,
+                base_dataset_stable_id=base_dataset.stable_id,
                 new_dataset_stable_id=dataset_stable_id,
             )
     else:
         logging.info(
-            "Skipping change tracker task for dataset %s: no previous dataset found.",
+            "Skipping change tracker task for dataset %s: no base dataset found.",
             dataset_stable_id,
         )

--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -153,15 +153,15 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
     )
     if previous_dataset:
         # Check the DB for an existing changelog record rather than the GCS blob presence.
-        # The unique constraint on (previous_dataset_id, current_dataset_id) makes this the
+        # The unique constraint on (base_dataset_id, new_dataset_id) makes this the
         # authoritative idempotency check. GCS blob presence could be used instead, but that
         # would require an extra API call and could miss cases where the blob exists but the
         # DB record does not (or vice versa).
         changelog_exists = (
             db_session.query(GtfsDatasetChangelog)
             .filter_by(
-                previous_dataset_id=previous_dataset.id,
-                current_dataset_id=dataset.id,
+                base_dataset_id=previous_dataset.id,
+                new_dataset_id=dataset.id,
             )
             .first()
             is not None

--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -74,9 +74,7 @@ def get_changed_files(
     if not base_dataset:
         return [f.file_name for f in new_files]
 
-    prev_map = {
-        f.file_name: getattr(f, "hash", None) for f in base_dataset.gtfsfiles
-    }
+    prev_map = {f.file_name: getattr(f, "hash", None) for f in base_dataset.gtfsfiles}
 
     changed_files = []
     for f in new_files:

--- a/functions-python/gtfs_datasets_comparer/src/main.py
+++ b/functions-python/gtfs_datasets_comparer/src/main.py
@@ -48,8 +48,8 @@ def gtfs_datasets_comparer(request: flask.Request) -> dict:
 
     Expects a JSON body with:
         feed_stable_id            – stable_id of the GTFS feed
-        base_dataset_stable_id    – stable_id of the base (previous) Gtfsdataset
-        new_dataset_stable_id     – stable_id of the new (current) Gtfsdataset
+        base_dataset_stable_id    – stable_id of the base Gtfsdataset
+        new_dataset_stable_id     – stable_id of the new Gtfsdataset
         disallow_overwrite        – (optional, default false) skip if changelog already exists
         dry_run                   – (optional, default false) compute diff but skip GCS upload and DB write
 
@@ -167,7 +167,7 @@ class GtfsDatasetsComparer:
                 "changelog_url": changelog_url,
             }
 
-        prev_dataset_uuid, curr_dataset_uuid, feed_uuid = self._resolve_datasets()
+        base_dataset_uuid, new_dataset_uuid, feed_uuid = self._resolve_datasets()
 
         self.logger.info(
             "Computing diff for feed %s: %s -> %s",
@@ -176,10 +176,10 @@ class GtfsDatasetsComparer:
             self.new_dataset_stable_id,
         )
 
-        prev_dir = self._extracted_dir(self.feed_stable_id, self.base_dataset_stable_id)
-        curr_dir = self._extracted_dir(self.feed_stable_id, self.new_dataset_stable_id)
+        base_dir = self._extracted_dir(self.feed_stable_id, self.base_dataset_stable_id)
+        new_dir = self._extracted_dir(self.feed_stable_id, self.new_dataset_stable_id)
 
-        diff_result = diff_feeds(prev_dir, curr_dir)
+        diff_result = diff_feeds(base_dir, new_dir)
 
         if self.dry_run:
             self.logger.info("Dry run — skipping GCS upload and DB write.")
@@ -199,8 +199,8 @@ class GtfsDatasetsComparer:
         diff_summary = diff_result.summary.model_dump()
         self._save_changelog_record(
             feed_uuid=feed_uuid,
-            prev_dataset_uuid=prev_dataset_uuid,
-            curr_dataset_uuid=curr_dataset_uuid,
+            base_dataset_uuid=base_dataset_uuid,
+            new_dataset_uuid=new_dataset_uuid,
             changelog_url=changelog_url,
             diff_summary=diff_summary,
         )
@@ -215,36 +215,34 @@ class GtfsDatasetsComparer:
     def _resolve_datasets(self, db_session: Session = None) -> tuple:
         """
         Validate both datasets exist and belong to the given feed.
-        Returns (prev_dataset_uuid, curr_dataset_uuid, feed_uuid) as plain strings.
+        Returns (base_dataset_uuid, new_dataset_uuid, feed_uuid) as plain strings.
         """
-        prev_dataset = (
+        base_dataset = (
             db_session.query(Gtfsdataset)
             .filter(Gtfsdataset.stable_id == self.base_dataset_stable_id)
             .one_or_none()
         )
-        if prev_dataset is None:
-            raise ValueError(
-                f"Previous dataset not found: {self.base_dataset_stable_id}"
-            )
-        if prev_dataset.feed.stable_id != self.feed_stable_id:
+        if base_dataset is None:
+            raise ValueError(f"Base dataset not found: {self.base_dataset_stable_id}")
+        if base_dataset.feed.stable_id != self.feed_stable_id:
             raise ValueError(
                 f"Dataset {self.base_dataset_stable_id} does not belong to feed {self.feed_stable_id}."
             )
 
-        curr_dataset = (
+        new_dataset = (
             db_session.query(Gtfsdataset)
             .filter(Gtfsdataset.stable_id == self.new_dataset_stable_id)
             .one_or_none()
         )
-        if curr_dataset is None:
-            raise ValueError(f"Current dataset not found: {self.new_dataset_stable_id}")
+        if new_dataset is None:
+            raise ValueError(f"New dataset not found: {self.new_dataset_stable_id}")
 
-        if curr_dataset.feed.stable_id != self.feed_stable_id:
+        if new_dataset.feed.stable_id != self.feed_stable_id:
             raise ValueError(
                 f"Dataset {self.new_dataset_stable_id} does not belong to feed {self.feed_stable_id}."
             )
 
-        return prev_dataset.id, curr_dataset.id, curr_dataset.feed.id
+        return base_dataset.id, new_dataset.id, new_dataset.feed.id
 
     def _extracted_dir(self, feed_stable_id: str, dataset_stable_id: str) -> str:
         """
@@ -267,16 +265,16 @@ class GtfsDatasetsComparer:
         self,
         json_bytes: bytes,
         feed_stable_id: str,
-        prev_dataset_id: str,
-        curr_dataset_id: str,
+        base_dataset_id: str,
+        new_dataset_id: str,
     ) -> str:
         """
         Upload the changelog JSON to GCS at:
-          <feed_stable_id>/<curr_dataset_id>/<curr_dataset_id>_<prev_dataset_id>_changelog.json
+          <feed_stable_id>/<new_dataset_id>/<new_dataset_id>_<base_dataset_id>_changelog.json
 
         Returns the GCS public URL.
         """
-        blob_path = f"{feed_stable_id}/{curr_dataset_id}/{curr_dataset_id}_{prev_dataset_id}_changelog.json"
+        blob_path = f"{feed_stable_id}/{new_dataset_id}/{new_dataset_id}_{base_dataset_id}_changelog.json"
         bucket = storage.Client().bucket(self.bucket_name)
         blob = bucket.blob(blob_path)
         blob.upload_from_string(json_bytes, content_type="application/json")
@@ -290,27 +288,27 @@ class GtfsDatasetsComparer:
     def _save_changelog_record(
         self,
         feed_uuid: str,
-        prev_dataset_uuid: str,
-        curr_dataset_uuid: str,
+        base_dataset_uuid: str,
+        new_dataset_uuid: str,
         changelog_url: str,
         diff_summary: dict,
         db_session: Session = None,
     ) -> None:
         """
         Upsert a row into gtfs_dataset_changelog.
-        The UNIQUE constraint on (previous_dataset_id, current_dataset_id) ensures idempotency.
+        The UNIQUE constraint on (base_dataset_id, new_dataset_id) ensures idempotency.
         """
         stmt = (
             insert(GtfsDatasetChangelog)
             .values(
                 feed_id=feed_uuid,
-                previous_dataset_id=prev_dataset_uuid,
-                current_dataset_id=curr_dataset_uuid,
+                base_dataset_id=base_dataset_uuid,
+                new_dataset_id=new_dataset_uuid,
                 changelog_url=changelog_url,
                 diff_summary=diff_summary,
             )
             .on_conflict_do_update(
-                constraint="gtfs_dataset_changelog_previous_current_key",
+                constraint="gtfs_dataset_changelog_base_new_key",
                 set_={
                     "changelog_url": changelog_url,
                     "diff_summary": diff_summary,

--- a/functions-python/gtfs_datasets_comparer/tests/test_main.py
+++ b/functions-python/gtfs_datasets_comparer/tests/test_main.py
@@ -210,8 +210,8 @@ class TestGtfsDatasetsComparerRun(unittest.TestCase):
         )
         mock_save.assert_called_once_with(
             feed_uuid="feed-uuid",
-            prev_dataset_uuid="prev-uuid",
-            curr_dataset_uuid="curr-uuid",
+            base_dataset_uuid="prev-uuid",
+            new_dataset_uuid="curr-uuid",
             changelog_url=changelog_url,
             diff_summary={"total_changes": 42},
         )
@@ -223,9 +223,7 @@ class TestGtfsDatasetsComparerRun(unittest.TestCase):
         mock_storage.return_value.bucket.return_value.blob.return_value.exists.return_value = (
             False
         )
-        mock_resolve.side_effect = ValueError(
-            "Previous dataset not found: mdb-1-20240101"
-        )
+        mock_resolve.side_effect = ValueError("Base dataset not found: mdb-1-20240101")
         with self.assertRaises(ValueError):
             self.tracker.run()
 
@@ -339,22 +337,22 @@ class TestResolveDatasets(unittest.TestCase):
         )
 
     def _mock_session_with_datasets(self):
-        prev_ds = MagicMock()
-        prev_ds.id = "prev-uuid"
-        prev_ds.stable_id = "mdb-1-20240101"
-        prev_ds.feed.id = "feed-uuid"
-        prev_ds.feed.stable_id = "mdb-1"
+        base_ds = MagicMock()
+        base_ds.id = "prev-uuid"
+        base_ds.stable_id = "mdb-1-20240101"
+        base_ds.feed.id = "feed-uuid"
+        base_ds.feed.stable_id = "mdb-1"
 
-        curr_ds = MagicMock()
-        curr_ds.id = "curr-uuid"
-        curr_ds.stable_id = "mdb-1-20240201"
-        curr_ds.feed.id = "feed-uuid"
-        curr_ds.feed.stable_id = "mdb-1"
+        new_ds = MagicMock()
+        new_ds.id = "curr-uuid"
+        new_ds.stable_id = "mdb-1-20240201"
+        new_ds.feed.id = "feed-uuid"
+        new_ds.feed.stable_id = "mdb-1"
 
         mock_session = MagicMock()
         mock_session.query.return_value.filter.return_value.one_or_none.side_effect = [
-            prev_ds,
-            curr_ds,
+            base_ds,
+            new_ds,
         ]
         return mock_session
 
@@ -365,41 +363,41 @@ class TestResolveDatasets(unittest.TestCase):
         close would raise DetachedInstanceError in production."""
         mock_session = self._mock_session_with_datasets()
         result = self.tracker._resolve_datasets(db_session=mock_session)
-        prev_uuid, curr_uuid, feed_uuid = result
-        self.assertIsInstance(prev_uuid, str, "prev_uuid must be a plain string")
-        self.assertIsInstance(curr_uuid, str, "curr_uuid must be a plain string")
+        base_uuid, new_uuid, feed_uuid = result
+        self.assertIsInstance(base_uuid, str, "base_uuid must be a plain string")
+        self.assertIsInstance(new_uuid, str, "new_uuid must be a plain string")
         self.assertIsInstance(feed_uuid, str, "feed_uuid must be a plain string")
-        self.assertEqual(prev_uuid, "prev-uuid")
-        self.assertEqual(curr_uuid, "curr-uuid")
+        self.assertEqual(base_uuid, "prev-uuid")
+        self.assertEqual(new_uuid, "curr-uuid")
         self.assertEqual(feed_uuid, "feed-uuid")
 
     @patch("main.with_db_session", lambda f: f)
-    def test_raises_when_prev_feed_mismatch(self):
-        prev_ds = MagicMock()
-        prev_ds.id = "prev-uuid"
-        prev_ds.feed.stable_id = "mdb-999"  # wrong feed
+    def test_raises_when_base_feed_mismatch(self):
+        base_ds = MagicMock()
+        base_ds.id = "prev-uuid"
+        base_ds.feed.stable_id = "mdb-999"  # wrong feed
 
         mock_session = MagicMock()
         mock_session.query.return_value.filter.return_value.one_or_none.side_effect = [
-            prev_ds,
+            base_ds,
         ]
         with self.assertRaises(
-            ValueError, msg="should reject prev dataset from wrong feed"
+            ValueError, msg="should reject base dataset from wrong feed"
         ):
             self.tracker._resolve_datasets(db_session=mock_session)
 
     @patch("main.with_db_session", lambda f: f)
     def test_raises_when_feed_mismatch(self):
-        prev_ds = MagicMock()
-        prev_ds.id = "prev-uuid"
-        curr_ds = MagicMock()
-        curr_ds.id = "curr-uuid"
-        curr_ds.feed.stable_id = "mdb-999"  # wrong feed
+        base_ds = MagicMock()
+        base_ds.id = "prev-uuid"
+        new_ds = MagicMock()
+        new_ds.id = "curr-uuid"
+        new_ds.feed.stable_id = "mdb-999"  # wrong feed
 
         mock_session = MagicMock()
         mock_session.query.return_value.filter.return_value.one_or_none.side_effect = [
-            prev_ds,
-            curr_ds,
+            base_ds,
+            new_ds,
         ]
         with self.assertRaises(ValueError, msg="should reject dataset from wrong feed"):
             self.tracker._resolve_datasets(db_session=mock_session)

--- a/functions-python/helpers/utils.py
+++ b/functions-python/helpers/utils.py
@@ -539,9 +539,13 @@ def create_http_gtfs_datasets_comparer_task(
     feed_stable_id: str,
     base_dataset_stable_id: str,
     new_dataset_stable_id: str,
+    disallow_overwrite: bool = True,
 ) -> None:
     """
     Create a Cloud Task to run the gtfs-datasets-comparer function for a pair of datasets.
+
+    disallow_overwrite: when True (default) the comparer skips the pair if its changelog
+    already exists; pass False to force regeneration/overwrite.
     """
     from google.cloud import tasks_v2
     import json
@@ -552,7 +556,7 @@ def create_http_gtfs_datasets_comparer_task(
             "feed_stable_id": feed_stable_id,
             "base_dataset_stable_id": base_dataset_stable_id,
             "new_dataset_stable_id": new_dataset_stable_id,
-            "disallow_overwrite": True,
+            "disallow_overwrite": disallow_overwrite,
         }
     ).encode()
     queue_name = os.getenv("GTFS_CHANGE_TRACKER_QUEUE")

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -247,7 +247,7 @@ The task is **idempotent / restartable**: pairs that already have a changelog ro
 | `datasets_per_feed` | int | `3` | Number of most recent datasets considered per feed. `N` datasets produce up to `N-1` consecutive pairs (must be `>= 2`) |
 | `stable_feed_ids` | list[str] \| null | `null` | If provided, only process feeds with these stable IDs |
 | `feeds_not_updated_days` | int \| null | `null` | If provided, only process feeds whose most recent dataset is older than this many days (e.g. `30` to target feeds not updated in the last month) |
-| `force` | bool | `false` | If `true`, dispatch every pair even when a changelog row already exists (forces a rerun) |
+| `force` | bool | `false` | If `true`, dispatch every pair even when a changelog row already exists, and run the comparer with `disallow_overwrite=false` so existing changelogs are regenerated (forces a full rerun) |
 
 **Required environment variables**: `GTFS_CHANGE_TRACKER_QUEUE`, `PROJECT_ID`, `GCP_REGION`, `ENVIRONMENT` (used to dispatch Cloud Tasks to the `gtfs-datasets-comparer` function).
 

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -226,6 +226,8 @@ Backfills `gtfs_dataset_changelog` records from the **existing** dataset history
 
 The task is **idempotent / restartable**: pairs that already have a changelog row are skipped (unless `force` is set), and each dispatched Cloud Task runs with `disallow_overwrite=true`. It is **rate-limited**: `limit` caps how many feeds are processed per invocation, and a dedicated Cloud Tasks queue (`GTFS_CHANGE_TRACKER_QUEUE`) throttles the actual comparer invocations. Call it repeatedly to walk the whole catalog.
 
+Only **comparable** datasets are considered: a dataset must have a `downloaded_at` timestamp and extracted GTFS files registered in the db (`gtfsfile` rows), since the comparer reads those pre-extracted files. Datasets without extracted files are skipped, and a feed needs at least two comparable datasets to produce a pair.
+
 ```json
 {
   "task": "backfill_changelog",

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -219,3 +219,45 @@ Migrates Firebase Auth users into the `users.app_user` PostgreSQL table. This ta
 | `brevo_not_found` | Users not found in Brevo |
 | `brevo_failed` | Users where the Brevo check failed (non-fatal; user is still inserted) |
 | `dry_run` | Whether the task ran in dry-run mode |
+
+### `backfill_changelog`
+
+Backfills `gtfs_dataset_changelog` records from the **existing** dataset history. The live pipeline (`batch_process_dataset` → `gtfs-datasets-comparer`) only produces changelogs for new datasets going forward; this task walks the stored history and, for each consecutive `(previous, current)` dataset pair that has no changelog row yet, dispatches a Cloud Task to the same `gtfs-datasets-comparer` function.
+
+The task is **idempotent / restartable**: pairs that already have a changelog row are skipped, and each dispatched Cloud Task runs with `disallow_overwrite=true`. It is **rate-limited**: `limit` caps how many feeds are processed per invocation, and a dedicated Cloud Tasks queue (`GTFS_CHANGE_TRACKER_QUEUE`) throttles the actual comparer invocations. Call it repeatedly to walk the whole catalog.
+
+```json
+{
+  "task": "backfill_changelog",
+  "payload": {
+    "dry_run": true,
+    "limit": 100,
+    "datasets_per_feed": 3,
+    "stable_feed_ids": null,
+    "feeds_not_updated_days": null
+  }
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `dry_run` | bool | `true` | Enumerate the pairs that would be dispatched without creating any Cloud Task. The response includes a `dispatched` list of the pairs |
+| `limit` | int \| null | `100` | Maximum number of feeds processed per invocation; omit or pass `null` for no limit |
+| `datasets_per_feed` | int | `3` | Number of most recent datasets considered per feed. `N` datasets produce up to `N-1` consecutive pairs (must be `>= 2`) |
+| `stable_feed_ids` | list[str] \| null | `null` | If provided, only process feeds with these stable IDs |
+| `feeds_not_updated_days` | int \| null | `null` | If provided, only process feeds whose most recent dataset is older than this many days (e.g. `30` to target feeds not updated in the last month) |
+
+**Required environment variables**: `GTFS_CHANGE_TRACKER_QUEUE`, `PROJECT_ID`, `GCP_REGION`, `ENVIRONMENT` (used to dispatch Cloud Tasks to the `gtfs-datasets-comparer` function).
+
+> Note: the comparer reads the pre-extracted GTFS files from the datasets bucket (`<feed>/<dataset>/extracted/`). Historical datasets whose extracted files are no longer present will surface as comparer-side errors (logged, HTTP 200); the backfill dispatch itself still succeeds.
+
+**Response fields**:
+
+| Field | Description |
+|---|---|
+| `feeds_processed` | Feeds that had at least one consecutive pair to consider |
+| `feeds_skipped_recent` | Feeds skipped because of `feeds_not_updated_days` |
+| `pairs_found` | Total consecutive pairs examined |
+| `pairs_already_done` | Pairs skipped because a changelog row already exists |
+| `pairs_dispatched` | Pairs dispatched (or, in `dry_run`, that would be dispatched) |
+| `dispatched` | (dry-run only) list of `{feed_stable_id, base_dataset_stable_id, new_dataset_stable_id}` |

--- a/functions-python/tasks_executor/README.md
+++ b/functions-python/tasks_executor/README.md
@@ -222,9 +222,9 @@ Migrates Firebase Auth users into the `users.app_user` PostgreSQL table. This ta
 
 ### `backfill_changelog`
 
-Backfills `gtfs_dataset_changelog` records from the **existing** dataset history. The live pipeline (`batch_process_dataset` → `gtfs-datasets-comparer`) only produces changelogs for new datasets going forward; this task walks the stored history and, for each consecutive `(previous, current)` dataset pair that has no changelog row yet, dispatches a Cloud Task to the same `gtfs-datasets-comparer` function.
+Backfills `gtfs_dataset_changelog` records from the **existing** dataset history. The live pipeline (`batch_process_dataset` → `gtfs-datasets-comparer`) only produces changelogs for new datasets going forward; this task walks the stored history and, for each consecutive `(base, new)` dataset pair that has no changelog row yet, dispatches a Cloud Task to the same `gtfs-datasets-comparer` function.
 
-The task is **idempotent / restartable**: pairs that already have a changelog row are skipped, and each dispatched Cloud Task runs with `disallow_overwrite=true`. It is **rate-limited**: `limit` caps how many feeds are processed per invocation, and a dedicated Cloud Tasks queue (`GTFS_CHANGE_TRACKER_QUEUE`) throttles the actual comparer invocations. Call it repeatedly to walk the whole catalog.
+The task is **idempotent / restartable**: pairs that already have a changelog row are skipped (unless `force` is set), and each dispatched Cloud Task runs with `disallow_overwrite=true`. It is **rate-limited**: `limit` caps how many feeds are processed per invocation, and a dedicated Cloud Tasks queue (`GTFS_CHANGE_TRACKER_QUEUE`) throttles the actual comparer invocations. Call it repeatedly to walk the whole catalog.
 
 ```json
 {
@@ -234,7 +234,8 @@ The task is **idempotent / restartable**: pairs that already have a changelog ro
     "limit": 100,
     "datasets_per_feed": 3,
     "stable_feed_ids": null,
-    "feeds_not_updated_days": null
+    "feeds_not_updated_days": null,
+    "force": false
   }
 }
 ```
@@ -246,6 +247,7 @@ The task is **idempotent / restartable**: pairs that already have a changelog ro
 | `datasets_per_feed` | int | `3` | Number of most recent datasets considered per feed. `N` datasets produce up to `N-1` consecutive pairs (must be `>= 2`) |
 | `stable_feed_ids` | list[str] \| null | `null` | If provided, only process feeds with these stable IDs |
 | `feeds_not_updated_days` | int \| null | `null` | If provided, only process feeds whose most recent dataset is older than this many days (e.g. `30` to target feeds not updated in the last month) |
+| `force` | bool | `false` | If `true`, dispatch every pair even when a changelog row already exists (forces a rerun) |
 
 **Required environment variables**: `GTFS_CHANGE_TRACKER_QUEUE`, `PROJECT_ID`, `GCP_REGION`, `ENVIRONMENT` (used to dispatch Cloud Tasks to the `gtfs-datasets-comparer` function).
 

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -65,6 +65,7 @@ from tasks.feed_availability.check_gtfs_feed_availability import (
     check_gtfs_feed_availability_handler,
 )
 from tasks.users.migrate_firebase_users import migrate_firebase_users_handler
+from tasks.changelog.backfill_changelog import backfill_changelog_handler
 
 init_logger()
 LIST_COMMAND: Final[str] = "list"
@@ -173,6 +174,17 @@ tasks = {
             "user_ids (default null), only_not_migrated (default true)."
         ),
         "handler": migrate_firebase_users_handler,
+    },
+    "backfill_changelog": {
+        "description": (
+            "Backfills gtfs_dataset_changelog records from existing dataset history by "
+            "dispatching Cloud Tasks to the gtfs-datasets-comparer function for each "
+            "consecutive (previous, current) dataset pair that has no changelog row yet. "
+            "Parameters: dry_run (default true), limit (default 100), "
+            "datasets_per_feed (default 3), stable_feed_ids (default null), "
+            "feeds_not_updated_days (default null)."
+        ),
+        "handler": backfill_changelog_handler,
     },
 }
 

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -179,7 +179,7 @@ tasks = {
         "description": (
             "Backfills gtfs_dataset_changelog records from existing dataset history by "
             "dispatching Cloud Tasks to the gtfs-datasets-comparer function for each "
-            "consecutive (previous, current) dataset pair that has no changelog row yet. "
+            "consecutive (base, new) dataset pair that has no changelog row yet. "
             "Parameters: dry_run (default true), limit (default 100), "
             "datasets_per_feed (default 3), stable_feed_ids (default null), "
             "feeds_not_updated_days (default null)."

--- a/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
+++ b/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
@@ -23,7 +23,8 @@ gtfs-datasets-comparer function that the live pipeline uses.
 
 The task is:
   * idempotent / restartable — pairs that already have a changelog row are skipped,
-    and the dispatched Cloud Task itself runs with disallow_overwrite=True.
+    and the dispatched Cloud Task runs with disallow_overwrite=True (unless `force`,
+    which sets disallow_overwrite=False to regenerate even existing changelogs).
   * rate-limited — `limit` caps how many feeds are processed per invocation, and the
     dedicated Cloud Tasks queue throttles the actual comparer invocations.
 """
@@ -274,6 +275,7 @@ def backfill_changelog(
                     feed_stable_id=feed.stable_id,
                     base_dataset_stable_id=base.stable_id,
                     new_dataset_stable_id=new.stable_id,
+                    disallow_overwrite=not force,
                 )
 
     result = {

--- a/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
+++ b/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
@@ -117,7 +117,8 @@ def get_feeds_query(
 
     If stable_feed_ids is provided, restrict results to those specific stable IDs.
     If min_datasets is provided, restrict to feeds that have at least that many
-    datasets with a downloaded_at timestamp (i.e. enough to form a pair).
+    *comparable* datasets — ones with a downloaded_at timestamp AND extracted GTFS
+    files registered in the db (gtfsfile rows), since the comparer reads those.
     """
     query = db_session.query(Gtfsfeed).filter(
         Feed.data_type == "gtfs",
@@ -127,7 +128,10 @@ def get_feeds_query(
     if min_datasets is not None:
         feeds_with_enough_datasets = (
             select(Gtfsdataset.feed_id)
-            .where(Gtfsdataset.downloaded_at.isnot(None))
+            .where(
+                Gtfsdataset.downloaded_at.isnot(None),
+                Gtfsdataset.gtfsfiles.any(),
+            )
             .group_by(Gtfsdataset.feed_id)
             .having(func.count(Gtfsdataset.id) >= min_datasets)
         )
@@ -140,7 +144,10 @@ def get_feeds_query(
 def get_recent_datasets(
     db_session: Session, feed_id: str, datasets_per_feed: int
 ) -> list[Gtfsdataset]:
-    """Return the `datasets_per_feed` most recent datasets for a feed, oldest first.
+    """Return the `datasets_per_feed` most recent comparable datasets, oldest first.
+
+    Only datasets with extracted GTFS files (gtfsfile rows) are considered, since the
+    comparer reads those pre-extracted files; a dataset without them can't be compared.
 
     We order by downloaded_at DESC + LIMIT to grab the *most recent* N datasets
     (ASC + LIMIT would grab the oldest N), then reverse in Python so the list is
@@ -151,6 +158,7 @@ def get_recent_datasets(
         .filter(
             Gtfsdataset.feed_id == feed_id,
             Gtfsdataset.downloaded_at.isnot(None),
+            Gtfsdataset.gtfsfiles.any(),
         )
         .order_by(Gtfsdataset.downloaded_at.desc())
         .limit(datasets_per_feed)

--- a/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
+++ b/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
@@ -17,7 +17,7 @@
 
 The live pipeline (batch_process_dataset -> gtfs-datasets-comparer) only produces
 changelog records for *new* datasets going forward. This task walks the already
-stored dataset history and, for each consecutive (previous, current) pair that has
+stored dataset history and, for each consecutive (base, new) pair that has
 no gtfs_dataset_changelog row yet, dispatches a Cloud Task to the same
 gtfs-datasets-comparer function that the live pipeline uses.
 
@@ -32,6 +32,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from shared.database.database import with_db_session
@@ -44,10 +45,11 @@ from shared.database_gen.sqlacodegen_models import (
 from shared.helpers.utils import create_http_gtfs_datasets_comparer_task
 
 # Default number of most recent datasets to consider per feed. With 3 datasets we
-# compute 2 diffs: (latest, previous) and (previous, the one before) — matching the
-# issue's request to backfill the last three datasets.
+# compute 2 diffs from consecutive pairs: (d-2 -> d-1) and (d-1 -> latest).
 DEFAULT_DATASETS_PER_FEED: int = 3
 DEFAULT_LIMIT: int = 100
+# Minimum datasets a feed must have to form at least one (base, new) pair.
+MIN_DATASETS_FOR_PAIR: int = 2
 
 
 def get_parameters(payload: dict):
@@ -56,7 +58,15 @@ def get_parameters(payload: dict):
     datasets_per_feed = payload.get("datasets_per_feed", DEFAULT_DATASETS_PER_FEED)
     stable_feed_ids = payload.get("stable_feed_ids", None)
     feeds_not_updated_days = payload.get("feeds_not_updated_days", None)
-    return dry_run, limit, datasets_per_feed, stable_feed_ids, feeds_not_updated_days
+    force = payload.get("force", False)
+    return (
+        dry_run,
+        limit,
+        datasets_per_feed,
+        stable_feed_ids,
+        feeds_not_updated_days,
+        force,
+    )
 
 
 def backfill_changelog_handler(payload: dict) -> dict:
@@ -72,7 +82,12 @@ def backfill_changelog_handler(payload: dict) -> dict:
                                  N datasets produce up to N-1 consecutive pairs. Default: 3.
         stable_feed_ids (list[str] | None): If provided, only process these feeds. Default: None.
         feeds_not_updated_days (int | None): If provided, only process feeds whose most recent
-                                 dataset was downloaded more than this many days ago. Default: None.
+                                 dataset was downloaded more than this many days ago. Implements
+                                 the requirement to target feeds that haven't been updated in a
+                                 while (e.g. 30 to backfill feeds untouched in the last month).
+                                 Default: None (all feeds).
+        force (bool): If True, dispatch every pair even when a changelog row already exists
+                      (use to force a rerun). Default: False.
     """
     (
         dry_run,
@@ -80,6 +95,7 @@ def backfill_changelog_handler(payload: dict) -> dict:
         datasets_per_feed,
         stable_feed_ids,
         feeds_not_updated_days,
+        force,
     ) = get_parameters(payload)
     return backfill_changelog(
         dry_run=dry_run,
@@ -87,19 +103,34 @@ def backfill_changelog_handler(payload: dict) -> dict:
         datasets_per_feed=datasets_per_feed,
         stable_feed_ids=stable_feed_ids,
         feeds_not_updated_days=feeds_not_updated_days,
+        force=force,
     )
 
 
-def get_feeds_query(db_session: Session, stable_feed_ids: Optional[list[str]] = None):
+def get_feeds_query(
+    db_session: Session,
+    stable_feed_ids: Optional[list[str]] = None,
+    min_datasets: Optional[int] = None,
+):
     """Return a query for non-deprecated, published GTFS feeds.
 
     If stable_feed_ids is provided, restrict results to those specific stable IDs.
+    If min_datasets is provided, restrict to feeds that have at least that many
+    datasets with a downloaded_at timestamp (i.e. enough to form a pair).
     """
     query = db_session.query(Gtfsfeed).filter(
         Feed.data_type == "gtfs",
         Feed.status != "deprecated",
         Feed.operational_status == "published",
     )
+    if min_datasets is not None:
+        feeds_with_enough_datasets = (
+            select(Gtfsdataset.feed_id)
+            .where(Gtfsdataset.downloaded_at.isnot(None))
+            .group_by(Gtfsdataset.feed_id)
+            .having(func.count(Gtfsdataset.id) >= min_datasets)
+        )
+        query = query.filter(Feed.id.in_(feeds_with_enough_datasets))
     if stable_feed_ids is not None:
         query = query.filter(Feed.stable_id.in_(stable_feed_ids))
     return query.order_by(Feed.stable_id)
@@ -110,7 +141,9 @@ def get_recent_datasets(
 ) -> list[Gtfsdataset]:
     """Return the `datasets_per_feed` most recent datasets for a feed, oldest first.
 
-    Ordering oldest-first lets us build consecutive (previous, current) pairs directly.
+    We order by downloaded_at DESC + LIMIT to grab the *most recent* N datasets
+    (ASC + LIMIT would grab the oldest N), then reverse in Python so the list is
+    oldest-first, which lets us build consecutive (base, new) pairs directly.
     """
     datasets = (
         db_session.query(Gtfsdataset)
@@ -126,14 +159,14 @@ def get_recent_datasets(
 
 
 def changelog_exists(
-    db_session: Session, previous_dataset_id: str, current_dataset_id: str
+    db_session: Session, base_dataset_id: str, new_dataset_id: str
 ) -> bool:
     """Authoritative idempotency check against the gtfs_dataset_changelog table."""
     return (
         db_session.query(GtfsDatasetChangelog.id)
         .filter_by(
-            previous_dataset_id=previous_dataset_id,
-            current_dataset_id=current_dataset_id,
+            base_dataset_id=base_dataset_id,
+            new_dataset_id=new_dataset_id,
         )
         .first()
         is not None
@@ -148,13 +181,15 @@ def backfill_changelog(
     datasets_per_feed: int = DEFAULT_DATASETS_PER_FEED,
     stable_feed_ids: Optional[list[str]] = None,
     feeds_not_updated_days: Optional[int] = None,
+    force: bool = False,
 ) -> dict:
     """
     Walk the stored dataset history and dispatch comparer Cloud Tasks for missing pairs.
 
     For each eligible GTFS feed, take its `datasets_per_feed` most recent datasets,
-    form consecutive (previous, current) pairs, and — for each pair without an existing
-    changelog row — dispatch a Cloud Task to the gtfs-datasets-comparer function.
+    form consecutive (base, new) pairs, and — for each pair without an existing
+    changelog row (unless `force`) — dispatch a Cloud Task to the gtfs-datasets-comparer
+    function.
 
     Args:
         db_session: SQLAlchemy session (injected by @with_db_session).
@@ -164,13 +199,16 @@ def backfill_changelog(
         stable_feed_ids: If provided, only process feeds with these stable IDs.
         feeds_not_updated_days: If provided, only process feeds whose most recent dataset
                                 is older than this many days.
+        force: If True, dispatch every pair even when a changelog row already exists.
 
     Returns:
         dict: Summary with feeds processed, pairs found, pairs skipped (already done),
               and pairs dispatched.
     """
-    if datasets_per_feed < 2:
-        raise ValueError("datasets_per_feed must be >= 2 to form at least one pair.")
+    if datasets_per_feed < MIN_DATASETS_FOR_PAIR:
+        raise ValueError(
+            f"datasets_per_feed must be >= {MIN_DATASETS_FOR_PAIR} to form at least one pair."
+        )
 
     cutoff = (
         datetime.now(timezone.utc) - timedelta(days=feeds_not_updated_days)
@@ -178,13 +216,25 @@ def backfill_changelog(
         else None
     )
 
-    query = get_feeds_query(db_session, stable_feed_ids=stable_feed_ids)
+    # Validate requested feeds exist (as published GTFS feeds) independently of the
+    # min-datasets filter, so a feed that simply lacks history yields no misleading error.
     if stable_feed_ids is not None:
-        found = {feed.stable_id for feed in query.all()}
+        found = {
+            feed.stable_id
+            for feed in get_feeds_query(
+                db_session, stable_feed_ids=stable_feed_ids
+            ).all()
+        }
         missing = sorted(set(stable_feed_ids) - found)
         if missing:
             raise ValueError(f"stable_feed_ids not found: {missing}")
 
+    # Only feeds with enough datasets to form at least one pair are processed.
+    query = get_feeds_query(
+        db_session,
+        stable_feed_ids=stable_feed_ids,
+        min_datasets=MIN_DATASETS_FOR_PAIR,
+    )
     if limit is not None:
         query = query.limit(limit)
     feeds = query.all()
@@ -198,8 +248,6 @@ def backfill_changelog(
 
     for feed in feeds:
         datasets = get_recent_datasets(db_session, feed.id, datasets_per_feed)
-        if len(datasets) < 2:
-            continue
 
         if cutoff is not None and datasets[-1].downloaded_at >= cutoff:
             # Most recent dataset is newer than the cutoff — feed updated recently, skip.
@@ -208,27 +256,24 @@ def backfill_changelog(
 
         feeds_processed += 1
 
-        for previous, current in zip(datasets, datasets[1:]):
+        for base, new in zip(datasets, datasets[1:]):
             pairs_found += 1
-            if changelog_exists(db_session, previous.id, current.id):
+            if not force and changelog_exists(db_session, base.id, new.id):
                 pairs_already_done += 1
                 continue
             pairs_dispatched += 1
             dispatched.append(
                 {
                     "feed_stable_id": feed.stable_id,
-                    "base_dataset_stable_id": previous.stable_id,
-                    "new_dataset_stable_id": current.stable_id,
+                    "base_dataset_stable_id": base.stable_id,
+                    "new_dataset_stable_id": new.stable_id,
                 }
             )
             if not dry_run:
-                # ponytail: missing extracted GTFS files on the bucket for old datasets
-                # surface as comparer-side errors (logged, HTTP 200), not here. If that
-                # becomes common, pre-check the extracted/ prefix before dispatching.
                 create_http_gtfs_datasets_comparer_task(
                     feed_stable_id=feed.stable_id,
-                    base_dataset_stable_id=previous.stable_id,
-                    new_dataset_stable_id=current.stable_id,
+                    base_dataset_stable_id=base.stable_id,
+                    new_dataset_stable_id=new.stable_id,
                 )
 
     result = {
@@ -239,6 +284,7 @@ def backfill_changelog(
             f"{pairs_already_done} already done."
         ),
         "dry_run": dry_run,
+        "force": force,
         "feeds_processed": feeds_processed,
         "feeds_skipped_recent": feeds_skipped_recent,
         "pairs_found": pairs_found,

--- a/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
+++ b/functions-python/tasks_executor/src/tasks/changelog/backfill_changelog.py
@@ -1,0 +1,251 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Backfill GTFS dataset changelog records for the existing dataset history.
+
+The live pipeline (batch_process_dataset -> gtfs-datasets-comparer) only produces
+changelog records for *new* datasets going forward. This task walks the already
+stored dataset history and, for each consecutive (previous, current) pair that has
+no gtfs_dataset_changelog row yet, dispatches a Cloud Task to the same
+gtfs-datasets-comparer function that the live pipeline uses.
+
+The task is:
+  * idempotent / restartable — pairs that already have a changelog row are skipped,
+    and the dispatched Cloud Task itself runs with disallow_overwrite=True.
+  * rate-limited — `limit` caps how many feeds are processed per invocation, and the
+    dedicated Cloud Tasks queue throttles the actual comparer invocations.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import (
+    Feed,
+    GtfsDatasetChangelog,
+    Gtfsdataset,
+    Gtfsfeed,
+)
+from shared.helpers.utils import create_http_gtfs_datasets_comparer_task
+
+# Default number of most recent datasets to consider per feed. With 3 datasets we
+# compute 2 diffs: (latest, previous) and (previous, the one before) — matching the
+# issue's request to backfill the last three datasets.
+DEFAULT_DATASETS_PER_FEED: int = 3
+DEFAULT_LIMIT: int = 100
+
+
+def get_parameters(payload: dict):
+    dry_run = payload.get("dry_run", True)
+    limit = payload.get("limit", DEFAULT_LIMIT)
+    datasets_per_feed = payload.get("datasets_per_feed", DEFAULT_DATASETS_PER_FEED)
+    stable_feed_ids = payload.get("stable_feed_ids", None)
+    feeds_not_updated_days = payload.get("feeds_not_updated_days", None)
+    return dry_run, limit, datasets_per_feed, stable_feed_ids, feeds_not_updated_days
+
+
+def backfill_changelog_handler(payload: dict) -> dict:
+    """
+    Handler for backfilling GTFS dataset changelog records from existing datasets.
+
+    Payload parameters:
+        dry_run (bool): If True, only enumerate the dataset pairs that would be
+                        dispatched — no Cloud Tasks are created. Default: True.
+        limit (int | None): Maximum number of feeds processed per invocation.
+                            Call repeatedly to walk through every feed. Default: 100.
+        datasets_per_feed (int): Number of most recent datasets to consider per feed.
+                                 N datasets produce up to N-1 consecutive pairs. Default: 3.
+        stable_feed_ids (list[str] | None): If provided, only process these feeds. Default: None.
+        feeds_not_updated_days (int | None): If provided, only process feeds whose most recent
+                                 dataset was downloaded more than this many days ago. Default: None.
+    """
+    (
+        dry_run,
+        limit,
+        datasets_per_feed,
+        stable_feed_ids,
+        feeds_not_updated_days,
+    ) = get_parameters(payload)
+    return backfill_changelog(
+        dry_run=dry_run,
+        limit=limit,
+        datasets_per_feed=datasets_per_feed,
+        stable_feed_ids=stable_feed_ids,
+        feeds_not_updated_days=feeds_not_updated_days,
+    )
+
+
+def get_feeds_query(db_session: Session, stable_feed_ids: Optional[list[str]] = None):
+    """Return a query for non-deprecated, published GTFS feeds.
+
+    If stable_feed_ids is provided, restrict results to those specific stable IDs.
+    """
+    query = db_session.query(Gtfsfeed).filter(
+        Feed.data_type == "gtfs",
+        Feed.status != "deprecated",
+        Feed.operational_status == "published",
+    )
+    if stable_feed_ids is not None:
+        query = query.filter(Feed.stable_id.in_(stable_feed_ids))
+    return query.order_by(Feed.stable_id)
+
+
+def get_recent_datasets(
+    db_session: Session, feed_id: str, datasets_per_feed: int
+) -> list[Gtfsdataset]:
+    """Return the `datasets_per_feed` most recent datasets for a feed, oldest first.
+
+    Ordering oldest-first lets us build consecutive (previous, current) pairs directly.
+    """
+    datasets = (
+        db_session.query(Gtfsdataset)
+        .filter(
+            Gtfsdataset.feed_id == feed_id,
+            Gtfsdataset.downloaded_at.isnot(None),
+        )
+        .order_by(Gtfsdataset.downloaded_at.desc())
+        .limit(datasets_per_feed)
+        .all()
+    )
+    return list(reversed(datasets))
+
+
+def changelog_exists(
+    db_session: Session, previous_dataset_id: str, current_dataset_id: str
+) -> bool:
+    """Authoritative idempotency check against the gtfs_dataset_changelog table."""
+    return (
+        db_session.query(GtfsDatasetChangelog.id)
+        .filter_by(
+            previous_dataset_id=previous_dataset_id,
+            current_dataset_id=current_dataset_id,
+        )
+        .first()
+        is not None
+    )
+
+
+@with_db_session
+def backfill_changelog(
+    db_session: Session,
+    dry_run: bool = True,
+    limit: Optional[int] = DEFAULT_LIMIT,
+    datasets_per_feed: int = DEFAULT_DATASETS_PER_FEED,
+    stable_feed_ids: Optional[list[str]] = None,
+    feeds_not_updated_days: Optional[int] = None,
+) -> dict:
+    """
+    Walk the stored dataset history and dispatch comparer Cloud Tasks for missing pairs.
+
+    For each eligible GTFS feed, take its `datasets_per_feed` most recent datasets,
+    form consecutive (previous, current) pairs, and — for each pair without an existing
+    changelog row — dispatch a Cloud Task to the gtfs-datasets-comparer function.
+
+    Args:
+        db_session: SQLAlchemy session (injected by @with_db_session).
+        dry_run: If True, only enumerate pairs; do not dispatch Cloud Tasks.
+        limit: Maximum number of feeds processed in this invocation.
+        datasets_per_feed: Number of most recent datasets considered per feed.
+        stable_feed_ids: If provided, only process feeds with these stable IDs.
+        feeds_not_updated_days: If provided, only process feeds whose most recent dataset
+                                is older than this many days.
+
+    Returns:
+        dict: Summary with feeds processed, pairs found, pairs skipped (already done),
+              and pairs dispatched.
+    """
+    if datasets_per_feed < 2:
+        raise ValueError("datasets_per_feed must be >= 2 to form at least one pair.")
+
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=feeds_not_updated_days)
+        if feeds_not_updated_days is not None
+        else None
+    )
+
+    query = get_feeds_query(db_session, stable_feed_ids=stable_feed_ids)
+    if stable_feed_ids is not None:
+        found = {feed.stable_id for feed in query.all()}
+        missing = sorted(set(stable_feed_ids) - found)
+        if missing:
+            raise ValueError(f"stable_feed_ids not found: {missing}")
+
+    if limit is not None:
+        query = query.limit(limit)
+    feeds = query.all()
+
+    feeds_processed = 0
+    feeds_skipped_recent = 0
+    pairs_found = 0
+    pairs_already_done = 0
+    pairs_dispatched = 0
+    dispatched: list[dict] = []
+
+    for feed in feeds:
+        datasets = get_recent_datasets(db_session, feed.id, datasets_per_feed)
+        if len(datasets) < 2:
+            continue
+
+        if cutoff is not None and datasets[-1].downloaded_at >= cutoff:
+            # Most recent dataset is newer than the cutoff — feed updated recently, skip.
+            feeds_skipped_recent += 1
+            continue
+
+        feeds_processed += 1
+
+        for previous, current in zip(datasets, datasets[1:]):
+            pairs_found += 1
+            if changelog_exists(db_session, previous.id, current.id):
+                pairs_already_done += 1
+                continue
+            pairs_dispatched += 1
+            dispatched.append(
+                {
+                    "feed_stable_id": feed.stable_id,
+                    "base_dataset_stable_id": previous.stable_id,
+                    "new_dataset_stable_id": current.stable_id,
+                }
+            )
+            if not dry_run:
+                # ponytail: missing extracted GTFS files on the bucket for old datasets
+                # surface as comparer-side errors (logged, HTTP 200), not here. If that
+                # becomes common, pre-check the extracted/ prefix before dispatching.
+                create_http_gtfs_datasets_comparer_task(
+                    feed_stable_id=feed.stable_id,
+                    base_dataset_stable_id=previous.stable_id,
+                    new_dataset_stable_id=current.stable_id,
+                )
+
+    result = {
+        "message": (
+            f"{'Dry run: ' if dry_run else ''}"
+            f"{feeds_processed} feed(s) processed, {pairs_dispatched} pair(s) "
+            f"{'to dispatch' if dry_run else 'dispatched'}, "
+            f"{pairs_already_done} already done."
+        ),
+        "dry_run": dry_run,
+        "feeds_processed": feeds_processed,
+        "feeds_skipped_recent": feeds_skipped_recent,
+        "pairs_found": pairs_found,
+        "pairs_already_done": pairs_already_done,
+        "pairs_dispatched": pairs_dispatched,
+    }
+    if dry_run:
+        result["dispatched"] = dispatched
+    logging.info("Task completed: %s", result)
+    return result

--- a/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
+++ b/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
@@ -179,7 +179,17 @@ class TestBackfillChangelog(unittest.TestCase):
             feed_stable_id="stable_a",
             base_dataset_stable_id="stable_a1",
             new_dataset_stable_id="stable_a2",
+            disallow_overwrite=True,
         )
+
+    @patch(PATCH_DISPATCH)
+    def test_force_dispatch_allows_overwrite(self, mock_dispatch):
+        # force=True must dispatch every pair with disallow_overwrite=False so the
+        # comparer regenerates even existing changelogs.
+        result = backfill_changelog(dry_run=False, force=True, stable_feed_ids=SCOPE)
+        self.assertEqual(result["pairs_dispatched"], 2)
+        for call in mock_dispatch.call_args_list:
+            self.assertFalse(call.kwargs["disallow_overwrite"])
 
     @patch(PATCH_DISPATCH)
     def test_idempotent_when_all_pairs_done(self, mock_dispatch):

--- a/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
+++ b/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
@@ -100,8 +100,8 @@ def seed(db_session: Session):
     db_session.add(
         GtfsDatasetChangelog(
             feed_id="feed_a",
-            previous_dataset_id="a0",
-            current_dataset_id="a1",
+            base_dataset_id="a0",
+            new_dataset_id="a1",
             changelog_url="https://example.com/changelog.json",
             diff_summary={},
         )
@@ -120,6 +120,7 @@ class TestBackfillChangelogHandler(unittest.TestCase):
             datasets_per_feed=DEFAULT_DATASETS_PER_FEED,
             stable_feed_ids=None,
             feeds_not_updated_days=None,
+            force=False,
         )
 
     @patch("tasks.changelog.backfill_changelog.backfill_changelog")
@@ -132,6 +133,7 @@ class TestBackfillChangelogHandler(unittest.TestCase):
                 "datasets_per_feed": 4,
                 "stable_feed_ids": ["stable_a"],
                 "feeds_not_updated_days": 30,
+                "force": True,
             }
         )
         mock_backfill.assert_called_once_with(
@@ -140,6 +142,7 @@ class TestBackfillChangelogHandler(unittest.TestCase):
             datasets_per_feed=4,
             stable_feed_ids=["stable_a"],
             feeds_not_updated_days=30,
+            force=True,
         )
 
 
@@ -186,8 +189,8 @@ class TestBackfillChangelog(unittest.TestCase):
             db_session.add(
                 GtfsDatasetChangelog(
                     feed_id="feed_a",
-                    previous_dataset_id="a1",
-                    current_dataset_id="a2",
+                    base_dataset_id="a1",
+                    new_dataset_id="a2",
                     changelog_url="https://example.com/c2.json",
                     diff_summary={},
                 )
@@ -234,6 +237,28 @@ class TestBackfillChangelog(unittest.TestCase):
             dry_run=True, feeds_not_updated_days=1, stable_feed_ids=SCOPE
         )
         self.assertEqual(result["feeds_processed"], 1)
+
+    @patch(PATCH_DISPATCH)
+    def test_force_redispatches_existing_pairs(self, mock_dispatch):
+        # With force=True the already-done a0->a1 pair is dispatched too.
+        result = backfill_changelog(dry_run=True, force=True, stable_feed_ids=SCOPE)
+        self.assertTrue(result["force"])
+        self.assertEqual(result["pairs_found"], 2)
+        self.assertEqual(result["pairs_already_done"], 0)
+        self.assertEqual(result["pairs_dispatched"], 2)
+
+    @patch(PATCH_DISPATCH)
+    def test_min_datasets_filter_excludes_short_feeds(self, mock_dispatch):
+        # feed_b (1 dataset) is excluded from processing, only feed_a remains.
+        result = backfill_changelog(dry_run=True, stable_feed_ids=SCOPE)
+        self.assertEqual(result["feeds_processed"], 1)
+
+    @patch(PATCH_DISPATCH)
+    def test_existing_feed_with_few_datasets_not_reported_missing(self, mock_dispatch):
+        # stable_b exists but has <2 datasets: it must not raise "not found".
+        result = backfill_changelog(dry_run=True, stable_feed_ids=["stable_b"])
+        self.assertEqual(result["feeds_processed"], 0)
+        self.assertEqual(result["pairs_found"], 0)
 
     @patch(PATCH_DISPATCH)
     def test_invalid_datasets_per_feed_raises(self, mock_dispatch):

--- a/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
+++ b/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
@@ -25,6 +25,7 @@ from shared.database_gen.sqlacodegen_models import (
     GtfsDatasetChangelog,
     Gtfsdataset,
     Gtfsfeed,
+    Gtfsfile,
 )
 from tasks.changelog.backfill_changelog import (
     DEFAULT_DATASETS_PER_FEED,
@@ -42,17 +43,30 @@ PATCH_DISPATCH = (
 SCOPE = ["stable_a", "stable_b"]
 
 
+def _extracted_file(dataset_id: str) -> Gtfsfile:
+    """A minimal gtfsfile row marking a dataset as extracted in GCP."""
+    return Gtfsfile(
+        id=f"file_{dataset_id}",
+        gtfs_dataset_id=dataset_id,
+        file_name="stops.txt",
+        file_size_bytes=1,
+    )
+
+
 @with_db_session(db_url=default_db_url)
 def seed(db_session: Session):
-    """Seed two published GTFS feeds with dataset history.
+    """Seed published GTFS feeds with dataset history.
 
-    feed_a: 3 datasets (a0 oldest -> a2 newest), one existing changelog (a0->a1).
-    feed_b: 1 dataset (no pairs possible).
+    feed_a: 3 datasets (a0 oldest -> a2 newest), all extracted, one existing
+            changelog (a0->a1).
+    feed_b: 1 extracted dataset (no pairs possible).
+    feed_c: 3 datasets but the newest (c2) has NO extracted files, so only c0,c1
+            are comparable -> a single pair. Used to test the extracted-files filter.
 
-    Only our own rows are touched: existing feed_a/feed_b are deleted first
-    (FK cascade removes their datasets and changelogs), then re-inserted.
+    Only our own rows are touched: existing feeds are deleted first (FK cascade
+    removes their datasets, files and changelogs), then re-inserted.
     """
-    db_session.query(Feed).filter(Feed.id.in_(["feed_a", "feed_b"])).delete(
+    db_session.query(Feed).filter(Feed.id.in_(["feed_a", "feed_b", "feed_c"])).delete(
         synchronize_session=False
     )
     db_session.commit()
@@ -74,7 +88,15 @@ def seed(db_session: Session):
         operational_status="published",
         created_at=now,
     )
-    db_session.add_all([feed_a, feed_b])
+    feed_c = Gtfsfeed(
+        id="feed_c",
+        stable_id="stable_c",
+        data_type="gtfs",
+        status="active",
+        operational_status="published",
+        created_at=now,
+    )
+    db_session.add_all([feed_a, feed_b, feed_c])
     db_session.flush()
 
     for i in range(3):
@@ -94,6 +116,21 @@ def seed(db_session: Session):
             downloaded_at=now - timedelta(days=5),
         )
     )
+    for i in range(3):
+        db_session.add(
+            Gtfsdataset(
+                id=f"c{i}",
+                stable_id=f"stable_c{i}",
+                feed_id="feed_c",
+                downloaded_at=now - timedelta(days=10 - i),
+            )
+        )
+    db_session.flush()
+
+    # Mark datasets as extracted in GCP via gtfsfile rows. c2 (newest of feed_c)
+    # and b0 are intentionally left without files.
+    for dataset_id in ["a0", "a1", "a2", "c0", "c1"]:
+        db_session.add(_extracted_file(dataset_id))
     db_session.flush()
 
     # Existing changelog for the oldest pair (a0 -> a1) => must be skipped.
@@ -262,6 +299,31 @@ class TestBackfillChangelog(unittest.TestCase):
         # feed_b (1 dataset) is excluded from processing, only feed_a remains.
         result = backfill_changelog(dry_run=True, stable_feed_ids=SCOPE)
         self.assertEqual(result["feeds_processed"], 1)
+
+    @patch(PATCH_DISPATCH)
+    def test_only_extracted_datasets_considered(self, mock_dispatch):
+        # feed_c has 3 datasets but c2 (newest) has no extracted files, so only the
+        # c0->c1 pair is comparable.
+        result = backfill_changelog(dry_run=True, stable_feed_ids=["stable_c"])
+        self.assertEqual(result["feeds_processed"], 1)
+        self.assertEqual(result["pairs_found"], 1)
+        self.assertEqual(
+            result["dispatched"],
+            [
+                {
+                    "feed_stable_id": "stable_c",
+                    "base_dataset_stable_id": "stable_c0",
+                    "new_dataset_stable_id": "stable_c1",
+                }
+            ],
+        )
+
+    @patch(PATCH_DISPATCH)
+    def test_feed_without_extracted_datasets_excluded(self, mock_dispatch):
+        # feed_b's only dataset has no extracted files -> not comparable.
+        result = backfill_changelog(dry_run=True, stable_feed_ids=["stable_b"])
+        self.assertEqual(result["feeds_processed"], 0)
+        self.assertEqual(result["pairs_found"], 0)
 
     @patch(PATCH_DISPATCH)
     def test_existing_feed_with_few_datasets_not_reported_missing(self, mock_dispatch):

--- a/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
+++ b/functions-python/tasks_executor/tests/tasks/changelog/test_backfill_changelog.py
@@ -1,0 +1,245 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import (
+    Feed,
+    GtfsDatasetChangelog,
+    Gtfsdataset,
+    Gtfsfeed,
+)
+from tasks.changelog.backfill_changelog import (
+    DEFAULT_DATASETS_PER_FEED,
+    DEFAULT_LIMIT,
+    backfill_changelog,
+    backfill_changelog_handler,
+)
+from test_shared.test_utils.database_utils import default_db_url
+
+PATCH_DISPATCH = (
+    "tasks.changelog.backfill_changelog.create_http_gtfs_datasets_comparer_task"
+)
+# Scope every query to our own feeds so the shared conftest seed data does not
+# affect counts (and so we never wipe it).
+SCOPE = ["stable_a", "stable_b"]
+
+
+@with_db_session(db_url=default_db_url)
+def seed(db_session: Session):
+    """Seed two published GTFS feeds with dataset history.
+
+    feed_a: 3 datasets (a0 oldest -> a2 newest), one existing changelog (a0->a1).
+    feed_b: 1 dataset (no pairs possible).
+
+    Only our own rows are touched: existing feed_a/feed_b are deleted first
+    (FK cascade removes their datasets and changelogs), then re-inserted.
+    """
+    db_session.query(Feed).filter(Feed.id.in_(["feed_a", "feed_b"])).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+    now = datetime.now(timezone.utc)
+
+    feed_a = Gtfsfeed(
+        id="feed_a",
+        stable_id="stable_a",
+        data_type="gtfs",
+        status="active",
+        operational_status="published",
+        created_at=now,
+    )
+    feed_b = Gtfsfeed(
+        id="feed_b",
+        stable_id="stable_b",
+        data_type="gtfs",
+        status="active",
+        operational_status="published",
+        created_at=now,
+    )
+    db_session.add_all([feed_a, feed_b])
+    db_session.flush()
+
+    for i in range(3):
+        db_session.add(
+            Gtfsdataset(
+                id=f"a{i}",
+                stable_id=f"stable_a{i}",
+                feed_id="feed_a",
+                downloaded_at=now - timedelta(days=10 - i),
+            )
+        )
+    db_session.add(
+        Gtfsdataset(
+            id="b0",
+            stable_id="stable_b0",
+            feed_id="feed_b",
+            downloaded_at=now - timedelta(days=5),
+        )
+    )
+    db_session.flush()
+
+    # Existing changelog for the oldest pair (a0 -> a1) => must be skipped.
+    db_session.add(
+        GtfsDatasetChangelog(
+            feed_id="feed_a",
+            previous_dataset_id="a0",
+            current_dataset_id="a1",
+            changelog_url="https://example.com/changelog.json",
+            diff_summary={},
+        )
+    )
+    db_session.commit()
+
+
+class TestBackfillChangelogHandler(unittest.TestCase):
+    @patch("tasks.changelog.backfill_changelog.backfill_changelog")
+    def test_handler_default_params(self, mock_backfill):
+        mock_backfill.return_value = {"message": "ok"}
+        backfill_changelog_handler({})
+        mock_backfill.assert_called_once_with(
+            dry_run=True,
+            limit=DEFAULT_LIMIT,
+            datasets_per_feed=DEFAULT_DATASETS_PER_FEED,
+            stable_feed_ids=None,
+            feeds_not_updated_days=None,
+        )
+
+    @patch("tasks.changelog.backfill_changelog.backfill_changelog")
+    def test_handler_custom_params(self, mock_backfill):
+        mock_backfill.return_value = {"message": "ok"}
+        backfill_changelog_handler(
+            {
+                "dry_run": False,
+                "limit": 5,
+                "datasets_per_feed": 4,
+                "stable_feed_ids": ["stable_a"],
+                "feeds_not_updated_days": 30,
+            }
+        )
+        mock_backfill.assert_called_once_with(
+            dry_run=False,
+            limit=5,
+            datasets_per_feed=4,
+            stable_feed_ids=["stable_a"],
+            feeds_not_updated_days=30,
+        )
+
+
+class TestBackfillChangelog(unittest.TestCase):
+    def setUp(self):
+        seed()
+
+    @patch(PATCH_DISPATCH)
+    def test_dry_run_enumerates_without_dispatch(self, mock_dispatch):
+        result = backfill_changelog(dry_run=True, stable_feed_ids=SCOPE)
+        mock_dispatch.assert_not_called()
+        self.assertTrue(result["dry_run"])
+        # feed_a has 3 datasets -> 2 pairs; a0->a1 already done -> 1 to dispatch.
+        self.assertEqual(result["feeds_processed"], 1)
+        self.assertEqual(result["pairs_found"], 2)
+        self.assertEqual(result["pairs_already_done"], 1)
+        self.assertEqual(result["pairs_dispatched"], 1)
+        self.assertEqual(
+            result["dispatched"],
+            [
+                {
+                    "feed_stable_id": "stable_a",
+                    "base_dataset_stable_id": "stable_a1",
+                    "new_dataset_stable_id": "stable_a2",
+                }
+            ],
+        )
+
+    @patch(PATCH_DISPATCH)
+    def test_dispatches_missing_pair(self, mock_dispatch):
+        result = backfill_changelog(dry_run=False, stable_feed_ids=SCOPE)
+        self.assertEqual(result["pairs_dispatched"], 1)
+        mock_dispatch.assert_called_once_with(
+            feed_stable_id="stable_a",
+            base_dataset_stable_id="stable_a1",
+            new_dataset_stable_id="stable_a2",
+        )
+
+    @patch(PATCH_DISPATCH)
+    def test_idempotent_when_all_pairs_done(self, mock_dispatch):
+        # Add the missing changelog so no pair remains.
+        @with_db_session(db_url=default_db_url)
+        def add_remaining(db_session: Session):
+            db_session.add(
+                GtfsDatasetChangelog(
+                    feed_id="feed_a",
+                    previous_dataset_id="a1",
+                    current_dataset_id="a2",
+                    changelog_url="https://example.com/c2.json",
+                    diff_summary={},
+                )
+            )
+            db_session.commit()
+
+        add_remaining()
+        result = backfill_changelog(dry_run=False, stable_feed_ids=SCOPE)
+        mock_dispatch.assert_not_called()
+        self.assertEqual(result["pairs_dispatched"], 0)
+        self.assertEqual(result["pairs_already_done"], 2)
+
+    @patch(PATCH_DISPATCH)
+    def test_datasets_per_feed_limits_pairs(self, mock_dispatch):
+        # Only consider the 2 most recent datasets (a1, a2) -> single pair a1->a2.
+        result = backfill_changelog(
+            dry_run=True, datasets_per_feed=2, stable_feed_ids=SCOPE
+        )
+        self.assertEqual(result["pairs_found"], 1)
+        self.assertEqual(result["pairs_dispatched"], 1)
+
+    @patch(PATCH_DISPATCH)
+    def test_stable_feed_ids_filter(self, mock_dispatch):
+        result = backfill_changelog(dry_run=True, stable_feed_ids=["stable_b"])
+        # feed_b has a single dataset -> no pairs.
+        self.assertEqual(result["feeds_processed"], 0)
+        self.assertEqual(result["pairs_found"], 0)
+
+    @patch(PATCH_DISPATCH)
+    def test_unknown_stable_feed_id_raises(self, mock_dispatch):
+        with self.assertRaises(ValueError):
+            backfill_changelog(dry_run=True, stable_feed_ids=["does_not_exist"])
+
+    @patch(PATCH_DISPATCH)
+    def test_feeds_not_updated_days_skips_recent(self, mock_dispatch):
+        # feed_a newest dataset is ~7 days old; a 30-day cutoff skips it as "recent".
+        result = backfill_changelog(
+            dry_run=True, feeds_not_updated_days=30, stable_feed_ids=SCOPE
+        )
+        self.assertEqual(result["feeds_processed"], 0)
+        self.assertEqual(result["feeds_skipped_recent"], 1)
+        # With a 1-day cutoff the feed is old enough to be processed.
+        result = backfill_changelog(
+            dry_run=True, feeds_not_updated_days=1, stable_feed_ids=SCOPE
+        )
+        self.assertEqual(result["feeds_processed"], 1)
+
+    @patch(PATCH_DISPATCH)
+    def test_invalid_datasets_per_feed_raises(self, mock_dispatch):
+        with self.assertRaises(ValueError):
+            backfill_changelog(dry_run=True, datasets_per_feed=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1151,6 +1151,26 @@ resource "google_cloud_tasks_queue" "pmtiles_builder_task_queue" {
   }
 }
 
+# Task queue to invoke gtfs_datasets_comparer function for backfill changelog tasks
+resource "google_cloud_tasks_queue" "gtfs_datasets_comparer_backfill_task_queue" {
+  project  = var.project_id
+  location = var.gcp_region
+  name     = "gtfs-datasets-comparer-backfill-queue-${var.environment}-${local.deployment_timestamp}"
+
+  rate_limits {
+    max_concurrent_dispatches = 10
+    max_dispatches_per_second = 1
+  }
+
+  retry_config {
+    # Retries span ~10 minutes: initial try + 2 retries at 120s then 240s
+    max_attempts  = 3
+    min_backoff   = "120s"
+    max_backoff   = "240s"
+    max_doublings = 1
+  }
+}
+
 
 # 14. functions/tasks_executor cloud function
 resource "google_cloudfunctions2_function" "tasks_executor" {
@@ -1181,6 +1201,7 @@ resource "google_cloudfunctions2_function" "tasks_executor" {
       MATERIALIZED_VIEW_QUEUE = google_cloud_tasks_queue.refresh_materialized_view_task_queue.name
       DATASETS_BUCKET_NAME = "${var.datasets_bucket_name}-${var.environment}"
       GBFS_SNAPSHOTS_BUCKET_NAME = google_storage_bucket.gbfs_snapshots_bucket.name
+      GTFS_CHANGE_TRACKER_QUEUE = google_cloud_tasks_queue.gtfs_datasets_comparer_backfill_task_queue.name
       PMTILES_BUILDER_QUEUE = google_cloud_tasks_queue.pmtiles_builder_task_queue.name
       TASK_RUN_SYNC_QUEUE   = google_cloud_tasks_queue.task_run_sync_queue.name
       TDG_API_TOKEN = var.tdg_api_token

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -115,6 +115,8 @@
     <include file="changes/feat_1700_content_type.sql" relativeToChangelogFile="true"/>
     <!-- Add gtfs_dataset_changelog table to store changelog references (issue #1633). -->
     <include file="changes/feat_1633.sql" relativeToChangelogFile="true"/>
+    <!-- Rename gtfs_dataset_changelog (previous, current) dataset columns to (base, new) (issue #1639). -->
+    <include file="changes/feat_1639.sql" relativeToChangelogFile="true"/>
     <!-- Keep this at the very end to ensure all table and schema changes
          are applied before materialized views are (re)created. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/feat_1639.sql
+++ b/liquibase/changes/feat_1639.sql
@@ -1,0 +1,17 @@
+-- Rename gtfs_dataset_changelog dataset columns from (previous, current) to (base, new)
+-- so the database matches the comparer HTTP API naming (base_dataset_stable_id /
+-- new_dataset_stable_id) and a single, consistent vocabulary is used everywhere
+ALTER TABLE gtfs_dataset_changelog RENAME COLUMN previous_dataset_id TO base_dataset_id;
+ALTER TABLE gtfs_dataset_changelog RENAME COLUMN current_dataset_id TO new_dataset_id;
+
+ALTER TABLE gtfs_dataset_changelog
+    RENAME CONSTRAINT gtfs_dataset_changelog_previous_dataset_id_fkey
+    TO gtfs_dataset_changelog_base_dataset_id_fkey;
+ALTER TABLE gtfs_dataset_changelog
+    RENAME CONSTRAINT gtfs_dataset_changelog_current_dataset_id_fkey
+    TO gtfs_dataset_changelog_new_dataset_id_fkey;
+ALTER TABLE gtfs_dataset_changelog
+    RENAME CONSTRAINT gtfs_dataset_changelog_previous_current_key
+    TO gtfs_dataset_changelog_base_new_key;
+
+ALTER INDEX idx_gtfs_dataset_changelog_current RENAME TO idx_gtfs_dataset_changelog_new;


### PR DESCRIPTION
## Summary

- Add a `backfill_changelog` task to `tasks_executor` that walks existing dataset history and dispatches Cloud Tasks to the `gtfs-datasets-comparer` for each consecutive `(base, new)` dataset pair missing a changelog record
- Rename `gtfs_dataset_changelog` columns from `(previous_dataset_id, current_dataset_id)` to `(base_dataset_id, new_dataset_id)` via a Liquibase migration, aligning the DB schema with the comparer HTTP API naming
- Add a dedicated Cloud Tasks queue (`gtfs-datasets-comparer-backfill-queue`) with rate limiting (1 req/s, 10 concurrent) and retry config for backfill dispatches

## Key design decisions

- **Idempotent & restartable**: pairs with existing changelog rows are skipped (unless `force=True`), and dispatched tasks run with `disallow_overwrite=True` by default
- **Rate-limited**: `limit` caps feeds per invocation, `datasets_per_feed` controls how deep into history we look (default: 3 most recent → 2 pairs), and the Cloud Tasks queue throttles comparer invocations
- **Filtering**: supports `stable_feed_ids` to target specific feeds and `feeds_not_updated_days` to focus on stale feeds
- **Dry-run by default**: `dry_run=True` enumerates pairs without dispatching, making it safe to preview before running

## Note about testing
Only 25 feeds in DEV have enough comparable datasets (with extracted files) to produce changelog pairs. Backfill ran successfully against all of them with no issues found.

Further testing in QA is impractical for this feature: QA mirrors the production database but does not have access to the production GCS bucket where extracted GTFS files are stored. Since the comparer reads those files to compute diffs, changelog generation fails without them. Meaningful end-to-end validation will need to happen in PROD (starting with a scoped dry-run, then a small `stable_feed_ids` batch).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
