### PR TITLE
feat: automate sitemap generation for mobilitydatabase

### DIFF
--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -264,7 +264,7 @@ tasks = {
             "feeds' latest dataset; GBFS its newest GBFS version date — all "
             "floored at 2026-03-05. "
             "Parameters: dry_run (default true), "
-            "bucket_name (default 'mobilitydatabase-sitemap'), "
+            "bucket_name (default 'mobilitydatabase-sitemap-{ENVIRONMENT}'), "
             "object_name (default 'sitemap.xml'), "
             "base_url (default 'https://mobilitydatabase.org'), "
             "make_public (default true), include_xml (default false)."

--- a/functions-python/tasks_executor/src/main.py
+++ b/functions-python/tasks_executor/src/main.py
@@ -79,6 +79,9 @@ from tasks.changelog.backfill_changelog import backfill_changelog_handler
 from tasks.seal_of_reliability.update_seal_of_reliability import (
     update_seal_of_reliability_handler,
 )
+from tasks.sitemap.generate_sitemap import (
+    generate_mobilitydatabase_sitemap_handler,
+)
 
 init_logger()
 LIST_COMMAND: Final[str] = "list"
@@ -250,6 +253,23 @@ tasks = {
             "Parameters: run_id (required)."
         ),
         "handler": notifications_dispatch_monitor_handler,
+    },
+    "generate_mobilitydatabase_sitemap": {
+        "description": (
+            "Generate the mobilitydatabase.org sitemap from published, "
+            "non-deprecated feeds and upload it to GCS as sitemap.xml. "
+            "One URL per feed at /feeds/{data_type}/{stable_id}, priority 0.8, "
+            "no changefreq. lastmod: GTFS uses its latest dataset download; "
+            "GTFS-RT the latest of its created_at and its related scheduled "
+            "feeds' latest dataset; GBFS its newest GBFS version date — all "
+            "floored at 2026-03-05. "
+            "Parameters: dry_run (default true), "
+            "bucket_name (default 'mobilitydatabase-sitemap'), "
+            "object_name (default 'sitemap.xml'), "
+            "base_url (default 'https://mobilitydatabase.org'), "
+            "make_public (default true), include_xml (default false)."
+        ),
+        "handler": generate_mobilitydatabase_sitemap_handler,
     },
     "backfill_changelog": {
         "description": (

--- a/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
+++ b/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
@@ -328,6 +328,7 @@ def generate_mobilitydatabase_sitemap(
         "url_count": len(entries),
         "counts_by_data_type": counts,
         "size_bytes": size_bytes,
+        "exceeds_limits": len(entries) > MAX_URLS_PER_SITEMAP or size_bytes > MAX_SITEMAP_BYTES,
     }
     if include_xml:
         result["xml"] = xml

--- a/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
+++ b/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
@@ -1,0 +1,331 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Generate the mobilitydatabase.org sitemap and upload it to GCS.
+
+One ``<url>`` entry is emitted per published, non-deprecated feed, pointing at
+``{base_url}/feeds/{data_type}/{stable_id}``. The ``lastmod`` rule differs per
+data type (see ``LASTMOD_FLOOR`` and the ``fetch_*`` helpers below); ``priority``
+is a flat 0.8 and ``changefreq`` is deliberately omitted.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Iterable, Optional
+from xml.sax.saxutils import escape
+
+from google.cloud import storage
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import (
+    Feed,
+    Gbfsversion,
+    Gtfsdataset,
+    t_feedreference,
+)
+
+DEFAULT_BUCKET_NAME: str = "mobilitydatabase-sitemap"
+DEFAULT_OBJECT_NAME: str = "sitemap.xml"
+DEFAULT_BASE_URL: str = "https://mobilitydatabase.org"
+
+# Every feed page is considered to have changed at least on this date (the date
+# the current feed pages went live), so nothing reports a lastmod older than it.
+LASTMOD_FLOOR: date = date(2026, 3, 5)
+
+# Flat across all feeds: <priority> is relative-only, so equal values carry no
+# signal, but it is kept for parity with the previous hand-maintained sitemap.
+PRIORITY: str = "0.8"
+
+# The sitemaps.org protocol caps a single file at 50,000 URLs / 50 MiB
+# uncompressed. Past either we must split into a sitemap index.
+MAX_URLS_PER_SITEMAP: int = 50_000
+MAX_SITEMAP_BYTES: int = 50 * 1024 * 1024
+
+# Ordering of the emitted entries; within a data type, entries sort by stable_id.
+DATA_TYPE_ORDER: dict[str, int] = {"gtfs": 0, "gtfs_rt": 1, "gbfs": 2}
+
+
+@dataclass(frozen=True)
+class SitemapEntry:
+    """A single ``<url>`` entry in the sitemap."""
+
+    data_type: str
+    stable_id: str
+    lastmod: date
+
+    def loc(self, base_url: str) -> str:
+        return f"{base_url.rstrip('/')}/feeds/{self.data_type}/{self.stable_id}"
+
+
+def to_utc_date(value: Optional[datetime | date]) -> Optional[date]:
+    """Normalize a timestamp to a UTC calendar date.
+
+    Naive datetimes are read as UTC: the only naive timestamp columns in the
+    schema are written by jobs that already store UTC.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.date()
+        return value.astimezone(timezone.utc).date()
+    return value
+
+
+def resolve_lastmod(
+    *candidates: Optional[datetime | date], floor: date = LASTMOD_FLOOR
+) -> date:
+    """Return the most recent of ``candidates``, never older than ``floor``."""
+    dates = [d for d in (to_utc_date(c) for c in candidates) if d is not None]
+    dates.append(floor)
+    return max(dates)
+
+
+def published_feed_filters() -> list:
+    """Filters shared by all three data types.
+
+    ``status`` is nullable, so ``IS DISTINCT FROM`` is used instead of ``!=`` —
+    the latter would silently drop feeds with a NULL status.
+    """
+    return [
+        Feed.operational_status == "published",
+        Feed.status.is_distinct_from("deprecated"),
+        Feed.stable_id.isnot(None),
+    ]
+
+
+def fetch_gtfs_entries(db_session: Session, floor: date) -> list[SitemapEntry]:
+    """GTFS: lastmod is the feed's most recent dataset download, floored."""
+    rows = (
+        db_session.query(
+            Feed.stable_id,
+            func.max(Gtfsdataset.downloaded_at).label("latest_dataset_at"),
+        )
+        .select_from(Feed)
+        .outerjoin(Gtfsdataset, Gtfsdataset.feed_id == Feed.id)
+        .filter(Feed.data_type == "gtfs", *published_feed_filters())
+        .group_by(Feed.stable_id)
+        .all()
+    )
+    return [
+        SitemapEntry("gtfs", stable_id, resolve_lastmod(latest_dataset_at, floor=floor))
+        for stable_id, latest_dataset_at in rows
+    ]
+
+
+def fetch_gtfs_rt_entries(db_session: Session, floor: date) -> list[SitemapEntry]:
+    """GTFS-RT: lastmod is the latest of the floor, the feed's own created_at,
+    and the most recent dataset download across its related scheduled feeds.
+
+    The schema records no "feed location last changed" timestamp, so the related
+    GTFS feed's latest dataset stands in for it: locations are re-derived
+    whenever a new dataset is processed.
+    """
+    rows = (
+        db_session.query(
+            Feed.stable_id,
+            Feed.created_at,
+            func.max(Gtfsdataset.downloaded_at).label("latest_related_dataset_at"),
+        )
+        .select_from(Feed)
+        .outerjoin(t_feedreference, t_feedreference.c.gtfs_rt_feed_id == Feed.id)
+        .outerjoin(Gtfsdataset, Gtfsdataset.feed_id == t_feedreference.c.gtfs_feed_id)
+        .filter(Feed.data_type == "gtfs_rt", *published_feed_filters())
+        .group_by(Feed.stable_id, Feed.created_at)
+        .all()
+    )
+    return [
+        SitemapEntry(
+            "gtfs_rt",
+            stable_id,
+            resolve_lastmod(created_at, latest_related_dataset_at, floor=floor),
+        )
+        for stable_id, created_at, latest_related_dataset_at in rows
+    ]
+
+
+def fetch_gbfs_entries(db_session: Session, floor: date) -> list[SitemapEntry]:
+    """GBFS: lastmod is the date the feed's newest GBFS version was recorded.
+
+    ``gbfsversion`` rows are upserted on a stable id, so ``created_at`` only
+    moves when the feed actually gains a version rather than on every crawl.
+    """
+    rows = (
+        db_session.query(
+            Feed.stable_id,
+            func.max(Gbfsversion.created_at).label("latest_version_at"),
+        )
+        .select_from(Feed)
+        .outerjoin(Gbfsversion, Gbfsversion.feed_id == Feed.id)
+        .filter(Feed.data_type == "gbfs", *published_feed_filters())
+        .group_by(Feed.stable_id)
+        .all()
+    )
+    return [
+        SitemapEntry("gbfs", stable_id, resolve_lastmod(latest_version_at, floor=floor))
+        for stable_id, latest_version_at in rows
+    ]
+
+
+def collect_entries(
+    db_session: Session, floor: date = LASTMOD_FLOOR
+) -> list[SitemapEntry]:
+    """Collect every sitemap entry, in a deterministic order."""
+    entries = [
+        *fetch_gtfs_entries(db_session, floor),
+        *fetch_gtfs_rt_entries(db_session, floor),
+        *fetch_gbfs_entries(db_session, floor),
+    ]
+    return sorted(
+        entries,
+        key=lambda entry: (
+            DATA_TYPE_ORDER.get(entry.data_type, len(DATA_TYPE_ORDER)),
+            entry.stable_id,
+        ),
+    )
+
+
+def build_sitemap_xml(entries: Iterable[SitemapEntry], base_url: str) -> str:
+    """Render entries as a sitemaps.org 0.9 urlset."""
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ]
+    for entry in entries:
+        lines.append("  <url>")
+        lines.append(f"    <loc>{escape(entry.loc(base_url))}</loc>")
+        lines.append(f"    <lastmod>{entry.lastmod.isoformat()}</lastmod>")
+        lines.append(f"    <priority>{PRIORITY}</priority>")
+        lines.append("  </url>")
+    lines.append("</urlset>")
+    return "\n".join(lines) + "\n"
+
+
+def upload_sitemap(
+    xml: str, bucket_name: str, object_name: str, make_public: bool
+) -> None:
+    """Overwrite ``object_name`` in ``bucket_name`` with the rendered sitemap."""
+    blob = storage.Client().bucket(bucket_name).blob(object_name)
+    blob.cache_control = "public, max-age=3600"
+    blob.upload_from_string(xml, content_type="application/xml; charset=utf-8")
+    logging.info(
+        "Uploaded sitemap to gs://%s/%s (%d bytes).",
+        bucket_name,
+        object_name,
+        len(xml.encode("utf-8")),
+    )
+    if make_public:
+        try:
+            blob.make_public()
+        except Exception as exc:
+            # Buckets with uniform bucket-level access reject per-object ACLs;
+            # public read is granted at the bucket level there instead, so this
+            # is not fatal to the upload that already succeeded.
+            logging.warning(
+                "Could not set a public ACL on gs://%s/%s: %s",
+                bucket_name,
+                object_name,
+                exc,
+            )
+
+
+def generate_mobilitydatabase_sitemap_handler(payload: dict) -> dict:
+    """Handler for generating the mobilitydatabase.org sitemap.
+
+    Payload parameters:
+        dry_run (bool): If True, build the sitemap but do not upload it. Default: True.
+        bucket_name (str): Destination GCS bucket. Default: 'mobilitydatabase-sitemap'.
+        object_name (str): Destination object name. Default: 'sitemap.xml'.
+        base_url (str): Site origin used to build each <loc>. Default: 'https://mobilitydatabase.org'.
+        make_public (bool): Set a public-read ACL on the uploaded object. Default: True.
+        include_xml (bool): Return the rendered XML in the response. Default: False.
+    """
+    dry_run = payload.get("dry_run", True)
+    bucket_name = payload.get("bucket_name", DEFAULT_BUCKET_NAME)
+    object_name = payload.get("object_name", DEFAULT_OBJECT_NAME)
+    base_url = payload.get("base_url", DEFAULT_BASE_URL)
+    make_public = payload.get("make_public", True)
+    include_xml = payload.get("include_xml", False)
+
+    return generate_mobilitydatabase_sitemap(
+        dry_run=dry_run,
+        bucket_name=bucket_name,
+        object_name=object_name,
+        base_url=base_url,
+        make_public=make_public,
+        include_xml=include_xml,
+    )
+
+
+@with_db_session
+def generate_mobilitydatabase_sitemap(
+    dry_run: bool = True,
+    bucket_name: str = DEFAULT_BUCKET_NAME,
+    object_name: str = DEFAULT_OBJECT_NAME,
+    base_url: str = DEFAULT_BASE_URL,
+    make_public: bool = True,
+    include_xml: bool = False,
+    db_session: Session | None = None,
+) -> dict:
+    """Build the sitemap from the DB and (unless dry_run) upload it to GCS."""
+    entries = collect_entries(db_session)
+    xml = build_sitemap_xml(entries, base_url)
+    size_bytes = len(xml.encode("utf-8"))
+
+    counts: dict[str, int] = {data_type: 0 for data_type in DATA_TYPE_ORDER}
+    for entry in entries:
+        counts[entry.data_type] = counts.get(entry.data_type, 0) + 1
+    logging.info(
+        "Built sitemap with %d URLs (%s), %d bytes.",
+        len(entries),
+        ", ".join(f"{key}={value}" for key, value in counts.items()),
+        size_bytes,
+    )
+
+    if len(entries) > MAX_URLS_PER_SITEMAP or size_bytes > MAX_SITEMAP_BYTES:
+        # Still uploaded — a slightly oversized sitemap is better than none —
+        # but it needs splitting into a sitemap index before crawlers reject it.
+        logging.error(
+            "Sitemap exceeds the sitemaps.org limits (%d URLs / %d bytes vs %d / %d). "
+            "It must be split into a sitemap index.",
+            len(entries),
+            size_bytes,
+            MAX_URLS_PER_SITEMAP,
+            MAX_SITEMAP_BYTES,
+        )
+
+    if dry_run:
+        logging.info(
+            "Dry run: skipping upload to gs://%s/%s.", bucket_name, object_name
+        )
+    else:
+        upload_sitemap(xml, bucket_name, object_name, make_public)
+
+    result = {
+        "dry_run": dry_run,
+        "uploaded": not dry_run,
+        "bucket_name": bucket_name,
+        "object_name": object_name,
+        "base_url": base_url,
+        "url_count": len(entries),
+        "counts_by_data_type": counts,
+        "size_bytes": size_bytes,
+    }
+    if include_xml:
+        result["xml"] = xml
+    return result

--- a/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
+++ b/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
@@ -328,7 +328,8 @@ def generate_mobilitydatabase_sitemap(
         "url_count": len(entries),
         "counts_by_data_type": counts,
         "size_bytes": size_bytes,
-        "exceeds_limits": len(entries) > MAX_URLS_PER_SITEMAP or size_bytes > MAX_SITEMAP_BYTES,
+        "exceeds_limits": len(entries) > MAX_URLS_PER_SITEMAP
+        or size_bytes > MAX_SITEMAP_BYTES,
     }
     if include_xml:
         result["xml"] = xml

--- a/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
+++ b/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
@@ -99,12 +99,12 @@ def resolve_lastmod(
 def published_feed_filters() -> list:
     """Filters shared by all three data types.
 
-    ``status`` is nullable, so ``IS DISTINCT FROM`` is used instead of ``!=`` —
-    the latter would silently drop feeds with a NULL status.
+    ``status`` must be one of the non-deprecated, non-null values; a NULL
+    status (or ``deprecated``) excludes the feed from the sitemap.
     """
     return [
         Feed.operational_status == "published",
-        Feed.status.is_distinct_from("deprecated"),
+        Feed.status.in_(["future", "inactive", "active"]),
         Feed.stable_id.isnot(None),
     ]
 

--- a/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
+++ b/functions-python/tasks_executor/src/tasks/sitemap/generate_sitemap.py
@@ -22,6 +22,7 @@ is a flat 0.8 and ``changefreq`` is deliberately omitted.
 """
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Iterable, Optional
@@ -39,7 +40,9 @@ from shared.database_gen.sqlacodegen_models import (
     t_feedreference,
 )
 
-DEFAULT_BUCKET_NAME: str = "mobilitydatabase-sitemap"
+# ``ENVIRONMENT`` (dev/qa/prod) is set on the Cloud Function by Terraform, same
+# as every other environment-scoped bucket in this repo (see infra/*/main.tf).
+DEFAULT_BUCKET_NAME: str = f"mobilitydatabase-sitemap-{os.getenv('ENVIRONMENT')}"
 DEFAULT_OBJECT_NAME: str = "sitemap.xml"
 DEFAULT_BASE_URL: str = "https://mobilitydatabase.org"
 
@@ -249,7 +252,7 @@ def generate_mobilitydatabase_sitemap_handler(payload: dict) -> dict:
 
     Payload parameters:
         dry_run (bool): If True, build the sitemap but do not upload it. Default: True.
-        bucket_name (str): Destination GCS bucket. Default: 'mobilitydatabase-sitemap'.
+        bucket_name (str): Destination GCS bucket. Default: 'mobilitydatabase-sitemap-{ENVIRONMENT}'.
         object_name (str): Destination object name. Default: 'sitemap.xml'.
         base_url (str): Site origin used to build each <loc>. Default: 'https://mobilitydatabase.org'.
         make_public (bool): Set a public-read ACL on the uploaded object. Default: True.

--- a/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap.py
+++ b/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap.py
@@ -1,0 +1,200 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for the sitemap rendering and lastmod rules (no database)."""
+
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from xml.etree import ElementTree
+
+from tasks.sitemap.generate_sitemap import (
+    LASTMOD_FLOOR,
+    PRIORITY,
+    SitemapEntry,
+    build_sitemap_xml,
+    resolve_lastmod,
+    to_utc_date,
+    upload_sitemap,
+)
+
+SITEMAP_NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+
+
+class TestToUtcDate(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(to_utc_date(None))
+
+    def test_date_passes_through(self):
+        self.assertEqual(to_utc_date(date(2026, 5, 1)), date(2026, 5, 1))
+
+    def test_naive_datetime_read_as_utc(self):
+        self.assertEqual(
+            to_utc_date(datetime(2026, 5, 1, 23, 30)),
+            date(2026, 5, 1),
+        )
+
+    def test_aware_datetime_converted_to_utc_before_taking_the_date(self):
+        """23:30 on May 1st at UTC-6 is already May 2nd in UTC."""
+        tz_minus_six = timezone(timedelta(hours=-6))
+        self.assertEqual(
+            to_utc_date(datetime(2026, 5, 1, 23, 30, tzinfo=tz_minus_six)),
+            date(2026, 5, 2),
+        )
+
+
+class TestResolveLastmod(unittest.TestCase):
+    def test_no_candidates_returns_the_floor(self):
+        self.assertEqual(resolve_lastmod(), LASTMOD_FLOOR)
+
+    def test_all_none_returns_the_floor(self):
+        self.assertEqual(resolve_lastmod(None, None), LASTMOD_FLOOR)
+
+    def test_candidate_older_than_the_floor_is_raised_to_the_floor(self):
+        older = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        self.assertEqual(resolve_lastmod(older), LASTMOD_FLOOR)
+
+    def test_candidate_newer_than_the_floor_wins(self):
+        newer = datetime(2026, 7, 4, tzinfo=timezone.utc)
+        self.assertEqual(resolve_lastmod(newer), date(2026, 7, 4))
+
+    def test_most_recent_of_several_candidates_wins(self):
+        self.assertEqual(
+            resolve_lastmod(
+                datetime(2026, 4, 1, tzinfo=timezone.utc),
+                None,
+                datetime(2026, 9, 9, tzinfo=timezone.utc),
+                datetime(2026, 6, 1, tzinfo=timezone.utc),
+            ),
+            date(2026, 9, 9),
+        )
+
+    def test_explicit_floor_is_honoured(self):
+        self.assertEqual(
+            resolve_lastmod(None, floor=date(2026, 1, 1)), date(2026, 1, 1)
+        )
+
+
+class TestSitemapEntry(unittest.TestCase):
+    def test_loc_uses_the_data_type_and_stable_id(self):
+        entry = SitemapEntry("gtfs_rt", "mdb-3486", LASTMOD_FLOOR)
+        self.assertEqual(
+            entry.loc("https://mobilitydatabase.org"),
+            "https://mobilitydatabase.org/feeds/gtfs_rt/mdb-3486",
+        )
+
+    def test_loc_does_not_double_up_a_trailing_slash(self):
+        entry = SitemapEntry("gbfs", "gbfs-dott-presov", LASTMOD_FLOOR)
+        self.assertEqual(
+            entry.loc("https://mobilitydatabase.org/"),
+            "https://mobilitydatabase.org/feeds/gbfs/gbfs-dott-presov",
+        )
+
+
+class TestBuildSitemapXml(unittest.TestCase):
+    entries = [
+        SitemapEntry("gtfs", "mdb-460", date(2026, 3, 5)),
+        SitemapEntry("gtfs_rt", "mdb-3486", date(2026, 7, 1)),
+        SitemapEntry("gbfs", "gbfs-donkey_aarhus", date(2026, 6, 21)),
+    ]
+
+    def render(self):
+        return build_sitemap_xml(self.entries, "https://mobilitydatabase.org")
+
+    def test_output_is_well_formed_xml_in_the_sitemap_namespace(self):
+        root = ElementTree.fromstring(self.render())
+        self.assertEqual(root.tag, f"{SITEMAP_NS}urlset")
+
+    def test_one_url_element_per_entry_in_order(self):
+        root = ElementTree.fromstring(self.render())
+        locs = [url.find(f"{SITEMAP_NS}loc").text for url in root]
+        self.assertEqual(
+            locs,
+            [
+                "https://mobilitydatabase.org/feeds/gtfs/mdb-460",
+                "https://mobilitydatabase.org/feeds/gtfs_rt/mdb-3486",
+                "https://mobilitydatabase.org/feeds/gbfs/gbfs-donkey_aarhus",
+            ],
+        )
+
+    def test_lastmod_is_rendered_as_an_iso_date(self):
+        root = ElementTree.fromstring(self.render())
+        lastmods = [url.find(f"{SITEMAP_NS}lastmod").text for url in root]
+        self.assertEqual(lastmods, ["2026-03-05", "2026-07-01", "2026-06-21"])
+
+    def test_every_priority_is_flat(self):
+        root = ElementTree.fromstring(self.render())
+        priorities = {url.find(f"{SITEMAP_NS}priority").text for url in root}
+        self.assertEqual(priorities, {PRIORITY})
+
+    def test_changefreq_is_never_emitted(self):
+        self.assertNotIn("changefreq", self.render())
+
+    def test_empty_entry_list_still_renders_a_valid_urlset(self):
+        root = ElementTree.fromstring(build_sitemap_xml([], "https://example.org"))
+        self.assertEqual(root.tag, f"{SITEMAP_NS}urlset")
+        self.assertEqual(len(root), 0)
+
+    def test_stable_ids_needing_escaping_are_escaped(self):
+        xml = build_sitemap_xml(
+            [SitemapEntry("gtfs", "weird&id", LASTMOD_FLOOR)], "https://example.org"
+        )
+        self.assertIn("weird&amp;id", xml)
+        root = ElementTree.fromstring(xml)
+        self.assertEqual(
+            root[0].find(f"{SITEMAP_NS}loc").text,
+            "https://example.org/feeds/gtfs/weird&id",
+        )
+
+
+class TestUploadSitemap(unittest.TestCase):
+    def setUp(self):
+        patcher = patch("tasks.sitemap.generate_sitemap.storage.Client")
+        self.client_cls = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.blob = MagicMock()
+        self.client_cls.return_value.bucket.return_value.blob.return_value = self.blob
+
+    def test_uploads_the_xml_to_the_requested_bucket_and_object(self):
+        upload_sitemap("<xml/>", "a-bucket", "sitemap.xml", make_public=False)
+        self.client_cls.return_value.bucket.assert_called_once_with("a-bucket")
+        self.client_cls.return_value.bucket.return_value.blob.assert_called_once_with(
+            "sitemap.xml"
+        )
+        self.blob.upload_from_string.assert_called_once_with(
+            "<xml/>", content_type="application/xml; charset=utf-8"
+        )
+
+    def test_sets_a_cache_control_header(self):
+        upload_sitemap("<xml/>", "a-bucket", "sitemap.xml", make_public=False)
+        self.assertEqual(self.blob.cache_control, "public, max-age=3600")
+
+    def test_make_public_false_leaves_the_acl_alone(self):
+        upload_sitemap("<xml/>", "a-bucket", "sitemap.xml", make_public=False)
+        self.blob.make_public.assert_not_called()
+
+    def test_make_public_true_sets_the_acl(self):
+        upload_sitemap("<xml/>", "a-bucket", "sitemap.xml", make_public=True)
+        self.blob.make_public.assert_called_once()
+
+    def test_a_rejected_public_acl_does_not_fail_the_upload(self):
+        """Uniform bucket-level access rejects per-object ACLs; the upload still stands."""
+        self.blob.make_public.side_effect = Exception("uniform bucket-level access")
+        upload_sitemap("<xml/>", "a-bucket", "sitemap.xml", make_public=True)
+        self.blob.upload_from_string.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
+++ b/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
@@ -22,7 +22,7 @@ afterwards, so it neither depends on nor disturbs the shared conftest fixtures.
 import unittest
 from datetime import date, datetime, timezone
 
-from sqlalchemy import or_
+from sqlalchemy import null, or_
 from sqlalchemy.orm import Session
 
 from shared.database.database import with_db_session
@@ -69,7 +69,10 @@ def seed(db_session: Session = None):
     gtfs_old = Gtfsfeed(**_feed_kwargs("gtfs_old", data_type="gtfs"))
     gtfs_no_dataset = Gtfsfeed(**_feed_kwargs("gtfs_no_dataset", data_type="gtfs"))
     gtfs_null_status = Gtfsfeed(
-        **_feed_kwargs("gtfs_null_status", data_type="gtfs", status=None)
+        # `status` has a server_default, so a plain `status=None` is treated by
+        # the ORM as "unset" and the default fires instead; `null()` forces an
+        # actual NULL to be inserted.
+        **_feed_kwargs("gtfs_null_status", data_type="gtfs", status=null())
     )
     gtfs_deprecated = Gtfsfeed(
         **_feed_kwargs("gtfs_deprecated", data_type="gtfs", status="deprecated")
@@ -222,9 +225,8 @@ class TestFetchGtfsEntries(unittest.TestCase):
             self.entries[f"{PREFIX}gtfs_no_dataset"].lastmod, LASTMOD_FLOOR
         )
 
-    def test_null_status_feed_is_included(self):
-        """`status != 'deprecated'` would drop these; `IS DISTINCT FROM` keeps them."""
-        self.assertIn(f"{PREFIX}gtfs_null_status", self.entries)
+    def test_null_status_feed_is_excluded(self):
+        self.assertNotIn(f"{PREFIX}gtfs_null_status", self.entries)
 
     def test_deprecated_feed_is_excluded(self):
         self.assertNotIn(f"{PREFIX}gtfs_deprecated", self.entries)

--- a/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
+++ b/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
@@ -1,0 +1,323 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Integration tests for the sitemap queries against the real test database.
+
+Each test class seeds its own rows under a dedicated id prefix and removes them
+afterwards, so it neither depends on nor disturbs the shared conftest fixtures.
+"""
+
+import unittest
+from datetime import date, datetime, timezone
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from shared.database.database import with_db_session
+from shared.database_gen.sqlacodegen_models import (
+    Feed,
+    Gbfsfeed,
+    Gbfsversion,
+    Gtfsdataset,
+    Gtfsfeed,
+    Gtfsrealtimefeed,
+    t_feedreference,
+)
+from tasks.sitemap.generate_sitemap import (
+    LASTMOD_FLOOR,
+    collect_entries,
+    fetch_gbfs_entries,
+    fetch_gtfs_entries,
+    fetch_gtfs_rt_entries,
+)
+from test_shared.test_utils.database_utils import default_db_url
+
+PREFIX = "sitemap_test_"
+AFTER_FLOOR = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+BEFORE_FLOOR = datetime(2025, 1, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def _feed_kwargs(suffix, **overrides):
+    kwargs = {
+        "id": f"{PREFIX}{suffix}",
+        "stable_id": f"{PREFIX}{suffix}",
+        "status": "active",
+        "operational_status": "published",
+        "created_at": BEFORE_FLOOR,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@with_db_session(db_url=default_db_url)
+def seed(db_session: Session = None):
+    """Insert the sitemap fixtures. Safe to call after `unseed`."""
+    # --- GTFS ---------------------------------------------------------------
+    gtfs_recent = Gtfsfeed(**_feed_kwargs("gtfs_recent", data_type="gtfs"))
+    gtfs_old = Gtfsfeed(**_feed_kwargs("gtfs_old", data_type="gtfs"))
+    gtfs_no_dataset = Gtfsfeed(**_feed_kwargs("gtfs_no_dataset", data_type="gtfs"))
+    gtfs_null_status = Gtfsfeed(
+        **_feed_kwargs("gtfs_null_status", data_type="gtfs", status=None)
+    )
+    gtfs_deprecated = Gtfsfeed(
+        **_feed_kwargs("gtfs_deprecated", data_type="gtfs", status="deprecated")
+    )
+    gtfs_wip = Gtfsfeed(
+        **_feed_kwargs("gtfs_wip", data_type="gtfs", operational_status="wip")
+    )
+    db_session.add_all(
+        [
+            gtfs_recent,
+            gtfs_old,
+            gtfs_no_dataset,
+            gtfs_null_status,
+            gtfs_deprecated,
+            gtfs_wip,
+        ]
+    )
+    db_session.flush()
+
+    # gtfs_recent has two datasets; the newest one must win.
+    db_session.add_all(
+        [
+            Gtfsdataset(
+                id=f"{PREFIX}ds_older",
+                feed_id=gtfs_recent.id,
+                stable_id=f"{PREFIX}ds_older",
+                downloaded_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            ),
+            Gtfsdataset(
+                id=f"{PREFIX}ds_newest",
+                feed_id=gtfs_recent.id,
+                stable_id=f"{PREFIX}ds_newest",
+                downloaded_at=AFTER_FLOOR,
+            ),
+            # Predates the floor, so the floor must win for this feed.
+            Gtfsdataset(
+                id=f"{PREFIX}ds_old",
+                feed_id=gtfs_old.id,
+                stable_id=f"{PREFIX}ds_old",
+                downloaded_at=BEFORE_FLOOR,
+            ),
+        ]
+    )
+
+    # --- GTFS-RT ------------------------------------------------------------
+    # Inherits its lastmod from the related scheduled feed's newest dataset.
+    rt_with_parent = Gtfsrealtimefeed(
+        **_feed_kwargs("rt_with_parent", data_type="gtfs_rt")
+    )
+    rt_with_parent.gtfs_feeds = [gtfs_recent]
+    # No parent and a created_at before the floor: falls back to the floor.
+    rt_orphan = Gtfsrealtimefeed(**_feed_kwargs("rt_orphan", data_type="gtfs_rt"))
+    # No parent but created after the floor: its own created_at wins.
+    rt_recent = Gtfsrealtimefeed(
+        **_feed_kwargs("rt_recent", data_type="gtfs_rt", created_at=AFTER_FLOOR)
+    )
+    db_session.add_all([rt_with_parent, rt_orphan, rt_recent])
+
+    # --- GBFS ---------------------------------------------------------------
+    gbfs_versioned = Gbfsfeed(**_feed_kwargs("gbfs_versioned", data_type="gbfs"))
+    gbfs_no_version = Gbfsfeed(**_feed_kwargs("gbfs_no_version", data_type="gbfs"))
+    db_session.add_all([gbfs_versioned, gbfs_no_version])
+    db_session.flush()
+    db_session.add_all(
+        [
+            Gbfsversion(
+                id=f"{PREFIX}v23",
+                feed_id=gbfs_versioned.id,
+                version="2.3",
+                url="http://example.org/2.3",
+                created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            ),
+            Gbfsversion(
+                id=f"{PREFIX}v30",
+                feed_id=gbfs_versioned.id,
+                version="3.0",
+                url="http://example.org/3.0",
+                created_at=AFTER_FLOOR,
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+@with_db_session(db_url=default_db_url)
+def unseed(db_session: Session = None):
+    """Remove every row this module created.
+
+    Core deletes in FK order: the subclass tables (`gtfsfeed`, `gbfsfeed`, ...)
+    reference `feed.id` without ON DELETE CASCADE, so the base rows can only go
+    once their subclass rows and every dependent row are gone.
+    """
+    feed_ids = [
+        row[0] for row in db_session.query(Feed.id).filter(Feed.id.like(f"{PREFIX}%"))
+    ]
+    if not feed_ids:
+        return
+    db_session.execute(
+        Gbfsversion.__table__.delete().where(Gbfsversion.feed_id.in_(feed_ids))
+    )
+    db_session.execute(
+        Gtfsdataset.__table__.delete().where(Gtfsdataset.feed_id.in_(feed_ids))
+    )
+    db_session.execute(
+        t_feedreference.delete().where(
+            or_(
+                t_feedreference.c.gtfs_rt_feed_id.in_(feed_ids),
+                t_feedreference.c.gtfs_feed_id.in_(feed_ids),
+            )
+        )
+    )
+    for table in (
+        Gtfsfeed.__table__,
+        Gtfsrealtimefeed.__table__,
+        Gbfsfeed.__table__,
+        Feed.__table__,
+    ):
+        db_session.execute(table.delete().where(table.c.id.in_(feed_ids)))
+    db_session.commit()
+
+
+def setUpModule():
+    unseed()
+    seed()
+
+
+def tearDownModule():
+    unseed()
+
+
+def as_map(entries):
+    return {entry.stable_id: entry for entry in entries}
+
+
+class TestFetchGtfsEntries(unittest.TestCase):
+    @with_db_session(db_url=default_db_url)
+    def setUp(self, db_session: Session = None):
+        self.entries = as_map(fetch_gtfs_entries(db_session, LASTMOD_FLOOR))
+
+    def test_lastmod_is_the_newest_dataset_download(self):
+        self.assertEqual(
+            self.entries[f"{PREFIX}gtfs_recent"].lastmod, AFTER_FLOOR.date()
+        )
+
+    def test_dataset_older_than_the_floor_falls_back_to_the_floor(self):
+        self.assertEqual(self.entries[f"{PREFIX}gtfs_old"].lastmod, LASTMOD_FLOOR)
+
+    def test_feed_without_any_dataset_is_still_included_at_the_floor(self):
+        self.assertEqual(
+            self.entries[f"{PREFIX}gtfs_no_dataset"].lastmod, LASTMOD_FLOOR
+        )
+
+    def test_null_status_feed_is_included(self):
+        """`status != 'deprecated'` would drop these; `IS DISTINCT FROM` keeps them."""
+        self.assertIn(f"{PREFIX}gtfs_null_status", self.entries)
+
+    def test_deprecated_feed_is_excluded(self):
+        self.assertNotIn(f"{PREFIX}gtfs_deprecated", self.entries)
+
+    def test_non_published_feed_is_excluded(self):
+        self.assertNotIn(f"{PREFIX}gtfs_wip", self.entries)
+
+    def test_every_entry_is_tagged_gtfs(self):
+        seeded = [k for k in self.entries if k.startswith(PREFIX)]
+        self.assertTrue(seeded)
+        for stable_id in seeded:
+            self.assertEqual(self.entries[stable_id].data_type, "gtfs")
+
+    def test_no_realtime_or_gbfs_feed_leaks_in(self):
+        self.assertNotIn(f"{PREFIX}rt_with_parent", self.entries)
+        self.assertNotIn(f"{PREFIX}gbfs_versioned", self.entries)
+
+
+class TestFetchGtfsRtEntries(unittest.TestCase):
+    @with_db_session(db_url=default_db_url)
+    def setUp(self, db_session: Session = None):
+        self.entries = as_map(fetch_gtfs_rt_entries(db_session, LASTMOD_FLOOR))
+
+    def test_lastmod_comes_from_the_related_scheduled_feed(self):
+        self.assertEqual(
+            self.entries[f"{PREFIX}rt_with_parent"].lastmod, AFTER_FLOOR.date()
+        )
+
+    def test_feed_without_a_scheduled_reference_falls_back_to_the_floor(self):
+        self.assertEqual(self.entries[f"{PREFIX}rt_orphan"].lastmod, LASTMOD_FLOOR)
+
+    def test_own_created_at_wins_when_it_is_newer_than_the_floor(self):
+        self.assertEqual(self.entries[f"{PREFIX}rt_recent"].lastmod, AFTER_FLOOR.date())
+
+    def test_the_join_does_not_duplicate_a_feed_with_references(self):
+        entries = [e for e in self.entries if e == f"{PREFIX}rt_with_parent"]
+        self.assertEqual(len(entries), 1)
+
+    def test_every_entry_is_tagged_gtfs_rt(self):
+        for stable_id, entry in self.entries.items():
+            if stable_id.startswith(PREFIX):
+                self.assertEqual(entry.data_type, "gtfs_rt")
+
+
+class TestFetchGbfsEntries(unittest.TestCase):
+    @with_db_session(db_url=default_db_url)
+    def setUp(self, db_session: Session = None):
+        self.entries = as_map(fetch_gbfs_entries(db_session, LASTMOD_FLOOR))
+
+    def test_lastmod_is_the_newest_gbfs_version_date(self):
+        self.assertEqual(
+            self.entries[f"{PREFIX}gbfs_versioned"].lastmod, AFTER_FLOOR.date()
+        )
+
+    def test_feed_without_any_version_falls_back_to_the_floor(self):
+        self.assertEqual(
+            self.entries[f"{PREFIX}gbfs_no_version"].lastmod, LASTMOD_FLOOR
+        )
+
+    def test_every_entry_is_tagged_gbfs(self):
+        for stable_id, entry in self.entries.items():
+            if stable_id.startswith(PREFIX):
+                self.assertEqual(entry.data_type, "gbfs")
+
+
+class TestCollectEntries(unittest.TestCase):
+    @with_db_session(db_url=default_db_url)
+    def setUp(self, db_session: Session = None):
+        self.entries = collect_entries(db_session)
+
+    def test_entries_are_grouped_by_data_type_then_sorted_by_stable_id(self):
+        order = {"gtfs": 0, "gtfs_rt": 1, "gbfs": 2}
+        keys = [(order[e.data_type], e.stable_id) for e in self.entries]
+        self.assertEqual(keys, sorted(keys))
+
+    def test_stable_ids_are_unique(self):
+        stable_ids = [e.stable_id for e in self.entries]
+        self.assertEqual(len(stable_ids), len(set(stable_ids)))
+
+    def test_no_entry_predates_the_floor(self):
+        for entry in self.entries:
+            self.assertGreaterEqual(entry.lastmod, LASTMOD_FLOOR)
+
+    def test_lastmod_is_always_a_date(self):
+        for entry in self.entries:
+            self.assertIsInstance(entry.lastmod, date)
+
+    def test_all_three_data_types_are_represented(self):
+        self.assertEqual(
+            {e.data_type for e in self.entries if e.stable_id.startswith(PREFIX)},
+            {"gtfs", "gtfs_rt", "gbfs"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
+++ b/functions-python/tasks_executor/tests/tasks/sitemap/test_generate_sitemap_db.py
@@ -248,7 +248,8 @@ class TestFetchGtfsEntries(unittest.TestCase):
 class TestFetchGtfsRtEntries(unittest.TestCase):
     @with_db_session(db_url=default_db_url)
     def setUp(self, db_session: Session = None):
-        self.entries = as_map(fetch_gtfs_rt_entries(db_session, LASTMOD_FLOOR))
+        self.entries_list = fetch_gtfs_rt_entries(db_session, LASTMOD_FLOOR)
+        self.entries = as_map(self.entries_list)
 
     def test_lastmod_comes_from_the_related_scheduled_feed(self):
         self.assertEqual(
@@ -262,8 +263,10 @@ class TestFetchGtfsRtEntries(unittest.TestCase):
         self.assertEqual(self.entries[f"{PREFIX}rt_recent"].lastmod, AFTER_FLOOR.date())
 
     def test_the_join_does_not_duplicate_a_feed_with_references(self):
-        entries = [e for e in self.entries if e == f"{PREFIX}rt_with_parent"]
-        self.assertEqual(len(entries), 1)
+        matches = [
+            e for e in self.entries_list if e.stable_id == f"{PREFIX}rt_with_parent"
+        ]
+        self.assertEqual(len(matches), 1)
 
     def test_every_entry_is_tagged_gtfs_rt(self):
         for stable_id, entry in self.entries.items():

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -137,6 +137,27 @@ resource "google_storage_bucket" "gbfs_snapshots_bucket" {
   }
 }
 
+resource "google_storage_bucket" "sitemap_bucket" {
+  location                    = var.gcp_region
+  name                        = "mobilitydatabase-sitemap-${var.environment}"
+  uniform_bucket_level_access = true
+  cors {
+    origin          = ["*"]
+    method          = ["GET"]
+    response_header = ["*"]
+  }
+}
+
+# Public, unauthenticated read access so sitemap.xml can be fetched directly
+# (e.g. by the Next.js web app) without a GCP identity. Uniform bucket-level
+# access is on for this bucket, so per-object ACLs (blob.make_public()) don't
+# apply here — public read has to be granted at the bucket level instead.
+resource "google_storage_bucket_iam_member" "sitemap_bucket_public_read" {
+  bucket = google_storage_bucket.sitemap_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
 resource "google_storage_bucket_iam_member" "datasets_bucket_functions_service_account" {
   bucket = data.google_storage_bucket.datasets_bucket.name
   role   = "roles/storage.admin"
@@ -1659,8 +1680,9 @@ resource "google_storage_bucket_iam_binding" "bucket_object_viewer" {
 resource "google_storage_bucket_iam_binding" "bucket_object_creator" {
   for_each = {
     gbfs_snapshots_bucket = google_storage_bucket.gbfs_snapshots_bucket.name
+    sitemap_bucket        = google_storage_bucket.sitemap_bucket.name
   }
-  depends_on = [google_storage_bucket.gbfs_snapshots_bucket]
+  depends_on = [google_storage_bucket.gbfs_snapshots_bucket, google_storage_bucket.sitemap_bucket]
   bucket     = each.value
   role       = "roles/storage.objectCreator"
   members = [

--- a/infra/functions-python/main.tf
+++ b/infra/functions-python/main.tf
@@ -687,6 +687,31 @@ resource "google_cloud_scheduler_job" "reconcile_announcements_from_brevo_schedu
   attempt_deadline = "320s"
 }
 
+# Schedule the mobilitydatabase.org sitemap generation to run daily at 08:00 UTC.
+# Overwrites sitemap.xml in the sitemap bucket on every run. Disabled (paused)
+# outside prod, like the other tasks_executor schedulers.
+resource "google_cloud_scheduler_job" "generate_sitemap_scheduler" {
+  name        = "generate-mobilitydatabase-sitemap-${var.environment}"
+  description = "Daily regeneration of the mobilitydatabase.org sitemap"
+  time_zone   = "Etc/UTC"
+  schedule    = var.generate_sitemap_schedule
+  region      = var.gcp_region
+  paused      = var.environment == "prod" ? false : true
+  depends_on  = [google_cloudfunctions2_function.tasks_executor, google_cloudfunctions2_function_iam_member.tasks_executor_invoker]
+  http_target {
+    http_method = "POST"
+    uri         = google_cloudfunctions2_function.tasks_executor.url
+    oidc_token {
+      service_account_email = google_service_account.functions_service_account.email
+    }
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    body = base64encode("{\"task\": \"generate_mobilitydatabase_sitemap\", \"payload\": {\"dry_run\": false}}")
+  }
+  attempt_deadline = "600s"
+}
+
 # 5.3 Create function that subscribes to the Pub/Sub topic
 resource "google_cloudfunctions2_function" "gbfs_validator_pubsub" {
   name        = "${local.function_gbfs_validation_report_config.name}-pubsub"

--- a/infra/functions-python/vars.tf
+++ b/infra/functions-python/vars.tf
@@ -154,6 +154,12 @@ variable "update_feed_status_schedule" {
     default     = "0 4 * * *" # At 4am every day.
 }
 
+variable "generate_sitemap_schedule" {
+    type        = string
+    description = "Schedule the mobilitydatabase.org sitemap generation task"
+    default     = "0 8 * * *" # At 08:00 UTC every day.
+}
+
 variable "brevo_api_announcements_list_id" {
     type        = string
     description = "Brevo list ID for API announcements"


### PR DESCRIPTION
**Summary:**

This PR generates a sitemap for the MobilityDatabase daily through a cron job at midnight + 8 hours UTC with the objective of guiding bots crawl the MobilityDatabases new or updated feeds. It will upload this sitemap to a GCP bucket for NextJs to consume

It will only show feeds with status `["future", "inactive", "active"]` and an operational status of `published`

The logic of the last modification date is not perfect, but is as follows

GTFS: The date of the last dataset
GTFS RT: Either it's created_at date or the date of the latest dataset of it's related feed
GBFS: The date of the last GBFS Version introduced

**To note**
- Many bots (ex: Google) don't put much emphasis on sitemap properties like `changefreq` or `priority` so they were not optimized 
- For GBFS having the `lastmod` be changed to new every day would effectively make that value worthless to crawlers
- This PR only uploads the sitemap to the GCP bucket, another ticket will be required for the MobilityDatabase to consume it

**Expected behavior:** 

Every day at midnight + 8 hours UTC, the generate sitemap task will run and generate a new sitemap that will be placed in the `mobilitydatabase-sitemap-*` bucket

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
