### PR TITLE
Added seal_criterion_snapshot table.

### DIFF
--- a/api/src/shared/database/database.py
+++ b/api/src/shared/database/database.py
@@ -78,6 +78,7 @@ cascade_entities = {
         Feed.redirectingids_,  # redirectingid_target_id_fkey
         Feed.feed_license_changes,
         Feed.seal_criteria,  # seal_criterion_feed_id_fkey
+        Feed.seal_criterion_snapshots,  # seal_criterion_snapshot_feed_id_fkey
         Feed.feed_reliability_seal,  # feed_reliability_seal_feed_id_fkey
     ],
     Gtfsfeed: [Gtfsfeed.gtfs_dataset_changelogs],

--- a/api/tests/integration/cascade_delete/test_cascade_delete.py
+++ b/api/tests/integration/cascade_delete/test_cascade_delete.py
@@ -27,6 +27,7 @@ from shared.database_gen.sqlacodegen_models import (
     Geopolygon,
     FeedLicenseChange,
     SealCriterion,
+    SealCriterionSnapshot,
     FeedReliabilitySeal,
 )
 
@@ -228,6 +229,37 @@ def test_delete_feed_cascadeto_seal_criterion(test_database):
             [
                 "SELECT COUNT(*) FROM feed where id = 'f1'",
                 "SELECT COUNT(*) FROM seal_criterion where feed_id = 'f1'",
+            ],
+            feed,
+        )
+
+
+def test_delete_feed_cascadeto_seal_criterion_snapshot(test_database):
+    """Deleting a feed removes its recorded per-day criterion state (issue #1809).
+
+    Same shape as the seal_criterion case above: feed_id is NOT NULL and part of the
+    composite primary key, so without the `Feed.seal_criterion_snapshots` entry in
+    `cascade_entities` SQLAlchemy would try to NULL it instead of letting ON DELETE CASCADE
+    remove the rows.
+    """
+
+    with test_database.start_db_session() as session:
+        feed = Feed(id="f1")
+        log_row = SealCriterionSnapshot(
+            feed_id="f1",
+            criterion="official",
+            snapshot_date=datetime.date(2026, 6, 1),
+            observed_status="pass",
+            confirmed_status="pass",
+        )
+        session.add_all([feed, log_row])
+        session.commit()
+
+        delete_and_assert(
+            session,
+            [
+                "SELECT COUNT(*) FROM feed where id = 'f1'",
+                "SELECT COUNT(*) FROM seal_criterion_snapshot where feed_id = 'f1'",
             ],
             feed,
         )

