### PR TITLE
fix: missing headers for feeds mdb-3237 to mdb-3293 and mdb-2939

### DIFF
--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -117,6 +117,8 @@
     <include file="changes/feat_1633.sql" relativeToChangelogFile="true"/>
     <!-- Rename gtfs_dataset_changelog (previous, current) dataset columns to (base, new) (issue #1639). -->
     <include file="changes/feat_1639.sql" relativeToChangelogFile="true"/>
+    <!-- Add feed_download/http_headers override for feeds mdb-3237 to mdb-3293 and mdb-2939 -->
+    <include file="changes/hotfix_missing_header.sql" relativeToChangelogFile="true"/>
     <!-- Keep this at the very end to ensure all table and schema changes
          are applied before materialized views are (re)created. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/hotfix_missing_header.sql
+++ b/liquibase/changes/hotfix_missing_header.sql
@@ -1,0 +1,17 @@
+-- Add a custom User-Agent/Referer header override for feeds mdb-3237 through mdb-3293, and mdb-2939,
+-- whose producer blocks the default download headers.
+INSERT INTO config_value_feed (feed_id, feed_stable_id, namespace, key, value, updated_at)
+SELECT
+    f.id,
+    f.stable_id,
+    'feed_download',
+    'http_headers',
+    '{"Accept": "*/*", "Referer": "https://opendata.samtrafiken.se/gtfs/vastexp/vastexp.zip", "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36", "Accept-Encoding": "gzip"}'::jsonb,
+    now()
+FROM feed f
+WHERE f.stable_id IN (
+    SELECT 'mdb-' || generate_series(3237, 3293)
+    UNION ALL
+    SELECT 'mdb-2939'
+)
+ON CONFLICT (feed_id, namespace, key) DO NOTHING;

--- a/liquibase/changes/hotfix_missing_header.sql
+++ b/liquibase/changes/hotfix_missing_header.sql
@@ -6,7 +6,7 @@ SELECT
     f.stable_id,
     'feed_download',
     'http_headers',
-    '{"Accept": "*/*", "Referer": "https://opendata.samtrafiken.se/gtfs/vastexp/vastexp.zip", "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36", "Accept-Encoding": "gzip"}'::jsonb,
+    '{"Accept": "*/*", "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36", "Accept-Encoding": "gzip"}'::jsonb,
     now()
 FROM feed f
 WHERE f.stable_id IN (


### PR DESCRIPTION
**Summary:**

This pull request introduces a hotfix to address issues with downloading certain GTFS feeds whose producers block the default HTTP headers. The main change is the addition of a custom `http_headers` override for a specific range of feeds.

**Database migration and configuration:**

* Added a new migration, `hotfix_missing_header.sql`, to insert a custom `User-Agent` and `Referer` header override for feeds with stable IDs from `mdb-3237` to `mdb-3293` and `mdb-2939`, ensuring successful downloads from producers that block the default headers. (`liquibase/changes/hotfix_missing_header.sql`)
* Updated the main Liquibase changelog (`changelog.xml`) to include the new hotfix migration, ensuring it is applied in the correct order. (`liquibase/changelog.xml`)
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
