### PR TITLE
feat: extract `feed_info.txt` content

### DIFF
--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -146,11 +146,16 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
             stable_id, dataset_stable_id, stops_url
         )
 
-    # Create GTFS file data extraction tasks for changed, extractable files.
+    # Create GTFS file data extraction tasks for every extractable file present in
+    # the dataset, whether or not it changed: each dataset needs its own reference
+    # to the extracted data, and an unchanged file may never have been extracted
+    # before. Extracted data is shared by file content hash, so for an unchanged
+    # file the extractor just links the dataset to the existing data instead of
+    # downloading the file again.
     files_by_name = {file.file_name: file for file in gtfs_files}
     for file_name in EXTRACTABLE_FILES:
         gtfs_file = files_by_name.get(file_name)
-        if gtfs_file and gtfs_file.hosted_url and file_name in changed_files:
+        if gtfs_file and gtfs_file.hosted_url:
             create_http_gtfs_file_data_extractor_task(
                 stable_id, dataset_stable_id, file_name, gtfs_file.hosted_url
             )

--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -147,11 +147,7 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
         )
 
     # Create GTFS file data extraction tasks for every extractable file present in
-    # the dataset, whether or not it changed: each dataset needs its own reference
-    # to the extracted data, and an unchanged file may never have been extracted
-    # before. Extracted data is shared by file content hash, so for an unchanged
-    # file the extractor just links the dataset to the existing data instead of
-    # downloading the file again.
+    # the dataset, whether it changed or not
     files_by_name = {file.file_name: file for file in gtfs_files}
     for file_name in EXTRACTABLE_FILES:
         gtfs_file = files_by_name.get(file_name)

--- a/functions-python/batch_process_dataset/src/pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/src/pipeline_tasks.py
@@ -14,6 +14,10 @@ from shared.helpers.utils import (
     create_http_gtfs_datasets_comparer_task,
 )
 