--- a/functions-python/tasks_executor/src/tasks/seal_of_reliability/seal_updater.py
+++ b/functions-python/tasks_executor/src/tasks/seal_of_reliability/seal_updater.py
@@ -15,16 +15,22 @@
 #
 """Nightly Seal of Reliability evaluation (issue #1761).
 
-Reads feed, dataset, validation report and availability data; writes only seal_criterion
-and feed_reliability_seal. The source tables are never modified.
+Reads feed, dataset, validation report and availability data; writes only seal_criterion,
+seal_criterion_snapshot and feed_reliability_seal. The source tables are never modified.
 
-Both seal tables are written with Core `insert(...).on_conflict_do_update` statements
+The seal tables are written with Core `insert(...).on_conflict_do_update` statements
 against `__table__` for bulk upsert.
+
+seal_criterion holds the current state, one row per feed and criterion. seal_criterion_snapshot
+records the same state under the day it was evaluated (issue #1809), one row per feed,
+criterion and day, so past values survive and a correction can resume from a day rather than
+cold-start the window. The job takes the snapshots but never reads them: the state it needs is the
+current one.
 """
 
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from sqlalchemy import select
@@ -36,6 +42,7 @@ from shared.database_gen.sqlacodegen_models import (
     Feed,
     FeedReliabilitySeal,
     SealCriterion,
+    SealCriterionSnapshot,
 )
 
 from tasks.seal_of_reliability.context import (
@@ -62,6 +69,17 @@ DEFAULT_MAX_REPORTED_FEEDS: int = 50
 
 SEAL_TABLE = FeedReliabilitySeal.__table__
 CRITERION_TABLE = SealCriterion.__table__
+SNAPSHOT_TABLE = SealCriterionSnapshot.__table__
+
+# The state columns of a snapshot row: everything but its key. Taken from the table rather than
+# listed here, so a column added to seal_criterion_snapshot is written without touching this file
+# — and, if it has no matching field on SealCriterionState, fails loudly on the first run
+# instead of being silently left NULL.
+SNAPSHOT_STATE_COLUMNS: Tuple[str, ...] = tuple(
+    column.name
+    for column in SNAPSHOT_TABLE.columns
+    if column.name not in ("feed_id", "criterion", "snapshot_date")
+)
 
 
 def _resolve_evaluators(criteria: Optional[Sequence[str]]) -> List:
@@ -224,6 +242,65 @@ def _upsert_criteria(
                 "last_confirmed_failure_at": statement.excluded.last_confirmed_failure_at,
                 "probation_start": statement.excluded.probation_start,
                 "updated_at": statement.excluded.updated_at,
+            },
+        )
+    )
+
+
+def snapshot_date_of(now: datetime) -> date:
+    """The UTC day a run evaluating at `now` takes its snapshots under.
+
+    Naive values are read as UTC rather than rejected: the entry point normalizes what an
+    operator passes, but `update_seals` is also called directly.
+    """
+    if now.tzinfo is None:
+        return now.date()
+    return now.astimezone(timezone.utc).date()
+
+
+def _snapshot_row(state: SealCriterionState, snapshot_date: date) -> dict:
+    """One seal_criterion_snapshot row: the key, then the state columns read off by name.
+
+    The column names and the SealCriterionState field names are deliberately the same, which
+    is what lets the state columns be taken from the table instead of listed here.
+    """
+    row = {
+        "feed_id": state.feed_id,
+        "criterion": state.criterion.value,
+        "snapshot_date": snapshot_date,
+    }
+    for column in SNAPSHOT_STATE_COLUMNS:
+        value = getattr(state, column)
+        row[column] = value.value if isinstance(value, CriterionStatus) else value
+    return row
+
+
+def _upsert_criterion_snapshot(
+    db_session: Session, states: Sequence[SealCriterionState], snapshot_date: date
+) -> None:
+    """Record the states under `snapshot_date` in seal_criterion_snapshot.
+
+    Same states and same transaction as `_upsert_criteria`, so the two tables cannot
+    disagree: a criterion's latest snapshot is its current state.
+
+    The day is the key, so a rerun or a replay of the same day overwrites its row instead of
+    adding one — the number of runs in a day leaves no trace. Earlier days are never touched
+    by a run evaluating a later one; they are the record.
+    """
+    if not states:
+        return
+    payload = [_snapshot_row(state, snapshot_date) for state in states]
+    statement = insert(SNAPSHOT_TABLE).values(payload)
+    db_session.execute(
+        statement.on_conflict_do_update(
+            index_elements=[
+                SNAPSHOT_TABLE.c.feed_id,
+                SNAPSHOT_TABLE.c.criterion,
+                SNAPSHOT_TABLE.c.snapshot_date,
+            ],
+            set_={
+                column: getattr(statement.excluded, column)
+                for column in SNAPSHOT_STATE_COLUMNS
             },
         )
     )
@@ -433,8 +510,10 @@ def update_seals(
     revoked = [outcome for outcome in outcomes if outcome["revoked"]]
     granted = [outcome for outcome in outcomes if outcome["granted"]]
     if not dry_run:
+        snapshot_date = snapshot_date_of(now)
         for state_batch in batched(all_states, batch_size):
             _upsert_criteria(db_session, state_batch, now)
+            _upsert_criterion_snapshot(db_session, state_batch, snapshot_date)
             db_session.commit()
         for outcome_batch in batched(outcomes, batch_size):
             _upsert_seals(db_session, outcome_batch, now)
@@ -447,6 +526,9 @@ def update_seals(
         ),
         "dry_run": dry_run,
         "evaluated_at": now.isoformat(),
+        # The day the snapshots were taken under, which is the day a replay would name to
+        # overwrite them.
+        "snapshot_date": snapshot_date_of(now).isoformat(),
         "total_feeds": len(feeds),
         "criteria": [evaluator.name.value for evaluator in evaluators],
         "partial_run": partial_run,

--- a/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_updater_db.py
+++ b/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_updater_db.py
@@ -16,6 +16,7 @@
 """Integration tests for the seal context loader and orchestrator, against the test DB."""
 
 import unittest
+from dataclasses import fields
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -27,6 +28,7 @@ from tasks.seal_of_reliability.criteria import (
 )
 from tasks.seal_of_reliability.evaluators import CriterionEvaluator, OfficialEvaluator
 from tasks.seal_of_reliability.seal_updater import update_seals
+from tasks.seal_of_reliability.state_machine import SealCriterionState
 from sqlalchemy import delete, select
 
 from shared.database.database import with_db_session
@@ -35,6 +37,7 @@ from shared.database_gen.sqlacodegen_models import (
     FeedReliabilitySeal,
     Gtfsfeed,
     SealCriterion,
+    SealCriterionSnapshot,
 )
 from test_shared.test_utils.database_utils import default_db_url
 
@@ -203,6 +206,17 @@ class SealDbTestCase(unittest.TestCase):
                 select(table).where(table.c.feed_id == feed_id)
             ).all()
         }
