### PR TITLE
fix: override GTFS-RT entity types during populate

### DIFF
--- a/api/src/scripts/populate_db_gtfs.py
+++ b/api/src/scripts/populate_db_gtfs.py
@@ -110,6 +110,8 @@ class GTFSDatabasePopulateHelper(DatabasePopulateHelper):
         """
         entity_types = self.get_safe_value(row, "entity_type", "").replace("|", "-").split("-")
         if len(entity_types) > 0:
+            if any(entity_types):
+                feed.entitytypes.clear()
             for entity_type_name in entity_types:
                 entity_type = session.query(Entitytype).filter(Entitytype.name == entity_type_name).first()
 

--- a/api/tests/integration/populate_tests/test_data/sources_test.csv
+++ b/api/tests/integration/populate_tests/test_data/sources_test.csv
@@ -14,6 +14,8 @@ mdb_source_id,data_type,entity_type,location.country_code,location.subdivision_n
 # For mdb-1562, change is_official from FALSE to TRUE. Should change to True.
 # Also change is_producer_url_unstable from base FALSE to TRUE: should change to True.
 # Also change is_seasonal from base FALSE to TRUE: should change to True.
+# For mdb-1562, first populate sa|vp, then the following row narrows entity_type to sa to verify replacement semantics.
+1562,gtfs-rt,sa|vp,CA,BC,Vancouver,Vancouver-Transit(éèàçíóúČ),TRUE,Realtime(ŘŤÜÎ),,,50,http://foo.org/google_transit.zip,0,,,,,,,,,,active,,10,,TRUE,TRUE
 1562,gtfs-rt,sa,CA,BC,Vancouver,Vancouver-Transit(éèàçíóúČ),TRUE,Realtime(ŘŤÜÎ),,,50,http://foo.org/google_transit.zip,0,,,,,,,,,,active,,10,,TRUE,TRUE
 # For mdb-1563, change is_official from TRUE to FALSE. Should change to False.
 # Also change is_producer_url_unstable from base TRUE to FALSE: should change to False.

--- a/api/tests/integration/populate_tests/test_populate.py
+++ b/api/tests/integration/populate_tests/test_populate.py
@@ -321,3 +321,15 @@ def test_locationless_gtfs_rt_feed_inherits_union_of_static_feed_locations(
         ("CA", "Ontario", "London"),
         ("CA", "Ontario", "Barrie"),
     }
+
+
+def test_entity_types_overwrite(client: TestClient):
+    """A later catalog row must replace, not add to, GTFS-RT entity types."""
+    response = client.request(
+        "GET",
+        "/v1/gtfs_rt_feeds/mdb-1562",
+        headers=authHeaders,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["entity_types"] == ["sa"]


### PR DESCRIPTION
## Summary

Fixes #1812.

GTFS-RT entity types were previously added to the existing relationship during catalogue population rather than replacing the previous catalogue values.

This meant that if a feed changed from, for example:

- `sa|vp`
- to `sa`

the stored result remained `sa|vp`.

This change clears the existing entity-type relationship before applying a non-empty catalogue `entity_type` value, so the latest catalogue row replaces the previous values.

## Regression coverage

Added an integration regression using the existing layered populate fixture:

- earlier populate row: `sa|vp`
- later populate row: `sa`
- expected final API value: `["sa"]`

Before the fix, the test failed with:

`['sa', 'vp'] != ['sa']`

After the fix, it passes.

## Tests

- focused regression: 1 passed
- populate integration package: 21 passed
- relevant API/model tests: 130 passed

Empty `entity_type` cell semantics are intentionally unchanged by this patch.