### PR TITLE
hotfix: missing entry in config_key for QA

### DIFF
--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -117,6 +117,8 @@
     <include file="changes/feat_1633.sql" relativeToChangelogFile="true"/>
     <!-- Rename gtfs_dataset_changelog (previous, current) dataset columns to (base, new) (issue #1639). -->
     <include file="changes/feat_1639.sql" relativeToChangelogFile="true"/>
+    <!-- Add missing config keys for feed_download/http_headers -->
+    <include file="changes/hotfix_missing_config_keys.sql" relativeToChangelogFile="true"/>
     <!-- Add feed_download/http_headers override for feeds mdb-3237 to mdb-3293 and mdb-2939 -->
     <include file="changes/hotfix_missing_header.sql" relativeToChangelogFile="true"/>
     <!-- Add is_producer_url_unstable column to the feed table (issue #1766). -->

--- a/liquibase/changes/hotfix_missing_config_keys.sql
+++ b/liquibase/changes/hotfix_missing_config_keys.sql
@@ -1,0 +1,4 @@
+-- Register the config key so the per-feed FK is satisfied.
+INSERT INTO config_key (namespace, key, description)
+VALUES ('feed_download', 'http_headers', 'HTTP headers to use when downloading a feed (per-feed override)')
+ON CONFLICT (namespace, key) DO NOTHING; -- DEV and PROD already have this key, but QA does not. This is a hotfix to ensure that the key exists in all environments.


### PR DESCRIPTION
**Summary:**

This PR introduces a hotfix to ensure the `feed_download/http_headers` config key is present in all environments, addressing an inconsistency where the key was missing in QA. The change updates the Liquibase changelog to include a new SQL migration that inserts the required config key if it does not already exist.