+
+    @staticmethod
+    @with_db_session(db_url=default_db_url)
+    def snapshot_rows(feed_id, criterion, db_session):
+        """Every recorded day of one criterion, oldest first (issue #1809)."""
+        table = SealCriterionSnapshot.__table__
+        return db_session.execute(
+            select(table)
+            .where(table.c.feed_id == feed_id, table.c.criterion == criterion)
+            .order_by(table.c.snapshot_date)
+        ).all()
 
     @staticmethod
     @with_db_session(db_url=default_db_url)
@@ -529,6 +543,110 @@ class TestUpdateSeals(SealDbTestCase):
         report = update_seals(dry_run=True, stable_feed_ids=[OFFICIAL], now=NOW)
         self.assertEqual(len(report["feeds"]), 1)
         self.assertEqual(report["feeds_omitted"], 0)
+
+
+class TestCriterionSnapshot(SealDbTestCase):
+    """seal_criterion_snapshot, the per-day record of each criterion (issue #1809).
+
+    Official is enough to drive all of this: what is under test is which day a run records,
+    what it leaves alone, and that the record matches the state — not the verdict itself.
+    """
+
+    CRITERION = SealCriterionName.OFFICIAL.value
+
+    def snapshots(self):
+        return self.snapshot_rows(OFFICIAL, self.CRITERION)
+
+    def test_a_run_records_the_day_it_evaluated(self):
+        update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW)
+        rows = self.snapshots()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].snapshot_date, NOW.date())
+        self.assertEqual(rows[0].observed_status, CriterionStatus.PASS.value)
+
+    def test_the_report_names_the_day_recorded(self):
+        report = update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW)
+        self.assertEqual(report["snapshot_date"], NOW.date().isoformat())
+
+    def test_a_dry_run_records_nothing(self):
+        update_seals(dry_run=True, stable_feed_ids=[OFFICIAL], now=NOW)
+        self.assertEqual(self.snapshots(), [])
+
+    def test_each_run_records_its_own_day(self):
+        days = [NOW, NOW + timedelta(days=1), NOW + timedelta(days=2)]
+        for moment in days:
+            update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=moment)
+
+        self.assertEqual(
+            [row.snapshot_date for row in self.snapshots()],
+            [moment.date() for moment in days],
+        )
+
+    def test_rerunning_a_day_overwrites_its_row(self):
+        """The day is the key, so how many times the job ran that day leaves no trace."""
+        update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW)
+        self.set_official(OFFICIAL, False)
+        update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW)
+
+        rows = self.snapshots()
+        self.assertEqual(len(rows), 1, "one row for the day, not one per run")
+        self.assertEqual(
+            rows[0].observed_status,
+            CriterionStatus.FAIL.value,
+            "and it holds what the last run of that day wrote",
+        )
+
+    def test_a_later_run_leaves_earlier_days_alone(self):
+        update_seals(dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW)
+        self.set_official(OFFICIAL, False)
+        update_seals(
+            dry_run=False, stable_feed_ids=[OFFICIAL], now=NOW + timedelta(days=1)
+        )
+
+        first, second = self.snapshots()
+        self.assertEqual(first.snapshot_date, NOW.date())
+        self.assertEqual(
+            first.confirmed_status,
+            CriterionStatus.PASS.value,
+            "day one still records the pass it saw; the record is not restated",
+        )
+        self.assertEqual(second.confirmed_status, CriterionStatus.FAIL.value)
+
+    def test_the_latest_row_matches_the_current_state(self):
+        """Both tables are written from the same state, so they cannot disagree."""
+        update_seals(dry_run=False, stable_feed_ids=[NOT_OFFICIAL], now=NOW)
+
+        current = self.criterion_rows(NOT_OFFICIAL)[self.CRITERION]
+        recorded = self.snapshot_rows(NOT_OFFICIAL, self.CRITERION)[-1]
+        for column in (
+            "observed_status",
+            "confirmed_status",
+            "last_verdict_at",
+            "first_observed_failure_at",
+            "last_observed_failure_at",
+            "last_confirmed_failure_at",
+            "probation_start",
+        ):
+            self.assertEqual(
+                getattr(recorded, column),
+                getattr(current, column),
+                f"{column} differs between seal_criterion and seal_criterion_snapshot",
+            )
+
+    def test_the_log_covers_every_field_the_state_carries(self):
+        """A field added to the state machine must be recorded, or a replay cannot resume.
+
+        Guards the derivation in `SNAPSHOT_STATE_COLUMNS`: it is built from the table, so a new
+        state field that nobody added a column for would be dropped silently.
+        """
+        recorded = {column.name for column in SealCriterionSnapshot.__table__.columns}
+        carried = {
+            field.name
+            for field in fields(SealCriterionState)
+            # The key, and the one field the state machine writes but never reads back.
+            if field.name not in ("feed_id", "criterion", "evaluated_at")
+        }
+        self.assertEqual(carried - recorded, set())
 
 
 @patch("tasks.seal_of_reliability.seal_updater.EVALUATORS", WITH_PROBATION)

