### PR TITLE
fix(ci): self-heal broken cached lint venvs

### DIFF
--- a/scripts/lint-tests.sh
+++ b/scripts/lint-tests.sh
@@ -14,7 +14,10 @@ execute_lint() {
     printf "\nExecuting lint check in $1\n" 
     cd $ABS_SCRIPTPATH/$1 || exit 1
     pip3 install --disable-pip-version-check virtualenv > /dev/null
-    python -m virtualenv venv > /dev/null
+    if [ ! -x venv/bin/python ] || ! venv/bin/python -m pip --version > /dev/null 2>&1; then
+        rm -rf venv
+        python -m virtualenv venv > /dev/null
+    fi
     venv/bin/python -m pip install -r requirements_dev.txt > /dev/null
     venv/bin/python -m flake8 && venv/bin/python -m black . --check
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
**Summary:**

Summary:
- Run lint checks was intermittently failing with venv/bin/python: No such file or directory.
- Cause: actions/cache restores venv/ dirs keyed only on requirements_dev.txt hashes. virtualenv symlinks venv/bin/python to the runner's system Python path; when a GitHub runner image bumps its Python patch version, that path vanishes but the cache key doesn't change, so a stale/broken venv gets restored. Re-running virtualenv against it doesn't repair the symlink.
- Fix: scripts/lint-tests.sh now checks that the cached venv/bin/python is actually executable before reusing it, and wipes/recreates the venv if not.
- Verified locally by reproducing the broken-symlink scenario and confirming self-heal, plus a full clean and cache-hit run of the lint suite.


**Expected behavior:** 
lint passes consistenly on GitHub

**Testing tips:**

Observe GH actions.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
