### PR TITLE
feat: add CORS to operations API

### DIFF
--- a/functions-python/operations_api/function_config.json
+++ b/functions-python/operations_api/function_config.json
@@ -10,6 +10,9 @@
   "environment_variables": [
     {
       "key": "GOOGLE_CLIENT_ID"
+    },
+    {
+      "key": "CORS_ALLOWED_ORIGINS"
     }
   ],
   "secret_environment_variables": [

--- a/functions-python/operations_api/src/main.py
+++ b/functions-python/operations_api/src/main.py
@@ -14,8 +14,11 @@
 #  limitations under the License.
 #
 
+import os
+
 from flask import Request, Response
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from feeds_gen.apis.operations_api import router as FeedsApiRouter
 from feeds_gen.apis.licenses_api import router as LicenseApiRouter
 from feeds_gen.apis.users_api import router as UsersApiRouter
@@ -35,6 +38,21 @@ app = FastAPI(
 
 # Add here middlewares that should be applied to all routes.
 app.add_middleware(RequestContextMiddleware)
+# Added last so it becomes the outermost ASGI layer (Starlette middlewares wrap
+# in reverse order of registration) and can answer CORS preflight OPTIONS
+# requests before they ever reach RequestContextMiddleware's auth check, which
+# would otherwise 401 every preflight since browsers never send Authorization
+# on an OPTIONS request.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        origin.strip()
+        for origin in os.getenv("CORS_ALLOWED_ORIGINS", "*").split(",")
+        if origin.strip()
+    ],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(FeedsApiRouter)
 app.include_router(LicenseApiRouter)
 app.include_router(UsersApiRouter)


### PR DESCRIPTION
**Summary:**

Add CORS to the operations API.

**Expected behavior:** 

A request with a preflight header is allowed.

**Testing tips:**

After deployment in DEV, this request must pass:
```
curl -i -X OPTIONS \
  "https://{dev-api-address}/operations-api/v1/operations/feeds?offset=0&limit=50" \
  -H "Origin: https://mobilitydatabase-operations-qmih98m11-mobility-data.vercel.app" \
  -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: authorization,content-type"
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