--- a/liquibase/changelog.xml
+++ b/liquibase/changelog.xml
@@ -135,6 +135,8 @@
     <include file="changes/feat_1775.sql" relativeToChangelogFile="true"/>
     <!-- Seal of Reliability: positive status columns and probation_start (issue #1783). -->
     <include file="changes/feat_1783.sql" relativeToChangelogFile="true"/>
+    <!-- Seal of Reliability: seal_criterion_snapshot, the per-day record of each criterion (issue #1809). -->
+    <include file="changes/feat_1809.sql" relativeToChangelogFile="true"/>
     <!-- Keep this after all source table and schema changes so materialized views
          are recreated from the final source schema. -->
     <include file="materialized_views/materialized_views.xml" relativeToChangelogFile="true"/>

--- a/liquibase/changes/feat_1809.sql
+++ b/liquibase/changes/feat_1809.sql
@@ -1,0 +1,33 @@
+-- Issue #1809: keep the state of each seal criterion on every day it is evaluated, so past
+-- values survive and a correction can resume from the day before the change instead of
+-- cold-starting the window. seal_criterion is unchanged and still holds the current state.
+--
+-- A DATE key rather than a timestamp, so re-running or replaying a day overwrites it. No
+-- cadence is assumed: gaps are normal, and a reader takes the latest row on or before the
+-- day it asks about.
+
+CREATE TABLE seal_criterion_snapshot (
+    feed_id                    VARCHAR(255) NOT NULL REFERENCES Feed(id) ON DELETE CASCADE,
+    criterion                  seal_criterion_name NOT NULL,
+    snapshot_date              DATE NOT NULL,
+
+    observed_status            seal_criterion_status NOT NULL,
+    confirmed_status           seal_criterion_status NOT NULL,
+
+    last_verdict_at            TIMESTAMPTZ,
+    first_observed_failure_at  TIMESTAMPTZ,
+    probation_start            TIMESTAMPTZ,
+    last_observed_failure_at   TIMESTAMPTZ,
+    last_confirmed_failure_at  TIMESTAMPTZ,
+
+    PRIMARY KEY (feed_id, criterion, snapshot_date)
+);
+
+-- For whole-catalogue-on-a-day queries and retention deletes; the primary key already
+-- covers a single feed's snapshots.
+CREATE INDEX idx_seal_criterion_snapshot_date
+    ON seal_criterion_snapshot (snapshot_date);
+
+COMMENT ON TABLE seal_criterion_snapshot IS
+    'State of each seal criterion per feed and evaluated day. seal_criterion holds the '
+    'current state; this holds the record.';


### PR DESCRIPTION
## From our AI friend:
`seal_criterion` holds only the current state and is overwritten on every run, so past values
are lost and a retroactive correction has to cold-start a feed's whole window.

Adds `seal_criterion_snapshot`: one row per feed, criterion and evaluated day, written by the
nightly job from the same state and in the same transaction as the `seal_criterion` write.
Keyed on `(feed_id, criterion, snapshot_date)` with the day as a `DATE`, so re-running or
replaying a day retakes that snapshot rather than adding a row. Gaps are normal — a reader
takes the latest snapshot on or before the day it asks about.

`seal_criterion` is unchanged, so nothing reading it today has to move. The job writes the
snapshots but never reads them; #1803 will, to resume a correction from the day before the
one it is changing.



Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
