### PR TITLE
Remove incorrectly created feed coverage tables

### DIFF
--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -96,7 +96,7 @@
     <!--  Adding alt_name to the geopolygon table  -->
     <include file="changes/feat_1479.sql" relativeToChangelogFile="true"/>
     <!-- Remove filename as the primary key on databasechangelog table and add composite(id, author, filename)  -->
-    <include file="changes/update_liquibase_changelog.sql" relativeToChangelogFile="true"/>    
+    <include file="changes/update_liquibase_changelog.sql" relativeToChangelogFile="true"/>
     <!-- Change gtfsfile table hosted_url column type to text to accomodate longer URLs. -->
     <include file="changes/feat_1542.sql" relativeToChangelogFile="true"/>
     <!-- Add license_tag table and license_license_tags join table for tag classification of licenses. -->
@@ -127,6 +127,8 @@
     <include file="changes/feat_pt_202.sql" relativeToChangelogFile="true"/>
     <!-- Add Seal of Reliability tables: feed_reliability_seal and seal_criterion (issue #1760). -->
     <include file="changes/feat_1760.sql" relativeToChangelogFile="true"/>
+    <!-- Drop incorrectly created ad-hoc coverage/feed-city analysis tables. -->
+    <include file="changes/fix_cleanup_coverage_tables.sql" relativeToChangelogFile="true"/>
     <!-- Keep this after all source table and schema changes so materialized views
     are recreated from the final source schema. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/fix_cleanup_coverage_tables.sql
+++ b/liquibase/changes/fix_cleanup_coverage_tables.sql
@@ -1,0 +1,17 @@
+-- Drop leftover ad-hoc analysis tables.
+-- These were incorrectly created for one-off for feed coverage mapping
+-- they are not part of the managed schema and are not
+-- referenced by the API, the Cloud Functions, or any materialized view.
+
+DROP TABLE IF EXISTS global_coverage_1_20260513205122;
+DROP TABLE IF EXISTS global_coverage_2_20260513205110;
+DROP TABLE IF EXISTS global_coverage_3_20260513205102;
+DROP TABLE IF EXISTS global_coverage_4_20260513205053;
+DROP TABLE IF EXISTS global_coverage_5_20260513205044;
+DROP TABLE IF EXISTS global_coverage_6_20260513205035;
+DROP TABLE IF EXISTS global_coverage_7_20260513205024;
+DROP TABLE IF EXISTS global_coverage_8_20260513205015;
+DROP TABLE IF EXISTS global_coverage_9_20260513204956;
+DROP TABLE IF EXISTS global_coverage_10_20260513204943;
+DROP TABLE IF EXISTS feed_city_50_cities_20260513180501;
+DROP TABLE IF EXISTS feed_city_50_cities_20260513153811;


### PR DESCRIPTION
**Summary:**

12 tables were created without the standard liquibase change management process. 10 global coverage tables containing lat/lon coordinates were created for use in mapping feed coverage around the world. 2 other tables representing priority cities were created. 

global_coverage_1_20260513205122
global_coverage_2_20260513205110
global_coverage_3_20260513205102
global_coverage_4_20260513205053
global_coverage_5_20260513205044
global_coverage_6_20260513205035
global_coverage_7_20260513205024
global_coverage_8_20260513205015
global_coverage_9_20260513204956
global_coverage_10_20260513204943

feed_city_50_cities_20260513180501
feed_city_50_cities_20260513153811

**Expected behaviour:** 

Drop tables if existing

**Testing tips:**

No testing required

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