+# GTFS files that have a registered extractor in the gtfs_file_data_extractor
+# function. Keep in sync with that function's src/extractors/registry.py.
+EXTRACTABLE_FILES = {"feed_info.txt"}
+
 
 def create_http_reverse_geolocation_processor_task(
     stable_id: str,
@@ -39,6 +43,39 @@ def create_http_reverse_geolocation_processor_task(
         client,
         body,
         f"https://{gcp_region}-{project_id}.cloudfunctions.net/reverse-geolocation-processor",
+        project_id,
+        gcp_region,
+        queue_name,
+    )
+
+
+def create_http_gtfs_file_data_extractor_task(
+    stable_id: str,
+    dataset_stable_id: str,
+    file_name: str,
+    file_url: str,
+) -> None:
+    """
+    Create a task to extract structured data from a single GTFS file
+    (handled by the gtfs_file_data_extractor function).
+    """
+    client = tasks_v2.CloudTasksClient()
+    body = json.dumps(
+        {
+            "stable_id": stable_id,
+            "dataset_id": dataset_stable_id,
+            "file_name": file_name,
+            "file_url": file_url,
+        }
+    ).encode()
+    queue_name = os.getenv("GTFS_FILE_DATA_EXTRACTOR_QUEUE")
+    project_id = os.getenv("PROJECT_ID")
+    gcp_region = os.getenv("GCP_REGION")
+
+    create_http_task(
+        client,
+        body,
+        f"https://{gcp_region}-{project_id}.cloudfunctions.net/gtfs-file-data-extractor",
         project_id,
         gcp_region,
         queue_name,
@@ -108,6 +145,15 @@ def create_pipeline_tasks(dataset: Gtfsdataset, db_session: Session) -> None:
         create_http_reverse_geolocation_processor_task(
             stable_id, dataset_stable_id, stops_url
         )
+
+    # Create GTFS file data extraction tasks for changed, extractable files.
+    files_by_name = {file.file_name: file for file in gtfs_files}
+    for file_name in EXTRACTABLE_FILES:
+        gtfs_file = files_by_name.get(file_name)
+        if gtfs_file and gtfs_file.hosted_url and file_name in changed_files:
+            create_http_gtfs_file_data_extractor_task(
+                stable_id, dataset_stable_id, file_name, gtfs_file.hosted_url
+            )
 
     routes_file = next(
         (file for file in gtfs_files if file.file_name == "routes.txt"), None

--- a/functions-python/batch_process_dataset/tests/test_pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/tests/test_pipeline_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 
 from pipeline_tasks import (
     create_http_reverse_geolocation_processor_task,
+    create_http_gtfs_file_data_extractor_task,
     get_changed_files,
     create_pipeline_tasks,
 )
@@ -84,6 +85,113 @@ class TestPipelineTasks(unittest.TestCase):
         self.assertEqual(args[3], "my-project")
         self.assertEqual(args[4], "northamerica-northeast1")
         self.assertEqual(args[5], "rev-geo-queue")
+
+    @patch.dict(
+        os.environ,
+        {
+            "GTFS_FILE_DATA_EXTRACTOR_QUEUE": "file-data-queue",
+            "PROJECT_ID": "my-project",
+            "GCP_REGION": "northamerica-northeast1",
+        },
+        clear=False,
+    )
+    @patch("pipeline_tasks.create_http_task")
+    @patch("pipeline_tasks.tasks_v2.CloudTasksClient")
+    def test_create_http_gtfs_file_data_extractor_task(
+        self, mock_client_cls, mock_create_http_task
+    ):
+        client_instance = MagicMock()
+        mock_client_cls.return_value = client_instance
+
+        create_http_gtfs_file_data_extractor_task(
+            stable_id="feed-123",
+            dataset_stable_id="dataset-abc",
+            file_name="feed_info.txt",
+            file_url="https://example.com/feed_info.txt",
+        )
+
+        self.assertEqual(mock_create_http_task.call_count, 1)
+        args, _ = mock_create_http_task.call_args
+        self.assertIs(args[0], client_instance)
+        payload = json.loads(args[1].decode("utf-8"))
+        self.assertEqual(
+            payload,
+            {
+                "stable_id": "feed-123",
+                "dataset_id": "dataset-abc",
+                "file_name": "feed_info.txt",
+                "file_url": "https://example.com/feed_info.txt",
+            },
+        )
+        self.assertEqual(
+            args[2],
+            "https://northamerica-northeast1-my-project.cloudfunctions.net/gtfs-file-data-extractor",
+        )
+        self.assertEqual(args[5], "file-data-queue")
+
+
+class TestCreatePipelineTasksFeedInfo(unittest.TestCase):
+    """Covers the gtfs_file_data_extractor enqueue gating in create_pipeline_tasks."""
+
+    def _mock_session_no_base_dataset(self):
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = (
+            None
+        )
+        return mock_session
+
+    def _run(self, files, changed_files):
+        dataset = SimpleDataset(
+            feed_id=1,
+            dataset_id=10,
+            feed_stable_id="feed-A",
+            dataset_stable_id="ds-1",
+            files=files,
+        )
+        with patch(
+            "pipeline_tasks.get_changed_files", return_value=changed_files
+        ), patch(
+            "pipeline_tasks.create_http_reverse_geolocation_processor_task"
+        ), patch(
+            "pipeline_tasks.create_http_pmtiles_builder_task"
+        ), patch(
+            "pipeline_tasks.create_http_gtfs_datasets_comparer_task"
+        ), patch(
+            "pipeline_tasks.create_http_gtfs_file_data_extractor_task"
+        ) as mock_extractor_task:
+            create_pipeline_tasks(
+                dataset, db_session=self._mock_session_no_base_dataset()
+            )
+        return mock_extractor_task
+
+    def test_enqueues_when_feed_info_present_and_changed(self):
+        files = [
+            SimpleFile(
+                "feed_info.txt",
+                hosted_url="https://x.com/feed_info.txt",
+                file_hash="h1",
+            )
+        ]
+        mock_task = self._run(files, changed_files=["feed_info.txt"])
+        mock_task.assert_called_once_with(
+            "feed-A", "ds-1", "feed_info.txt", "https://x.com/feed_info.txt"
+        )
+
+    def test_skips_when_feed_info_not_changed(self):
+        files = [
+            SimpleFile(
+                "feed_info.txt",
+                hosted_url="https://x.com/feed_info.txt",
+                file_hash="h1",
+            )
+        ]
+        mock_task = self._run(files, changed_files=["stops.txt"])
+        mock_task.assert_not_called()
+
+    def test_skips_when_feed_info_absent(self):
+        files = [SimpleFile("stops.txt", hosted_url="https://x.com/stops.txt")]
+        mock_task = self._run(files, changed_files=["stops.txt"])
+        mock_task.assert_not_called()
 
 
 class TestHasFileChanged(unittest.TestCase):

--- a/functions-python/batch_process_dataset/tests/test_pipeline_tasks.py
+++ b/functions-python/batch_process_dataset/tests/test_pipeline_tasks.py
@@ -177,7 +177,10 @@ class TestCreatePipelineTasksFeedInfo(unittest.TestCase):
             "feed-A", "ds-1", "feed_info.txt", "https://x.com/feed_info.txt"
         )
 
-    def test_skips_when_feed_info_not_changed(self):
+    def test_enqueues_when_feed_info_not_changed(self):
+        # Unchanged files are still enqueued: the new dataset needs its own
+        # extracted data, and the file may never have been extracted before.
+        # The extractor decides whether to copy or download.
         files = [
             SimpleFile(
                 "feed_info.txt",
@@ -186,7 +189,9 @@ class TestCreatePipelineTasksFeedInfo(unittest.TestCase):
             )
         ]
         mock_task = self._run(files, changed_files=["stops.txt"])
-        mock_task.assert_not_called()
+        mock_task.assert_called_once_with(
+            "feed-A", "ds-1", "feed_info.txt", "https://x.com/feed_info.txt"
+        )
 
     def test_skips_when_feed_info_absent(self):
         files = [SimpleFile("stops.txt", hosted_url="https://x.com/stops.txt")]

--- a/functions-python/gtfs_file_data_extractor/README.md
+++ b/functions-python/gtfs_file_data_extractor/README.md
@@ -18,12 +18,42 @@ The task payload identifies one GTFS file:
 }
 ```
 
-`processor.py` downloads the file, looks up the matching extractor in
-`extractors/registry.py`, and lets it write to the database.
+Extracted data is stored **once per distinct file content** and shared: one
+`feedinfo` row per `feed_info.txt` content hash, referenced by every dataset whose
+`feed_info.txt` has that hash (`gtfsdataset.feed_info_id` -> `feedinfo.id`, so one
+`feedinfo` to many datasets). A feed that republishes the same `feed_info.txt`
+every day therefore has one row, not one per dataset.
+
+`processor.py` looks up the matching extractor in `extractors/registry.py`, then
+resolves the data for that dataset in the cheapest way available:
+
+1. **The dataset is already linked** to extracted data -> nothing to do.
+2. **The file content has already been extracted** (a row exists for its
+   `gtfsfile.hash`) -> link the dataset to that row, without downloading
+   anything. This is what gives a dataset whose file did not change its
+   reference to the data.
+3. **Otherwise** -> download the file, extract it into a new row keyed by the
+   content hash, and link the dataset. This covers both a changed file and a
+   file that never changed but was never extracted before (for example a dataset
+   processed before this function existed).
+
+Because every dataset needs its own reference, `batch_process_dataset` enqueues a
+task for every extractable file present in a dataset, changed or not; step 2 is
+what keeps the unchanged case cheap.
+
+Extraction requires a known `gtfsfile.hash`: without it the data could not be
+matched back to the file content, and a row per dataset is exactly what this
+layout avoids. Such a task fails and is reported rather than silently writing an
+unshareable row.
+
+The function always responds with HTTP 200, reporting failures in the body, so
+that Cloud Tasks does not retry errors that can never succeed (a malformed file,
+a deleted dataset). Reruns are safe: every path above is idempotent.
 
 ## Adding a new file extractor
 
-1. Implement a `FileDataExtractor` subclass under `src/extractors/`.
+1. Implement a `FileDataExtractor` subclass under `src/extractors/`, including
+   `has_data` and `link_existing_data` so the sharing path above works for it.
 2. Register it in `src/extractors/registry.py`.
 3. Add its `file_name` to `EXTRACTABLE_FILES` in
    `batch_process_dataset/src/pipeline_tasks.py` so the producer enqueues it.

--- a/functions-python/gtfs_file_data_extractor/README.md
+++ b/functions-python/gtfs_file_data_extractor/README.md
@@ -1,0 +1,32 @@
+# GTFS File Data Extractor
+
+HTTP Cloud Function that extracts structured data from a single GTFS file and
+persists it to the database. It is enqueued as a Cloud Task by
+`batch_process_dataset` once a dataset has been processed (see
+`batch_process_dataset/src/pipeline_tasks.py`).
+
+## How it works
+
+The task payload identifies one GTFS file:
+
+```json
+{
+  "stable_id": "<feed stable id>",
+  "dataset_id": "<dataset stable id>",
+  "file_name": "feed_info.txt",
+  "file_url": "<hosted_url of the GTFS file>"
+}
+```
+
+`processor.py` downloads the file, looks up the matching extractor in
+`extractors/registry.py`, and lets it write to the database.
+
+## Adding a new file extractor
+
+1. Implement a `FileDataExtractor` subclass under `src/extractors/`.
+2. Register it in `src/extractors/registry.py`.
+3. Add its `file_name` to `EXTRACTABLE_FILES` in
+   `batch_process_dataset/src/pipeline_tasks.py` so the producer enqueues it.
+
+Currently registered: `feed_info.txt` -> `FeedInfoExtractor` (writes the
+`feedinfo` table).

--- a/functions-python/gtfs_file_data_extractor/function_config.json
+++ b/functions-python/gtfs_file_data_extractor/function_config.json
@@ -1,0 +1,21 @@
+{
+  "name": "gtfs-file-data-extractor",
+  "description": "Extracts structured data from GTFS files (e.g. feed_info.txt) into the database",
+  "entry_point": "gtfs_file_data_extractor",
+  "timeout": 540,
+  "available_memory": "512Mi",
+  "trigger_http": true,
+  "include_folders": ["helpers"],
+  "include_api_folders": ["database_gen", "database", "common"],
+  "environment_variables": [],
+  "secret_environment_variables": [
+    {
+      "key": "FEEDS_DATABASE_URL"
+    }
+  ],
+  "ingress_settings": "ALLOW_ALL",
+  "max_instance_request_concurrency": 1,
+  "max_instance_count": 5,
+  "min_instance_count": 0,
+  "available_cpu": 1
+}

--- a/functions-python/gtfs_file_data_extractor/requirements.txt
+++ b/functions-python/gtfs_file_data_extractor/requirements.txt
@@ -1,0 +1,20 @@
+# Common packages
+functions-framework==3.*
+google-cloud-logging
+psycopg2-binary==2.9.6
+requests~=2.33.1
+certifi~=2025.8.3
+
+# SQL Alchemy and Geo Alchemy (database_gen models depend on geoalchemy2)
+SQLAlchemy==2.0.23
+geoalchemy2==0.14.7
+
+# Google specific packages (shared helpers)
+google-cloud-tasks
+google-auth==2.29.0
+
+# Additional packages for this function
+pandas
+
+# Configuration
+python-dotenv==1.2.2

--- a/functions-python/gtfs_file_data_extractor/requirements_dev.txt
+++ b/functions-python/gtfs_file_data_extractor/requirements_dev.txt
@@ -1,0 +1,3 @@
+Faker
+pytest~=7.4.3
+requests-mock

--- a/functions-python/gtfs_file_data_extractor/src/extractors/base.py
+++ b/functions-python/gtfs_file_data_extractor/src/extractors/base.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from shared.database_gen.sqlacodegen_models import Gtfsdataset
+
+
+class FileDataExtractor(ABC):
+    """
+    Base class for extracting structured data from a single GTFS file.
+
+    Each subclass handles exactly one GTFS file (identified by ``file_name``)
+    and persists the extracted values to the database.
+
+    To add support for a new file:
+      1. Implement a subclass here and register it in ``extractors/registry.py``.
+      2. Add the file name to ``EXTRACTABLE_FILES`` in batch_process_dataset's
+         ``pipeline_tasks.py`` so the producer enqueues a task for it.
+    """
+
+    #: The GTFS file this extractor handles, e.g. "feed_info.txt".
+    file_name: str
+
+    @abstractmethod
+    def extract(
+        self, df: pd.DataFrame, dataset: Gtfsdataset, db_session: Session
+    ) -> None:
+        """
+        Parse ``df`` (the parsed contents of ``file_name``) and persist the
+        extracted data for ``dataset``. Implementations must be idempotent:
+        re-running for the same dataset should update, not duplicate.
+        """
+        raise NotImplementedError

--- a/functions-python/gtfs_file_data_extractor/src/extractors/base.py
+++ b/functions-python/gtfs_file_data_extractor/src/extractors/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import pandas as pd
 from sqlalchemy.orm import Session
@@ -13,22 +14,53 @@ class FileDataExtractor(ABC):
     Each subclass handles exactly one GTFS file (identified by ``file_name``)
     and persists the extracted values to the database.
 
+    Extracted data is keyed by the content hash of the file it came from and
+    shared by every dataset whose copy of the file has that hash, so a dataset
+    whose file did not change is linked to the existing data instead of getting
+    a duplicate of it.
+
     To add support for a new file:
       1. Implement a subclass here and register it in ``extractors/registry.py``.
       2. Add the file name to ``EXTRACTABLE_FILES`` in batch_process_dataset's
          ``pipeline_tasks.py`` so the producer enqueues a task for it.
     """
 
-    #: The GTFS file this extractor handles, e.g. "feed_info.txt".
+    # The GTFS file this extractor handles, e.g. "feed_info.txt".
     file_name: str
 
     @abstractmethod
     def extract(
-        self, df: pd.DataFrame, dataset: Gtfsdataset, db_session: Session
+        self,
+        df: pd.DataFrame,
+        dataset: Gtfsdataset,
+        file_hash: Optional[str],
+        db_session: Session,
     ) -> None:
         """
-        Parse ``df`` (the parsed contents of ``file_name``) and persist the
-        extracted data for ``dataset``. Implementations must be idempotent:
-        re-running for the same dataset should update, not duplicate.
+        Parse ``df`` (the parsed contents of ``file_name``, whose content hash is
+        ``file_hash``), persist the extracted data and link ``dataset`` to it.
+
+        Implementations must be idempotent: re-running for the same content
+        updates the existing data in place rather than duplicating it.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def has_data(self, dataset: Gtfsdataset, db_session: Session) -> bool:
+        """Whether ``dataset`` is already linked to this extractor's data."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def link_existing_data(
+        self, dataset: Gtfsdataset, file_hash: Optional[str], db_session: Session
+    ) -> bool:
+        """
+        Link ``dataset`` to data already extracted from a file with the same
+        content hash, and return whether such data was found.
+
+        This is what gives a dataset whose file did not change its own reference
+        to the data, without downloading and re-parsing the file. Returns False
+        when nothing has been extracted for this content yet, or when the hash is
+        unknown — in both cases the caller must extract from the file itself.
         """
         raise NotImplementedError

--- a/functions-python/gtfs_file_data_extractor/src/extractors/feed_info_extractor.py
+++ b/functions-python/gtfs_file_data_extractor/src/extractors/feed_info_extractor.py
@@ -1,0 +1,88 @@
+import logging
+from datetime import date, datetime
+from typing import Optional
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from extractors.base import FileDataExtractor
+from shared.database_gen.sqlacodegen_models import Feedinfo, Gtfsdataset
+
+# feed_info.txt text columns (GTFS spec) mapped 1:1 onto Feedinfo string columns.
+STRING_FIELDS = (
+    "feed_publisher_name",
+    "feed_publisher_url",
+    "feed_lang",
+    "default_lang",
+    "feed_version",
+    "feed_contact_email",
+    "feed_contact_url",
+)
+# feed_info.txt date columns, stored as plain DATE (YYYYMMDD, no timezone).
+DATE_FIELDS = ("feed_start_date", "feed_end_date")
+
+
+def clean_str(value) -> Optional[str]:
+    """Return a trimmed string, or None for empty/NaN/missing values."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def parse_gtfs_date(value) -> Optional[date]:
+    """Parse a GTFS YYYYMMDD date. Returns None when missing or unparseable."""
+    text = clean_str(value)
+    if text is None:
+        return None
+    # pandas may read a purely numeric column as int/float, yielding "20240101.0".
+    if text.endswith(".0"):
+        text = text[:-2]
+    try:
+        return datetime.strptime(text, "%Y%m%d").date()
+    except ValueError:
+        logging.warning("Unparseable feed_info date value: %r", value)
+        return None
+
+
+class FeedInfoExtractor(FileDataExtractor):
+    """Extracts feed_info.txt into a Feedinfo row (one per dataset)."""
+
+    file_name = "feed_info.txt"
+
+    def extract(
+        self, df: pd.DataFrame, dataset: Gtfsdataset, db_session: Session
+    ) -> None:
+        if df is None or df.empty:
+            logging.info(
+                "feed_info.txt is empty for dataset %s; nothing to extract.",
+                dataset.stable_id,
+            )
+            return
+
+        # feed_info.txt holds a single record.
+        row = df.iloc[0]
+
+        values = {field: clean_str(row.get(field)) for field in STRING_FIELDS}
+        for field in DATE_FIELDS:
+            values[field] = parse_gtfs_date(row.get(field))
+
+        # Upsert keyed by dataset so reprocessing updates in place.
+        feed_info = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
+            .one_or_none()
+        )
+        if feed_info is None:
+            feed_info = Feedinfo(gtfs_dataset_id=dataset.id)
+            db_session.add(feed_info)
+
+        for field, value in values.items():
+            setattr(feed_info, field, value)
+
+        logging.info(
+            "Extracted feed_info for dataset %s: start=%s end=%s",
+            dataset.stable_id,
+            values["feed_start_date"],
+            values["feed_end_date"],
+        )

--- a/functions-python/gtfs_file_data_extractor/src/extractors/feed_info_extractor.py
+++ b/functions-python/gtfs_file_data_extractor/src/extractors/feed_info_extractor.py
@@ -46,12 +46,50 @@ def parse_gtfs_date(value) -> Optional[date]:
 
 
 class FeedInfoExtractor(FileDataExtractor):
-    """Extracts feed_info.txt into a Feedinfo row (one per dataset)."""
+    """
+    Extracts feed_info.txt into a Feedinfo row.
+
+    One row per distinct feed_info.txt content, referenced by every dataset whose
+    feed_info.txt has that content hash.
+    """
 
     file_name = "feed_info.txt"
 
+    @staticmethod
+    def _get_by_hash(
+        file_hash: Optional[str], db_session: Session
+    ) -> Optional[Feedinfo]:
+        if not file_hash:
+            return None
+        return (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.file_hash == file_hash)
+            .one_or_none()
+        )
+
+    def has_data(self, dataset: Gtfsdataset, db_session: Session) -> bool:
+        return dataset.feed_info_id is not None
+
+    def link_existing_data(
+        self, dataset: Gtfsdataset, file_hash: Optional[str], db_session: Session
+    ) -> bool:
+        feed_info = self._get_by_hash(file_hash, db_session)
+        if feed_info is None:
+            return False
+        dataset.feed_info = feed_info
+        logging.info(
+            "Linked dataset %s to the feed_info already extracted for hash %s.",
+            dataset.stable_id,
+            file_hash,
+        )
+        return True
+
     def extract(
-        self, df: pd.DataFrame, dataset: Gtfsdataset, db_session: Session
+        self,
+        df: pd.DataFrame,
+        dataset: Gtfsdataset,
+        file_hash: Optional[str],
+        db_session: Session,
     ) -> None:
         if df is None or df.empty:
             logging.info(
@@ -59,6 +97,13 @@ class FeedInfoExtractor(FileDataExtractor):
                 dataset.stable_id,
             )
             return
+        if not file_hash:
+            # Without a hash the row could not be matched to this file content
+            # again, and a row per dataset is what the shared table avoids.
+            raise ValueError(
+                f"Cannot extract feed_info for dataset {dataset.stable_id}: "
+                "the content hash of feed_info.txt is unknown."
+            )
 
         # feed_info.txt holds a single record.
         row = df.iloc[0]
@@ -67,18 +112,17 @@ class FeedInfoExtractor(FileDataExtractor):
         for field in DATE_FIELDS:
             values[field] = parse_gtfs_date(row.get(field))
 
-        # Upsert keyed by dataset so reprocessing updates in place.
-        feed_info = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
-            .one_or_none()
-        )
+        # Upsert keyed by content hash: re-parsing the same file (for instance
+        # after this extractor learns a new column) updates the row in place, and
+        # every dataset already referencing it picks up the new values.
+        feed_info = self._get_by_hash(file_hash, db_session)
         if feed_info is None:
-            feed_info = Feedinfo(gtfs_dataset_id=dataset.id)
+            feed_info = Feedinfo(file_hash=file_hash)
             db_session.add(feed_info)
 
         for field, value in values.items():
             setattr(feed_info, field, value)
+        dataset.feed_info = feed_info
 
         logging.info(
             "Extracted feed_info for dataset %s: start=%s end=%s",

--- a/functions-python/gtfs_file_data_extractor/src/extractors/registry.py
+++ b/functions-python/gtfs_file_data_extractor/src/extractors/registry.py
@@ -1,0 +1,16 @@
+from typing import Dict, Optional
+
+from extractors.base import FileDataExtractor
+from extractors.feed_info_extractor import FeedInfoExtractor
+
+# Registry of GTFS file name -> extractor. Add new extractors here; the producer
+# side (batch_process_dataset/pipeline_tasks.py EXTRACTABLE_FILES) decides which
+# files actually get enqueued.
+EXTRACTORS: Dict[str, FileDataExtractor] = {
+    extractor.file_name: extractor for extractor in (FeedInfoExtractor(),)
+}
+
+
+def get_extractor(file_name: str) -> Optional[FileDataExtractor]:
+    """Return the extractor registered for ``file_name``, or None if unsupported."""
+    return EXTRACTORS.get(file_name)

--- a/functions-python/gtfs_file_data_extractor/src/main.py
+++ b/functions-python/gtfs_file_data_extractor/src/main.py
@@ -1,0 +1,24 @@
+import logging
+
+import flask
+import functions_framework
+
+from shared.helpers.logger import init_logger
+
+init_logger()
+
+
+@functions_framework.http
+def gtfs_file_data_extractor(request: flask.Request):
+    """
+    Cloud Function that extracts structured data from a single GTFS file
+    (e.g. feed_info.txt) and persists it to the database.
+
+    Function trigger: HTTP request by Cloud Tasks, enqueued by
+    batch_process_dataset once a dataset has been processed.
+    """
+    from processor import process_file_data
+
+    result = process_file_data(request)
+    logging.info(result)
+    return result

--- a/functions-python/gtfs_file_data_extractor/src/processor.py
+++ b/functions-python/gtfs_file_data_extractor/src/processor.py
@@ -23,7 +23,7 @@ def parse_request_parameters(request: flask.Request) -> Tuple[str, str, str, str
         "stable_id": "<feed stable id>",
         "dataset_id": "<dataset stable id>",
         "file_name": "feed_info.txt",
-        "file_url":"<hosted_url of the GTFS file>"
+        "file_url": "<hosted_url of the GTFS file>"
     }
     """
     request_json = request.get_json(silent=True)

--- a/functions-python/gtfs_file_data_extractor/src/processor.py
+++ b/functions-python/gtfs_file_data_extractor/src/processor.py
@@ -23,7 +23,7 @@ def parse_request_parameters(request: flask.Request) -> Tuple[str, str, str, str
         "stable_id": "<feed stable id>",
         "dataset_id": "<dataset stable id>",
         "file_name": "feed_info.txt",
-        "file_url": "<hosted_url of the GTFS file>"
+        "file_url":"<hosted_url of the GTFS file>"
     }
     """
     request_json = request.get_json(silent=True)

--- a/functions-python/gtfs_file_data_extractor/src/processor.py
+++ b/functions-python/gtfs_file_data_extractor/src/processor.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 import flask
 import pandas as pd
@@ -11,7 +11,6 @@ from extractors.registry import get_extractor
 from shared.database.database import with_db_session
 from shared.database_gen.sqlacodegen_models import Gtfsdataset
 
-ERROR_STATUS_CODE = 500
 REQUIRED_PARAMETERS = ("stable_id", "dataset_id", "file_name", "file_url")
 
 
@@ -61,19 +60,40 @@ def read_csv_from_url(file_url: str) -> pd.DataFrame:
     return pd.read_csv(io.StringIO(response.content.decode("utf-8")))
 
 
+def get_file_hash(dataset: Gtfsdataset, file_name: str) -> Optional[str]:
+    """Content hash of ``file_name`` within ``dataset``, or None if unknown."""
+    return next(
+        (
+            file.hash
+            for file in dataset.gtfsfiles
+            if file.file_name == file_name and file.hash
+        ),
+        None,
+    )
+
+
 @with_db_session
-def process_file_data(
-    request: flask.Request, db_session: Session = None
-) -> Tuple[str, int]:
+def process_file_data(request: flask.Request, db_session: Session) -> Tuple[str, int]:
     """
-    Download a single GTFS file and dispatch it to the registered extractor,
-    which persists the extracted data to the database.
+    Persist the data extracted from a single GTFS file for one dataset.
+
+    Extracted data is shared by content hash, so when the file has already been
+    extracted for any dataset the dataset is simply linked to that data instead
+    of downloading the file again. This is what gives datasets whose file did not
+    change a reference to the data, while still extracting from the file when the
+    content is unchanged but was never extracted before.
+
+    Always returns HTTP 200, including on failure — the error is reported in the
+    body. We cannot distinguish transient from permanent errors (a DB blip vs a
+    malformed file), so letting Cloud Tasks retry would mostly burn the queue on
+    failures that can never succeed. Reruns are safe: the function is
+    idempotent, so a failed dataset is picked up by the next explicit rerun.
     """
     try:
         stable_id, dataset_id, file_name, file_url = parse_request_parameters(request)
     except ValueError as error:
         logging.error("Invalid request: %s", error)
-        return str(error), 400
+        return str(error), 200
 
     extractor = get_extractor(file_name)
     if extractor is None:
@@ -83,8 +103,27 @@ def process_file_data(
 
     try:
         dataset = load_dataset(dataset_id, db_session)
+
+        if extractor.has_data(dataset, db_session):
+            message = (
+                f"Data from {file_name} was already extracted for dataset "
+                f"{dataset_id}. Skipping."
+            )
+            logging.info(message)
+            return message, 200
+
+        file_hash = get_file_hash(dataset, file_name)
+        if extractor.link_existing_data(dataset, file_hash, db_session):
+            db_session.commit()
+            message = (
+                f"Linked dataset {dataset_id} to the data already extracted from "
+                f"an identical {file_name}."
+            )
+            logging.info(message)
+            return message, 200
+
         df = read_csv_from_url(file_url)
-        extractor.extract(df, dataset, db_session)
+        extractor.extract(df, dataset, file_hash, db_session)
         db_session.commit()
     except Exception as error:
         db_session.rollback()
@@ -94,7 +133,7 @@ def process_file_data(
             dataset_id,
             error,
         )
-        return f"Error extracting data from {file_name}: {error}", ERROR_STATUS_CODE
+        return f"Error extracting data from {file_name}: {error}", 200
 
     message = f"Successfully extracted data from {file_name} for dataset {dataset_id}."
     logging.info(message)

--- a/functions-python/gtfs_file_data_extractor/src/processor.py
+++ b/functions-python/gtfs_file_data_extractor/src/processor.py
@@ -1,0 +1,101 @@
+import io
+import logging
+from typing import Tuple
+
+import flask
+import pandas as pd
+import requests
+from sqlalchemy.orm import Session
+
+from extractors.registry import get_extractor
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import Gtfsdataset
+
+ERROR_STATUS_CODE = 500
+REQUIRED_PARAMETERS = ("stable_id", "dataset_id", "file_name", "file_url")
+
+
+def parse_request_parameters(request: flask.Request) -> Tuple[str, str, str, str]:
+    """
+    Parse and validate the Cloud Task payload.
+
+    Expected JSON body:
+    {
+        "stable_id": "<feed stable id>",
+        "dataset_id": "<dataset stable id>",
+        "file_name": "feed_info.txt",
+        "file_url": "<hosted_url of the GTFS file>"
+    }
+    """
+    request_json = request.get_json(silent=True)
+    logging.info("Request JSON: %s", request_json)
+    if not request_json:
+        raise ValueError("Missing or invalid JSON body.")
+    missing = [key for key in REQUIRED_PARAMETERS if not request_json.get(key)]
+    if missing:
+        raise ValueError(f"Missing required parameters: {missing}.")
+    return (
+        request_json["stable_id"],
+        request_json["dataset_id"],
+        request_json["file_name"],
+        request_json["file_url"],
+    )
+
+
+def load_dataset(dataset_id: str, db_session: Session) -> Gtfsdataset:
+    dataset = (
+        db_session.query(Gtfsdataset)
+        .filter(Gtfsdataset.stable_id == dataset_id)
+        .one_or_none()
+    )
+    if not dataset:
+        raise ValueError(
+            f"Dataset with ID {dataset_id} does not exist in the database."
+        )
+    return dataset
+
+
+def read_csv_from_url(file_url: str) -> pd.DataFrame:
+    response = requests.get(file_url)
+    response.raise_for_status()
+    return pd.read_csv(io.StringIO(response.content.decode("utf-8")))
+
+
+@with_db_session
+def process_file_data(
+    request: flask.Request, db_session: Session = None
+) -> Tuple[str, int]:
+    """
+    Download a single GTFS file and dispatch it to the registered extractor,
+    which persists the extracted data to the database.
+    """
+    try:
+        stable_id, dataset_id, file_name, file_url = parse_request_parameters(request)
+    except ValueError as error:
+        logging.error("Invalid request: %s", error)
+        return str(error), 400
+
+    extractor = get_extractor(file_name)
+    if extractor is None:
+        message = f"No extractor registered for file '{file_name}'. Skipping."
+        logging.info(message)
+        return message, 200
+
+    try:
+        dataset = load_dataset(dataset_id, db_session)
+        df = read_csv_from_url(file_url)
+        extractor.extract(df, dataset, db_session)
+        db_session.commit()
+    except Exception as error:
+        db_session.rollback()
+        logging.error(
+            "Error extracting data from %s for dataset %s: %s",
+            file_name,
+            dataset_id,
+            error,
+        )
+        return f"Error extracting data from {file_name}: {error}", ERROR_STATUS_CODE
+
+    message = f"Successfully extracted data from {file_name} for dataset {dataset_id}."
+    logging.info(message)
+    return message, 200

--- a/functions-python/gtfs_file_data_extractor/tests/test_feed_info_extractor.py
+++ b/functions-python/gtfs_file_data_extractor/tests/test_feed_info_extractor.py
@@ -1,0 +1,157 @@
+import datetime
+import unittest
+
+import pandas as pd
+from faker import Faker
+
+from extractors.feed_info_extractor import (
+    FeedInfoExtractor,
+    clean_str,
+    parse_gtfs_date,
+)
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import Feedinfo, Gtfsdataset, Gtfsfeed
+from test_shared.test_utils.database_utils import clean_testing_db, default_db_url
+
+faker = Faker()
+
+
+class TestParsingHelpers(unittest.TestCase):
+    def test_clean_str(self):
+        self.assertIsNone(clean_str(None))
+        self.assertIsNone(clean_str(float("nan")))
+        self.assertIsNone(clean_str("   "))
+        self.assertEqual(clean_str("  Agency  "), "Agency")
+        self.assertEqual(clean_str(123), "123")
+
+    def test_parse_gtfs_date_valid(self):
+        self.assertEqual(parse_gtfs_date("20240115"), datetime.date(2024, 1, 15))
+
+    def test_parse_gtfs_date_numeric(self):
+        # pandas may read a purely numeric column as int or float
+        self.assertEqual(parse_gtfs_date("20240115.0"), datetime.date(2024, 1, 15))
+        self.assertEqual(parse_gtfs_date(20240115), datetime.date(2024, 1, 15))
+
+    def test_parse_gtfs_date_missing_or_invalid(self):
+        self.assertIsNone(parse_gtfs_date(None))
+        self.assertIsNone(parse_gtfs_date(""))
+        self.assertIsNone(parse_gtfs_date("not-a-date"))
+
+
+class TestFeedInfoExtractor(unittest.TestCase):
+    def setUp(self):
+        clean_testing_db()
+
+    def _create_dataset(self, db_session):
+        feed = Gtfsfeed(
+            id=faker.uuid4(cast_to=str),
+            data_type="gtfs",
+            stable_id=faker.uuid4(cast_to=str),
+        )
+        dataset_id = faker.uuid4(cast_to=str)
+        dataset = Gtfsdataset(id=dataset_id, stable_id=dataset_id, feed=feed)
+        db_session.add(dataset)
+        db_session.commit()
+        return dataset
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_inserts_feedinfo(self, db_session):
+        dataset = self._create_dataset(db_session)
+        df = pd.DataFrame(
+            [
+                {
+                    "feed_publisher_name": "Test Agency",
+                    "feed_publisher_url": "https://example.com",
+                    "feed_lang": "en",
+                    "default_lang": "fr",
+                    "feed_start_date": "20240101",
+                    "feed_end_date": "20241231",
+                    "feed_version": "v1",
+                    "feed_contact_email": "info@example.com",
+                    "feed_contact_url": "https://example.com/contact",
+                }
+            ]
+        )
+        FeedInfoExtractor().extract(df, dataset, db_session)
+        db_session.commit()
+
+        feed_info = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
+            .one()
+        )
+        self.assertEqual(feed_info.feed_publisher_name, "Test Agency")
+        self.assertEqual(feed_info.feed_publisher_url, "https://example.com")
+        self.assertEqual(feed_info.feed_lang, "en")
+        self.assertEqual(feed_info.default_lang, "fr")
+        self.assertEqual(feed_info.feed_start_date, datetime.date(2024, 1, 1))
+        self.assertEqual(feed_info.feed_end_date, datetime.date(2024, 12, 31))
+        self.assertEqual(feed_info.feed_version, "v1")
+        self.assertEqual(feed_info.feed_contact_email, "info@example.com")
+        self.assertEqual(feed_info.feed_contact_url, "https://example.com/contact")
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_upserts_existing(self, db_session):
+        dataset = self._create_dataset(db_session)
+        FeedInfoExtractor().extract(
+            pd.DataFrame(
+                [{"feed_publisher_name": "First", "feed_start_date": "20240101"}]
+            ),
+            dataset,
+            db_session,
+        )
+        db_session.commit()
+
+        FeedInfoExtractor().extract(
+            pd.DataFrame(
+                [{"feed_publisher_name": "Second", "feed_start_date": "20250101"}]
+            ),
+            dataset,
+            db_session,
+        )
+        db_session.commit()
+
+        rows = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
+            .all()
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].feed_publisher_name, "Second")
+        self.assertEqual(rows[0].feed_start_date, datetime.date(2025, 1, 1))
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_missing_optional_columns(self, db_session):
+        dataset = self._create_dataset(db_session)
+        FeedInfoExtractor().extract(
+            pd.DataFrame([{"feed_publisher_name": "Only Name"}]),
+            dataset,
+            db_session,
+        )
+        db_session.commit()
+
+        feed_info = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
+            .one()
+        )
+        self.assertEqual(feed_info.feed_publisher_name, "Only Name")
+        self.assertIsNone(feed_info.feed_start_date)
+        self.assertIsNone(feed_info.feed_lang)
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_empty_dataframe_is_noop(self, db_session):
+        dataset = self._create_dataset(db_session)
+        FeedInfoExtractor().extract(pd.DataFrame(), dataset, db_session)
+        db_session.commit()
+
+        count = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
+            .count()
+        )
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/functions-python/gtfs_file_data_extractor/tests/test_feed_info_extractor.py
+++ b/functions-python/gtfs_file_data_extractor/tests/test_feed_info_extractor.py
@@ -72,14 +72,12 @@ class TestFeedInfoExtractor(unittest.TestCase):
                 }
             ]
         )
-        FeedInfoExtractor().extract(df, dataset, db_session)
+        FeedInfoExtractor().extract(df, dataset, "hash-1", db_session)
         db_session.commit()
 
-        feed_info = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
-            .one()
-        )
+        feed_info = dataset.feed_info
+        self.assertIsNotNone(feed_info)
+        self.assertEqual(feed_info.file_hash, "hash-1")
         self.assertEqual(feed_info.feed_publisher_name, "Test Agency")
         self.assertEqual(feed_info.feed_publisher_url, "https://example.com")
         self.assertEqual(feed_info.feed_lang, "en")
@@ -91,13 +89,15 @@ class TestFeedInfoExtractor(unittest.TestCase):
         self.assertEqual(feed_info.feed_contact_url, "https://example.com/contact")
 
     @with_db_session(db_url=default_db_url)
-    def test_extract_upserts_existing(self, db_session):
+    def test_extract_upserts_by_hash(self, db_session):
+        """Re-parsing the same content updates the shared row in place."""
         dataset = self._create_dataset(db_session)
         FeedInfoExtractor().extract(
             pd.DataFrame(
                 [{"feed_publisher_name": "First", "feed_start_date": "20240101"}]
             ),
             dataset,
+            "hash-1",
             db_session,
         )
         db_session.commit()
@@ -107,18 +107,38 @@ class TestFeedInfoExtractor(unittest.TestCase):
                 [{"feed_publisher_name": "Second", "feed_start_date": "20250101"}]
             ),
             dataset,
+            "hash-1",
             db_session,
         )
         db_session.commit()
 
-        rows = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
-            .all()
-        )
+        rows = db_session.query(Feedinfo).all()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].feed_publisher_name, "Second")
         self.assertEqual(rows[0].feed_start_date, datetime.date(2025, 1, 1))
+        self.assertEqual(dataset.feed_info_id, rows[0].id)
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_different_hash_creates_second_row(self, db_session):
+        extractor = FeedInfoExtractor()
+        first = self._create_dataset(db_session)
+        second = self._create_dataset(db_session)
+        extractor.extract(
+            pd.DataFrame([{"feed_publisher_name": "First"}]),
+            first,
+            "hash-1",
+            db_session,
+        )
+        extractor.extract(
+            pd.DataFrame([{"feed_publisher_name": "Second"}]),
+            second,
+            "hash-2",
+            db_session,
+        )
+        db_session.commit()
+
+        self.assertEqual(db_session.query(Feedinfo).count(), 2)
+        self.assertNotEqual(first.feed_info_id, second.feed_info_id)
 
     @with_db_session(db_url=default_db_url)
     def test_extract_missing_optional_columns(self, db_session):
@@ -126,31 +146,90 @@ class TestFeedInfoExtractor(unittest.TestCase):
         FeedInfoExtractor().extract(
             pd.DataFrame([{"feed_publisher_name": "Only Name"}]),
             dataset,
+            "hash-1",
             db_session,
         )
         db_session.commit()
 
-        feed_info = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
-            .one()
-        )
-        self.assertEqual(feed_info.feed_publisher_name, "Only Name")
-        self.assertIsNone(feed_info.feed_start_date)
-        self.assertIsNone(feed_info.feed_lang)
+        self.assertEqual(dataset.feed_info.feed_publisher_name, "Only Name")
+        self.assertIsNone(dataset.feed_info.feed_start_date)
+        self.assertIsNone(dataset.feed_info.feed_lang)
 
     @with_db_session(db_url=default_db_url)
     def test_extract_empty_dataframe_is_noop(self, db_session):
         dataset = self._create_dataset(db_session)
-        FeedInfoExtractor().extract(pd.DataFrame(), dataset, db_session)
+        FeedInfoExtractor().extract(pd.DataFrame(), dataset, "hash-1", db_session)
         db_session.commit()
 
-        count = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset.id)
-            .count()
+        self.assertEqual(db_session.query(Feedinfo).count(), 0)
+        self.assertIsNone(dataset.feed_info_id)
+
+    @with_db_session(db_url=default_db_url)
+    def test_extract_without_hash_raises(self, db_session):
+        dataset = self._create_dataset(db_session)
+        with self.assertRaises(ValueError):
+            FeedInfoExtractor().extract(
+                pd.DataFrame([{"feed_publisher_name": "Agency"}]),
+                dataset,
+                None,
+                db_session,
+            )
+
+    @with_db_session(db_url=default_db_url)
+    def test_has_data(self, db_session):
+        dataset = self._create_dataset(db_session)
+        extractor = FeedInfoExtractor()
+        self.assertFalse(extractor.has_data(dataset, db_session))
+
+        extractor.extract(
+            pd.DataFrame([{"feed_publisher_name": "Agency"}]),
+            dataset,
+            "hash-1",
+            db_session,
         )
-        self.assertEqual(count, 0)
+        db_session.commit()
+        self.assertTrue(extractor.has_data(dataset, db_session))
+
+    @with_db_session(db_url=default_db_url)
+    def test_link_existing_data_shares_one_row(self, db_session):
+        extractor = FeedInfoExtractor()
+        source = self._create_dataset(db_session)
+        target = self._create_dataset(db_session)
+        extractor.extract(
+            pd.DataFrame(
+                [
+                    {
+                        "feed_publisher_name": "Agency",
+                        "feed_lang": "en",
+                        "feed_start_date": "20240101",
+                    }
+                ]
+            ),
+            source,
+            "hash-1",
+            db_session,
+        )
+        db_session.commit()
+
+        self.assertTrue(extractor.link_existing_data(target, "hash-1", db_session))
+        db_session.commit()
+
+        # No duplicate entity: both datasets reference the same feedinfo row.
+        self.assertEqual(db_session.query(Feedinfo).count(), 1)
+        self.assertEqual(target.feed_info_id, source.feed_info_id)
+        self.assertEqual(target.feed_info.feed_publisher_name, "Agency")
+        self.assertCountEqual(
+            [d.id for d in source.feed_info.gtfsdatasets], [source.id, target.id]
+        )
+
+    @with_db_session(db_url=default_db_url)
+    def test_link_existing_data_without_match(self, db_session):
+        extractor = FeedInfoExtractor()
+        dataset = self._create_dataset(db_session)
+        self.assertFalse(extractor.link_existing_data(dataset, "unknown", db_session))
+        # An unknown hash cannot be matched either.
+        self.assertFalse(extractor.link_existing_data(dataset, None, db_session))
+        self.assertIsNone(dataset.feed_info_id)
 
 
 if __name__ == "__main__":

--- a/functions-python/gtfs_file_data_extractor/tests/test_processor.py
+++ b/functions-python/gtfs_file_data_extractor/tests/test_processor.py
@@ -1,0 +1,137 @@
+import datetime
+import unittest
+from unittest.mock import MagicMock, patch
+
+from faker import Faker
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import Feedinfo, Gtfsdataset, Gtfsfeed
+from test_shared.test_utils.database_utils import clean_testing_db, default_db_url
+
+faker = Faker()
+
+
+def make_request(payload):
+    request = MagicMock()
+    request.get_json.return_value = payload
+    return request
+
+
+class TestParseRequestParameters(unittest.TestCase):
+    def test_valid(self):
+        from processor import parse_request_parameters
+
+        payload = {
+            "stable_id": "feed",
+            "dataset_id": "dataset",
+            "file_name": "feed_info.txt",
+            "file_url": "http://example.com/feed_info.txt",
+        }
+        self.assertEqual(
+            parse_request_parameters(make_request(payload)),
+            ("feed", "dataset", "feed_info.txt", "http://example.com/feed_info.txt"),
+        )
+
+    def test_missing_parameters(self):
+        from processor import parse_request_parameters
+
+        with self.assertRaises(ValueError):
+            parse_request_parameters(make_request({"stable_id": "feed"}))
+
+    def test_no_body(self):
+        from processor import parse_request_parameters
+
+        with self.assertRaises(ValueError):
+            parse_request_parameters(make_request(None))
+
+
+class TestProcessFileData(unittest.TestCase):
+    def setUp(self):
+        clean_testing_db()
+
+    def _create_dataset(self, db_session):
+        feed = Gtfsfeed(
+            id=faker.uuid4(cast_to=str),
+            data_type="gtfs",
+            stable_id=faker.uuid4(cast_to=str),
+        )
+        dataset_id = faker.uuid4(cast_to=str)
+        dataset = Gtfsdataset(id=dataset_id, stable_id=dataset_id, feed=feed)
+        db_session.add(dataset)
+        db_session.commit()
+        return dataset_id
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_success_writes_feedinfo(self, requests_mock, db_session):
+        dataset_id = self._create_dataset(db_session)
+        csv = (
+            "feed_publisher_name,feed_start_date,feed_end_date\n"
+            "Agency,20240101,20241231\n"
+        )
+        requests_mock.get.return_value.content = csv.encode("utf-8")
+
+        from processor import process_file_data
+
+        payload = {
+            "stable_id": "feed",
+            "dataset_id": dataset_id,
+            "file_name": "feed_info.txt",
+            "file_url": "http://example.com/feed_info.txt",
+        }
+        _, status = process_file_data(make_request(payload), db_session=db_session)
+        self.assertEqual(status, 200)
+
+        feed_info = (
+            db_session.query(Feedinfo)
+            .filter(Feedinfo.gtfs_dataset_id == dataset_id)
+            .one()
+        )
+        self.assertEqual(feed_info.feed_publisher_name, "Agency")
+        self.assertEqual(feed_info.feed_start_date, datetime.date(2024, 1, 1))
+        self.assertEqual(feed_info.feed_end_date, datetime.date(2024, 12, 31))
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_unregistered_file_skips(self, requests_mock, db_session):
+        from processor import process_file_data
+
+        payload = {
+            "stable_id": "feed",
+            "dataset_id": "dataset",
+            "file_name": "stops.txt",
+            "file_url": "http://example.com/stops.txt",
+        }
+        message, status = process_file_data(
+            make_request(payload), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("No extractor", message)
+        requests_mock.get.assert_not_called()
+
+    @with_db_session(db_url=default_db_url)
+    def test_process_invalid_payload_returns_400(self, db_session):
+        from processor import process_file_data
+
+        _, status = process_file_data(make_request({}), db_session=db_session)
+        self.assertEqual(status, 400)
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_missing_dataset_returns_500(self, requests_mock, db_session):
+        requests_mock.get.return_value.content = b"feed_publisher_name\nAgency\n"
+
+        from processor import process_file_data
+
+        payload = {
+            "stable_id": "feed",
+            "dataset_id": "does-not-exist",
+            "file_name": "feed_info.txt",
+            "file_url": "http://example.com/feed_info.txt",
+        }
+        _, status = process_file_data(make_request(payload), db_session=db_session)
+        self.assertEqual(status, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/functions-python/gtfs_file_data_extractor/tests/test_processor.py
+++ b/functions-python/gtfs_file_data_extractor/tests/test_processor.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 from faker import Faker
 
 from shared.database.database import with_db_session
-from shared.database_gen.sqlacodegen_models import Feedinfo, Gtfsdataset, Gtfsfeed
+from shared.database_gen.sqlacodegen_models import (
+    Feedinfo,
+    Gtfsdataset,
+    Gtfsfeed,
+    Gtfsfile,
+)
 from test_shared.test_utils.database_utils import clean_testing_db, default_db_url
 
 faker = Faker()
@@ -61,10 +66,48 @@ class TestProcessFileData(unittest.TestCase):
         db_session.commit()
         return dataset_id
 
+    def _create_dataset_with_file(
+        self, db_session, feed=None, file_hash="h1", downloaded_at=None
+    ):
+        """Create a dataset owning a feed_info.txt file with the given hash."""
+        if feed is None:
+            feed = Gtfsfeed(
+                id=faker.uuid4(cast_to=str),
+                data_type="gtfs",
+                stable_id=faker.uuid4(cast_to=str),
+            )
+        dataset_id = faker.uuid4(cast_to=str)
+        dataset = Gtfsdataset(
+            id=dataset_id,
+            stable_id=dataset_id,
+            feed=feed,
+            downloaded_at=downloaded_at or datetime.datetime.now(datetime.timezone.utc),
+        )
+        dataset.gtfsfiles = [
+            Gtfsfile(
+                id=faker.uuid4(cast_to=str),
+                file_name="feed_info.txt",
+                file_size_bytes=100,
+                hash=file_hash,
+                hosted_url="http://example.com/feed_info.txt",
+            )
+        ]
+        db_session.add(dataset)
+        db_session.commit()
+        return dataset
+
+    def _payload(self, dataset_stable_id):
+        return {
+            "stable_id": "feed",
+            "dataset_id": dataset_stable_id,
+            "file_name": "feed_info.txt",
+            "file_url": "http://example.com/feed_info.txt",
+        }
+
     @with_db_session(db_url=default_db_url)
     @patch("processor.requests")
     def test_process_success_writes_feedinfo(self, requests_mock, db_session):
-        dataset_id = self._create_dataset(db_session)
+        dataset = self._create_dataset_with_file(db_session)
         csv = (
             "feed_publisher_name,feed_start_date,feed_end_date\n"
             "Agency,20240101,20241231\n"
@@ -73,20 +116,13 @@ class TestProcessFileData(unittest.TestCase):
 
         from processor import process_file_data
 
-        payload = {
-            "stable_id": "feed",
-            "dataset_id": dataset_id,
-            "file_name": "feed_info.txt",
-            "file_url": "http://example.com/feed_info.txt",
-        }
-        _, status = process_file_data(make_request(payload), db_session=db_session)
+        _, status = process_file_data(
+            make_request(self._payload(dataset.stable_id)), db_session=db_session
+        )
         self.assertEqual(status, 200)
 
-        feed_info = (
-            db_session.query(Feedinfo)
-            .filter(Feedinfo.gtfs_dataset_id == dataset_id)
-            .one()
-        )
+        feed_info = dataset.feed_info
+        self.assertIsNotNone(feed_info)
         self.assertEqual(feed_info.feed_publisher_name, "Agency")
         self.assertEqual(feed_info.feed_start_date, datetime.date(2024, 1, 1))
         self.assertEqual(feed_info.feed_end_date, datetime.date(2024, 12, 31))
@@ -110,27 +146,152 @@ class TestProcessFileData(unittest.TestCase):
         requests_mock.get.assert_not_called()
 
     @with_db_session(db_url=default_db_url)
-    def test_process_invalid_payload_returns_400(self, db_session):
+    def test_process_invalid_payload_does_not_trigger_retry(self, db_session):
         from processor import process_file_data
 
-        _, status = process_file_data(make_request({}), db_session=db_session)
-        self.assertEqual(status, 400)
+        # Failures return 200 so Cloud Tasks does not retry them.
+        message, status = process_file_data(make_request({}), db_session=db_session)
+        self.assertEqual(status, 200)
+        self.assertIn("Missing or invalid JSON body", message)
+
+        message, status = process_file_data(
+            make_request({"stable_id": "feed"}), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("Missing required parameters", message)
 
     @with_db_session(db_url=default_db_url)
     @patch("processor.requests")
-    def test_process_missing_dataset_returns_500(self, requests_mock, db_session):
+    def test_process_missing_dataset_does_not_trigger_retry(
+        self, requests_mock, db_session
+    ):
         requests_mock.get.return_value.content = b"feed_publisher_name\nAgency\n"
 
         from processor import process_file_data
 
-        payload = {
-            "stable_id": "feed",
-            "dataset_id": "does-not-exist",
-            "file_name": "feed_info.txt",
-            "file_url": "http://example.com/feed_info.txt",
-        }
-        _, status = process_file_data(make_request(payload), db_session=db_session)
-        self.assertEqual(status, 500)
+        message, status = process_file_data(
+            make_request(self._payload("does-not-exist")), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("does not exist", message)
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_download_failure_does_not_trigger_retry(
+        self, requests_mock, db_session
+    ):
+        requests_mock.get.side_effect = Exception("connection reset")
+        dataset_id = self._create_dataset(db_session)
+
+        from processor import process_file_data
+
+        message, status = process_file_data(
+            make_request(self._payload(dataset_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("connection reset", message)
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_links_to_existing_data(self, requests_mock, db_session):
+        """Unchanged file, already extracted -> link to the same row, no download."""
+        source = self._create_dataset_with_file(db_session)
+        target = self._create_dataset_with_file(db_session, feed=source.feed)
+        feed_info = Feedinfo(file_hash="h1", feed_publisher_name="Agency")
+        source.feed_info = feed_info
+        db_session.commit()
+
+        from processor import process_file_data
+
+        message, status = process_file_data(
+            make_request(self._payload(target.stable_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("Linked", message)
+        requests_mock.get.assert_not_called()
+
+        # One shared entity, referenced by both datasets.
+        self.assertEqual(db_session.query(Feedinfo).count(), 1)
+        self.assertEqual(target.feed_info_id, source.feed_info_id)
+        self.assertEqual(target.feed_info.feed_publisher_name, "Agency")
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_extracts_when_unchanged_but_never_extracted(
+        self, requests_mock, db_session
+    ):
+        """Unchanged file that was never extracted -> download and extract."""
+        source = self._create_dataset_with_file(db_session)
+        target = self._create_dataset_with_file(db_session, feed=source.feed)
+        requests_mock.get.return_value.content = b"feed_publisher_name\nAgency\n"
+
+        from processor import process_file_data
+
+        message, status = process_file_data(
+            make_request(self._payload(target.stable_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("Successfully extracted", message)
+        requests_mock.get.assert_called_once()
+        self.assertEqual(target.feed_info.feed_publisher_name, "Agency")
+        self.assertEqual(target.feed_info.file_hash, "h1")
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_extracts_when_hash_differs(self, requests_mock, db_session):
+        """A different hash is different content: extract into its own row."""
+        source = self._create_dataset_with_file(db_session, file_hash="h1")
+        target = self._create_dataset_with_file(
+            db_session, feed=source.feed, file_hash="h2"
+        )
+        source.feed_info = Feedinfo(file_hash="h1", feed_publisher_name="Old")
+        db_session.commit()
+        requests_mock.get.return_value.content = b"feed_publisher_name\nNew\n"
+
+        from processor import process_file_data
+
+        _, status = process_file_data(
+            make_request(self._payload(target.stable_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        requests_mock.get.assert_called_once()
+        self.assertEqual(db_session.query(Feedinfo).count(), 2)
+        self.assertEqual(target.feed_info.feed_publisher_name, "New")
+        self.assertEqual(source.feed_info.feed_publisher_name, "Old")
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_skips_when_already_extracted(self, requests_mock, db_session):
+        dataset = self._create_dataset_with_file(db_session)
+        dataset.feed_info = Feedinfo(file_hash="h1", feed_publisher_name="Agency")
+        db_session.commit()
+
+        from processor import process_file_data
+
+        message, status = process_file_data(
+            make_request(self._payload(dataset.stable_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("already extracted", message)
+        requests_mock.get.assert_not_called()
+
+    @with_db_session(db_url=default_db_url)
+    @patch("processor.requests")
+    def test_process_without_file_hash_does_not_trigger_retry(
+        self, requests_mock, db_session
+    ):
+        """Without a hash the data cannot be shared, so this fails loudly - once."""
+        dataset = self._create_dataset_with_file(db_session, file_hash=None)
+        requests_mock.get.return_value.content = b"feed_publisher_name\nAgency\n"
+
+        from processor import process_file_data
+
+        message, status = process_file_data(
+            make_request(self._payload(dataset.stable_id)), db_session=db_session
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("content hash", message)
+        self.assertEqual(db_session.query(Feedinfo).count(), 0)
 
 
 if __name__ == "__main__":

--- a/functions-python/gtfs_file_data_extractor/tests/test_registry.py
+++ b/functions-python/gtfs_file_data_extractor/tests/test_registry.py
@@ -1,0 +1,20 @@
+import unittest
+
+from extractors.feed_info_extractor import FeedInfoExtractor
+from extractors.registry import EXTRACTORS, get_extractor
+
+
+class TestRegistry(unittest.TestCase):
+    def test_known_file_returns_extractor(self):
+        self.assertIsInstance(get_extractor("feed_info.txt"), FeedInfoExtractor)
+
+    def test_unknown_file_returns_none(self):
+        self.assertIsNone(get_extractor("stops.txt"))
+
+    def test_registry_keys_match_extractor_file_name(self):
+        for file_name, extractor in EXTRACTORS.items():
+            self.assertEqual(file_name, extractor.file_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -294,6 +294,25 @@ resource "google_cloud_tasks_queue" "gtfs_datasets_comparer_task_queue" {
   }
 }
 
+# Task queue to invoke gtfs_file_data_extractor function
+# The function itself is deployed by the infra/functions-python stack.
+resource "google_cloud_tasks_queue" "gtfs_file_data_extractor_task_queue" {
+  project  = var.project_id
+  location = var.gcp_region
+  name     = "gtfs-file-data-extractor-queue-${var.environment}-${local.deployment_timestamp}"
+
+  rate_limits {
+    max_concurrent_dispatches = 10
+    max_dispatches_per_second = 1
+  }
+
+  retry_config {
+    max_attempts = 10
+    min_backoff  = "20s"
+    max_backoff  = "60s"
+  }
+}
+
 
 # Batch process dataset function
 resource "google_cloudfunctions2_function" "pubsub_function" {
@@ -332,7 +351,7 @@ resource "google_cloudfunctions2_function" "pubsub_function" {
       MATERIALIZED_VIEW_QUEUE = google_cloud_tasks_queue.refresh_materialized_view_task_queue.name
       PMTILES_BUILDER_QUEUE = google_cloud_tasks_queue.pmtiles_builder_task_queue.name
       REVERSE_GEOLOCATION_QUEUE = "reverse-geolocation-processor-task-queue"
-      GTFS_FILE_DATA_EXTRACTOR_QUEUE = "gtfs-file-data-extractor-task-queue"
+      GTFS_FILE_DATA_EXTRACTOR_QUEUE = google_cloud_tasks_queue.gtfs_file_data_extractor_task_queue.name
       GTFS_CHANGE_TRACKER_QUEUE = google_cloud_tasks_queue.gtfs_datasets_comparer_task_queue.name
       WEB_REVALIDATION_QUEUE = google_cloud_tasks_queue.web_revalidation_task_queue.name
     }

--- a/infra/batch/main.tf
+++ b/infra/batch/main.tf
@@ -332,6 +332,7 @@ resource "google_cloudfunctions2_function" "pubsub_function" {
       MATERIALIZED_VIEW_QUEUE = google_cloud_tasks_queue.refresh_materialized_view_task_queue.name
       PMTILES_BUILDER_QUEUE = google_cloud_tasks_queue.pmtiles_builder_task_queue.name
       REVERSE_GEOLOCATION_QUEUE = "reverse-geolocation-processor-task-queue"
+      GTFS_FILE_DATA_EXTRACTOR_QUEUE = "gtfs-file-data-extractor-task-queue"
       GTFS_CHANGE_TRACKER_QUEUE = google_cloud_tasks_queue.gtfs_datasets_comparer_task_queue.name
       WEB_REVALIDATION_QUEUE = google_cloud_tasks_queue.web_revalidation_task_queue.name
     }

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -68,6 +68,9 @@ locals {
 
   function_gtfs_datasets_comparer_config = jsondecode(file("${path.module}/../../functions-python/gtfs_datasets_comparer/function_config.json"))
   function_gtfs_datasets_comparer_zip    = "${path.module}/../../functions-python/gtfs_datasets_comparer/.dist/gtfs_datasets_comparer.zip"
+
+  function_gtfs_file_data_extractor_config = jsondecode(file("${path.module}/../../functions-python/gtfs_file_data_extractor/function_config.json"))
+  function_gtfs_file_data_extractor_zip    = "${path.module}/../../functions-python/gtfs_file_data_extractor/.dist/gtfs_file_data_extractor.zip"
 }
 
 locals {
@@ -80,7 +83,8 @@ locals {
     local.function_export_csv_config.secret_environment_variables,
     local.function_tasks_executor_config.secret_environment_variables,
     local.function_pmtiles_builder_config.secret_environment_variables,
-    local.function_gtfs_datasets_comparer_config.secret_environment_variables
+    local.function_gtfs_datasets_comparer_config.secret_environment_variables,
+    local.function_gtfs_file_data_extractor_config.secret_environment_variables
   )
 
   # Remove duplicates by key, keeping the first occurrence
@@ -231,6 +235,13 @@ resource "google_storage_bucket_object" "gtfs_datasets_comparer_zip" {
   bucket = google_storage_bucket.functions_bucket.name
   name   = "gtfs-datasets-comparer-${substr(filebase64sha256(local.function_gtfs_datasets_comparer_zip), 0, 10)}.zip"
   source = local.function_gtfs_datasets_comparer_zip
+}
+
+# 17. GTFS File Data Extractor
+resource "google_storage_bucket_object" "gtfs_file_data_extractor_zip" {
+  bucket = google_storage_bucket.functions_bucket.name
+  name   = "gtfs-file-data-extractor-${substr(filebase64sha256(local.function_gtfs_file_data_extractor_zip), 0, 10)}.zip"
+  source = local.function_gtfs_file_data_extractor_zip
 }
 
 # Web app revalidation secret
@@ -1129,6 +1140,87 @@ resource "google_cloudfunctions2_function_iam_member" "gtfs_datasets_comparer_in
   cloud_function = google_cloudfunctions2_function.gtfs_datasets_comparer.name
   role           = "roles/cloudfunctions.invoker"
   member         = "serviceAccount:${google_service_account.functions_service_account.email}"
+}
+
+# 17.1 functions/gtfs_file_data_extractor cloud function
+resource "google_cloudfunctions2_function" "gtfs_file_data_extractor" {
+  name        = local.function_gtfs_file_data_extractor_config.name
+  description = local.function_gtfs_file_data_extractor_config.description
+  location    = var.gcp_region
+  depends_on = [
+    google_project_iam_member.event-receiving,
+    google_secret_manager_secret_iam_member.secret_iam_member,
+  ]
+
+  build_config {
+    runtime     = var.python_runtime
+    entry_point = local.function_gtfs_file_data_extractor_config.entry_point
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions_bucket.name
+        object = google_storage_bucket_object.gtfs_file_data_extractor_zip.name
+      }
+    }
+  }
+  service_config {
+    environment_variables = {
+      PYTHONNODEBUGRANGES = 0
+      ENVIRONMENT         = var.environment
+      PROJECT_ID          = var.project_id
+      GCP_REGION          = var.gcp_region
+    }
+    available_memory                 = local.function_gtfs_file_data_extractor_config.available_memory
+    timeout_seconds                  = local.function_gtfs_file_data_extractor_config.timeout
+    available_cpu                    = local.function_gtfs_file_data_extractor_config.available_cpu
+    max_instance_request_concurrency = local.function_gtfs_file_data_extractor_config.max_instance_request_concurrency
+    max_instance_count               = local.function_gtfs_file_data_extractor_config.max_instance_count
+    min_instance_count               = local.function_gtfs_file_data_extractor_config.min_instance_count
+    service_account_email            = google_service_account.functions_service_account.email
+    ingress_settings                 = local.function_gtfs_file_data_extractor_config.ingress_settings
+    vpc_connector                    = data.google_vpc_access_connector.vpc_connector.id
+    vpc_connector_egress_settings    = "PRIVATE_RANGES_ONLY"
+    dynamic "secret_environment_variables" {
+      for_each = local.function_gtfs_file_data_extractor_config.secret_environment_variables
+      content {
+        key        = secret_environment_variables.value["key"]
+        project_id = var.project_id
+        secret     = "${upper(var.environment)}_${secret_environment_variables.value["key"]}"
+        version    = "latest"
+      }
+    }
+  }
+}
+
+# 17.2 gtfs_file_data_extractor task queue
+resource "google_cloud_tasks_queue" "gtfs_file_data_extractor_task_queue" {
+  location = var.gcp_region
+  name     = "gtfs-file-data-extractor-task-queue"
+  rate_limits {
+    max_concurrent_dispatches = 10
+    max_dispatches_per_second = 1
+  }
+  retry_config {
+    max_attempts = 10
+    min_backoff  = "20s"
+    max_backoff  = "60s"
+  }
+}
+
+# Grant execution permission to batchfunctions service account to the gtfs_file_data_extractor function
+resource "google_cloudfunctions2_function_iam_member" "gtfs_file_data_extractor_invoker_batch_sa" {
+  project        = var.project_id
+  location       = var.gcp_region
+  cloud_function = google_cloudfunctions2_function.gtfs_file_data_extractor.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:${local.batchfunctions_sa_email}"
+}
+
+resource "google_cloud_run_service_iam_member" "gtfs_file_data_extractor_cloud_run_invoker" {
+  project  = var.project_id
+  location = var.gcp_region
+  service  = google_cloudfunctions2_function.gtfs_file_data_extractor.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${local.batchfunctions_sa_email}"
 }
 
 # 13.3 functions/reverse_geolocation - batch cloud function

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -1191,21 +1191,6 @@ resource "google_cloudfunctions2_function" "gtfs_file_data_extractor" {
   }
 }
 
-# 17.2 gtfs_file_data_extractor task queue
-resource "google_cloud_tasks_queue" "gtfs_file_data_extractor_task_queue" {
-  location = var.gcp_region
-  name     = "gtfs-file-data-extractor-task-queue"
-  rate_limits {
-    max_concurrent_dispatches = 10
-    max_dispatches_per_second = 1
-  }
-  retry_config {
-    max_attempts = 10
-    min_backoff  = "20s"
-    max_backoff  = "60s"
-  }
-}
-
 # Grant execution permission to batchfunctions service account to the gtfs_file_data_extractor function
 resource "google_cloudfunctions2_function_iam_member" "gtfs_file_data_extractor_invoker_batch_sa" {
   project        = var.project_id

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -125,6 +125,8 @@
     <include file="changes/feat_1766.sql" relativeToChangelogFile="true"/>
     <!-- Add hierarchy table for location search materialized view. -->
     <include file="changes/feat_pt_202.sql" relativeToChangelogFile="true"/>
+    <!-- Add feedinfo table storing parsed feed_info.txt fields (issue #1775). -->
+    <include file="changes/feat_1775.sql" relativeToChangelogFile="true"/>
     <!-- Keep this after all source table and schema changes so materialized views
     are recreated from the final source schema. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/feat_1775.sql
+++ b/liquibase/changes/feat_1775.sql
@@ -1,0 +1,26 @@
+-- Store parsed feed_info.txt fields per GTFS dataset (issue #1775).
+-- One row per dataset; populated by the gtfs_file_data_extractor cloud function.
+CREATE TABLE IF NOT EXISTS feedinfo (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    gtfs_dataset_id     VARCHAR(255) NOT NULL,
+    feed_publisher_name TEXT,
+    feed_publisher_url  TEXT,
+    feed_lang           VARCHAR(255),
+    default_lang        VARCHAR(255),
+    feed_start_date     DATE,
+    feed_end_date       DATE,
+    feed_version        TEXT,
+    feed_contact_email  TEXT,
+    feed_contact_url    TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT feedinfo_gtfs_dataset_id_fkey
+        FOREIGN KEY (gtfs_dataset_id)
+        REFERENCES gtfsdataset(id)
+        ON DELETE CASCADE,
+    CONSTRAINT feedinfo_gtfs_dataset_id_key
+        UNIQUE (gtfs_dataset_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedinfo_gtfs_dataset_id
+    ON feedinfo (gtfs_dataset_id);

--- a/liquibase/changes/feat_1775.sql
+++ b/liquibase/changes/feat_1775.sql
@@ -1,8 +1,21 @@
--- Store parsed feed_info.txt fields per GTFS dataset (issue #1775).
--- One row per dataset; populated by the gtfs_file_data_extractor cloud function.
-CREATE TABLE IF NOT EXISTS feedinfo (
+-- Recreate the table rather than relying on CREATE TABLE IF NOT EXISTS: an earlier
+-- revision of this changeset (while the feature was in review) created feedinfo as
+-- one row per dataset, and environments that applied it would otherwise silently
+-- keep that stale shape. Safe to drop: the rows are a cache of parsed
+-- feed_info.txt, rebuilt by re-running the gtfs_file_data_extractor function.
+DROP TABLE IF EXISTS feedinfo CASCADE;
+
+-- Store parsed feed_info.txt fields (issue #1775).
+-- One row per distinct feed_info.txt content, referenced by every GTFS dataset
+-- whose feed_info.txt has that content (one feedinfo -> many gtfsdataset).
+-- Populated by the gtfs_file_data_extractor cloud function.
+CREATE TABLE feedinfo (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    gtfs_dataset_id     VARCHAR(255) NOT NULL,
+    -- SHA-256 of the feed_info.txt this row was parsed from (gtfsfile.hash).
+    -- Every column below is a pure function of that file content, which is what
+    -- makes the row safe to share across datasets: never store per-dataset data
+    -- here, and never mutate a row except to re-parse the same content.
+    file_hash           VARCHAR(255) NOT NULL,
     feed_publisher_name TEXT,
     feed_publisher_url  TEXT,
     feed_lang           VARCHAR(255),
@@ -14,13 +27,20 @@ CREATE TABLE IF NOT EXISTS feedinfo (
     feed_contact_url    TEXT,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
 
-    CONSTRAINT feedinfo_gtfs_dataset_id_fkey
-        FOREIGN KEY (gtfs_dataset_id)
-        REFERENCES gtfsdataset(id)
-        ON DELETE CASCADE,
-    CONSTRAINT feedinfo_gtfs_dataset_id_key
-        UNIQUE (gtfs_dataset_id)
+    CONSTRAINT feedinfo_file_hash_key UNIQUE (file_hash)
 );
 
-CREATE INDEX IF NOT EXISTS idx_feedinfo_gtfs_dataset_id
-    ON feedinfo (gtfs_dataset_id);
+-- Datasets point at the shared feedinfo row. SET NULL rather than CASCADE: the
+-- row belongs to the file content, not to any one dataset, so it must survive
+-- the deletion of a dataset that references it.
+ALTER TABLE gtfsdataset ADD COLUMN IF NOT EXISTS feed_info_id UUID;
+
+-- The FK is dropped with the table above, so it is always re-added here.
+ALTER TABLE gtfsdataset
+    ADD CONSTRAINT fk_gtfsdataset_feed_info
+    FOREIGN KEY (feed_info_id)
+    REFERENCES feedinfo(id)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_gtfsdataset_feed_info_id
+    ON gtfsdataset (feed_info_id);


### PR DESCRIPTION
**Summary:**
Closes #1775
Creates the architecture to extract file content from GTFS files, plus the first extractor: `feed_info.txt`. A new `gtfs-file-data-extractor` function receives one file per invocation and delegates to an extractor resolved by file name, so supporting a new file means adding a `FileDataExtractor` subclass, registering it in `extractors/registry.py`, and adding the file name to `EXTRACTABLE_FILES` in `pipeline_tasks.py`.
Adds a `feedinfo` table with one row per distinct `feed_info.txt` content, keyed by its content hash and shared by every dataset with the same content (`gtfsdataset.feed_info_id` -> `feedinfo.id`, one `feedinfo` to many datasets). No API spec changes; the only existing-table change is the new nullable `gtfsdataset.feed_info_id` (`ON DELETE SET NULL`).

**Expected behavior:**
After the daily batch processing (`batch-process-dataset`), we have a list of files registered for content extraction. For each file we trigger the extraction providing the file url and dataset and feed information.
A task is enqueued for every extractable file present, changed or not, since an unchanged file may never have been extracted before. The extractor links the dataset to the row for that content hash when one already exists (no download), otherwise it downloads and extracts a new one. Failures return 200 with the error in the body, so Cloud Tasks does not retry what can never succeed; every path is idempotent. Existing datasets are not backfilled (follow-up ticket).

**Deploy note:** `feat_1775.sql` now drops and recreates `feedinfo` (an earlier revision created it one row per dataset), so environments that ran that revision need its `databasechangelog` row deleted first, or Liquibase aborts on a checksum mismatch. Never applied to prod.

**Testing tips:**
Function can be tested by running the batch processing function or by calling the newly created `gtfs-file-data-extractor` function directly through HTTP after building this branch on DEV/QA. E.g. of running it in QA:

```bash
curl -X POST "https://northamerica-northeast1-mobility-feeds-qa.cloudfunctions.net/gtfs-file-data-extractor" \
-H "Authorization: bearer $(gcloud auth print-identity-token)" \
-H "Content-Type: application/json" \
-d '{
  "stable_id": "mdb-1884",
  "dataset_id": "mdb-1884-202508220038",
  "file_name": "feed_info.txt",
  "file_url": "https://storage.googleapis.com/mobilitydata-datasets-prod/mdb-1884/mdb-1884-202508220038/extracted/feed_info.txt"
}'
```

For the sharing path, run it on two datasets of the same feed with an identical `feed_info.txt`: both end up on the same `feedinfo.id`.

Note for deploying: `api-deployer` creates the function, `datasets-batch-deployer` creates the task queue. Run `api-deployer` first, otherwise tasks are enqueued against a function that doesn't exist yet.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [x] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
