### PR TITLE
feat: fresh continuous coverage criterion impl

### DIFF
--- a/api/src/shared/common/continuous_coverage.py
+++ b/api/src/shared/common/continuous_coverage.py
@@ -21,10 +21,18 @@ from typing import Final, Optional, Tuple
 # this is not evidence of continuous coverage - it is more likely a placeholder calendar.
 MAX_COVERAGE_WINDOW: Final[timedelta] = timedelta(days=730)
 
+# The file supplying the producer's declared window.
+FEED_INFO_FILE: Final[str] = "feed_info.txt"
+
+# The files the validated service window is derived from. A dataset carrying neither published
+# no calendar data at all, which `fresh_continuous` reads as a verdict rather than as a gap
+# in what we know.
+CALENDAR_FILES: Final[Tuple[str, ...]] = ("calendar.txt", "calendar_dates.txt")
+
 # The files the calculation reads, in the order they are reported. `feed_info.txt` supplies the
 # declared window; the two calendar files are what the validator derives the service window
 # from. Order is fixed so a client can render one row of chips per dataset without sorting.
-COVERAGE_FILES: Final[Tuple[str, ...]] = ("feed_info.txt", "calendar.txt", "calendar_dates.txt")
+COVERAGE_FILES: Final[Tuple[str, ...]] = (FEED_INFO_FILE, *CALENDAR_FILES)
 
 # Which input a coverage window was taken from. Values match the `coverage_window_source` enum
 # in the API spec.

--- a/functions-python/tasks_executor/src/tasks/seal_of_reliability/context.py
+++ b/functions-python/tasks_executor/src/tasks/seal_of_reliability/context.py
@@ -18,35 +18,41 @@
 The evaluators are pure functions over a `FeedSealContext`, so every DB read for a batch of
 feeds happens here, in a fixed number of queries regardless of batch size.
 
-Official, Stable, Fresh (future coverage), Available and Compliant are implemented. Official
-and Stable read the feed row alone; Fresh needs one bulk-loaded extra, the feed's latest
-dataset; Available needs the run window's availability rows and Compliant the closest dataset's
-validation report. Each new criterion adds the fields it needs here plus, where they are not
-already on the feed row, one bulk query to populate them - Fresh continuous coverage would add
-the full dataset coverage history.
+All six criteria are implemented. Official and Stable read the feed row alone; Available needs
+the run window's availability rows and Compliant the closest dataset's validation report. The two
+Fresh criteria share `_load_recent_datasets`. Each new criterion adds the fields it needs here
+plus, where they are not already on the feed row, one bulk query to populate them.
 
 Every query here is bounded by the run's `now` rather than reading a "current" pointer column,
 so a run replayed for a past date sees the state as it was then. That is what lets a backfill
 (#1782) reconstruct history with the same evaluators.
 """
 
+import datetime as datetime_module
 import itertools
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Iterator, List, Optional, Sequence
+from typing import Dict, Final, Iterator, List, Optional, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from shared.common.continuous_coverage import CALENDAR_FILES
 from shared.common.seal_criteria import AVAILABILITY_LOOKBACK
 from shared.database_gen.sqlacodegen_models import (
     Feed,
+    Feedinfo,
     GtfsFeedAvailabilityCheck,
     Gtfsdataset,
     Gtfsfeed,
+    Gtfsfile,
     Validationreport,
     t_validationreportgtfsdataset,
 )
+
+# How far back down a feed's dataset history the contexts reach: `fresh_continuous` judges one
+# boundary, so it needs the closest dataset and the one before it.
+DATASET_HISTORY_DEPTH: Final[int] = 2
 
 
 @dataclass(frozen=True)
@@ -68,18 +74,26 @@ class ValidationReport:
 
 
 @dataclass(frozen=True)
-class ClosestDataset:
-    """
-    The feed's dataset closest to the run's `now`, and the fields criteria read off it.
+class DatasetCoverage:
+    """One dataset in a feed's history, and the coverage fields the Fresh criteria read off it.
 
-    "Closest" means closest at or before `now` - the dataset being served at that instant.
-    Never a later one, however near: a run for a past date must not see a dataset that had
-    not been downloaded yet.
+    The declared and validated windows are kept separate rather than resolved to one here: the
+    criteria disagree about which to prefer, and a missing one of each means something
+    different. `has_calendar_data` is what tells a dataset that published no calendar apart
+    from one whose window we simply have not derived yet.
     """
 
     dataset_id: str
     downloaded_at: datetime
+    service_date_range_start: Optional[datetime] = None
     service_date_range_end: Optional[datetime] = None
+
+    # The producer's declared window, from the `feedinfo` row this dataset points at.
+    feed_info_start: Optional[datetime_module.date] = None
+    feed_info_end: Optional[datetime_module.date] = None
+
+    # Whether the dataset carries `calendar.txt` or `calendar_dates.txt`.
+    has_calendar_data: bool = False
 
 
 @dataclass
@@ -104,7 +118,11 @@ class FeedSealContext:
     feed_created_at: Optional[datetime] = None
 
     # The feed's closest dataset as of `now` - resolved by `downloaded_at` vs `now`
-    closest_dataset: Optional[ClosestDataset] = None
+    closest_dataset: Optional[DatasetCoverage] = None
+
+    # Fresh / continuous coverage: the dataset downloaded immediately before `closest_dataset`,
+    # whose coverage the closest one has to meet. None when the feed had only one as of `now`.
+    previous_dataset: Optional[DatasetCoverage] = None
 
     # Available: the latest availability check in the window this run covers.
     availability_check: Optional[AvailabilityCheck] = None
@@ -192,52 +210,83 @@ def iter_eligible_stable_ids(
         yield chunk
 
 
-def _load_closest_datasets(
+def _load_recent_datasets(
     db_session: Session, feed_ids: Sequence[str], now: datetime
-) -> Dict[str, ClosestDataset]:
-    """feed_id -> the feed's closest dataset as of `now`, for feeds that had one.
+) -> Dict[str, List[DatasetCoverage]]:
+    """feed_id -> its `DATASET_HISTORY_DEPTH` most recent datasets as of `now`, newest first.
 
-    "Closest to `now`" is the most recently downloaded dataset with `downloaded_at <= now`
-    - closest looking backwards only, never the nearest in either direction.
+    Ordered by `downloaded_at` among the datasets with `downloaded_at <= now` - looking
+    backwards only, so a run for a past date cannot see a dataset downloaded after it.
 
-    A feed missing from the result had no dataset at all as of `now`. That is deliberately
-    distinct from a `ClosestDataset` whose `service_date_range_end` is None, which had one
-    whose coverage was never extracted - the criteria read both as UNKNOWN but report which.
+    A feed missing from the result had no dataset at all as of `now`, which stays distinct
+    from a `DatasetCoverage` whose windows are None: that one exists but was never processed.
+
+    One query for the whole batch, `ROW_NUMBER()` rather than a per-feed `LIMIT`.
     """
     if not feed_ids:
         return {}
-    rows = db_session.execute(
+
+    # Correlated, so the flag comes back with the row rather than needing a second query.
+    has_calendar_data = (
+        select(1)
+        .where(
+            Gtfsfile.gtfs_dataset_id == Gtfsdataset.id,
+            Gtfsfile.file_name.in_(CALENDAR_FILES),
+        )
+        .exists()
+    )
+    ranked = (
         select(
             Gtfsdataset.feed_id,
             Gtfsdataset.id,
             Gtfsdataset.downloaded_at,
+            Gtfsdataset.service_date_range_start,
             Gtfsdataset.service_date_range_end,
+            Feedinfo.feed_start_date,
+            Feedinfo.feed_end_date,
+            has_calendar_data.label("has_calendar_data"),
+            func.row_number()
+            .over(
+                partition_by=Gtfsdataset.feed_id,
+                order_by=(Gtfsdataset.downloaded_at.desc(), Gtfsdataset.id.desc()),
+            )
+            .label("recency"),
         )
+        .select_from(Gtfsdataset)
+        # Outer: a dataset with no `feed_info.txt` still comes back, with no declared window.
+        .outerjoin(Feedinfo, Feedinfo.id == Gtfsdataset.feed_info_id)
         .where(
             Gtfsdataset.feed_id.in_(list(feed_ids)),
             Gtfsdataset.downloaded_at.is_not(None),
             Gtfsdataset.downloaded_at <= now,
         )
-        .distinct(Gtfsdataset.feed_id)
-        .order_by(
-            Gtfsdataset.feed_id,
-            Gtfsdataset.downloaded_at.desc(),
-            Gtfsdataset.id.desc(),
-        )
+        .subquery()
+    )
+    rows = db_session.execute(
+        select(ranked)
+        .where(ranked.c.recency <= DATASET_HISTORY_DEPTH)
+        .order_by(ranked.c.feed_id, ranked.c.recency)
     ).all()
-    return {
-        row.feed_id: ClosestDataset(
-            dataset_id=row.id,
-            downloaded_at=row.downloaded_at,
-            service_date_range_end=row.service_date_range_end,
+
+    recent: Dict[str, List[DatasetCoverage]] = {}
+    for row in rows:
+        recent.setdefault(row.feed_id, []).append(
+            DatasetCoverage(
+                dataset_id=row.id,
+                downloaded_at=row.downloaded_at,
+                service_date_range_start=row.service_date_range_start,
+                service_date_range_end=row.service_date_range_end,
+                feed_info_start=row.feed_start_date,
+                feed_info_end=row.feed_end_date,
+                has_calendar_data=bool(row.has_calendar_data),
+            )
         )
-        for row in rows
-    }
+    return recent
 
 
 def _load_validation_reports(
     db_session: Session,
-    closest_datasets: Dict[str, ClosestDataset],
+    closest_datasets: Dict[str, DatasetCoverage],
     now: datetime,
 ) -> Dict[str, ValidationReport]:
     """feed_id -> the latest validation report of that feed's closest dataset, as of `now`.
@@ -345,7 +394,7 @@ def build_contexts(
 
     2. Needs its own query. Add the field, then a module-level `_load_*` helper that takes
        the whole batch and returns a dict keyed by feed_id, and call it once here, as
-       `_load_closest_datasets`, `_load_availability` and `_load_validation_reports` do.
+       `_load_recent_datasets`, `_load_availability` and `_load_validation_reports` do.
        Keeping the query per batch rather than per feed is what holds the query count
        proportional to the number of criteria instead of the number of feeds. Bound the
        helper by `now` so the criterion stays replayable, and leave feeds with no row out of
@@ -353,7 +402,17 @@ def build_contexts(
        the evaluators read as UNKNOWN rather than as a failure.
     """
     feed_ids = [feed.id for feed in feeds]
-    closest_datasets = _load_closest_datasets(db_session, feed_ids, now)
+    recent_datasets = _load_recent_datasets(db_session, feed_ids, now)
+    closest_datasets = {
+        feed_id: datasets[0]
+        for feed_id, datasets in recent_datasets.items()
+        if len(datasets) > 0
+    }
+    previous_datasets = {
+        feed_id: datasets[1]
+        for feed_id, datasets in recent_datasets.items()
+        if len(datasets) > 1
+    }
     availability = _load_availability(db_session, feed_ids, now)
     validation_reports = _load_validation_reports(db_session, closest_datasets, now)
 
@@ -367,6 +426,7 @@ def build_contexts(
             seasonal=feed.seasonal,
             feed_created_at=feed.created_at,
             closest_dataset=closest_datasets.get(feed.id),
+            previous_dataset=previous_datasets.get(feed.id),
             availability_check=availability.get(feed.id),
             latest_validation_report=validation_reports.get(feed.id),
         )

--- a/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/__init__.py
+++ b/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/__init__.py
@@ -15,15 +15,11 @@
 #
 """The seal criterion evaluators.
 
-`EVALUATORS` is the registry the job iterates. Official (issue #1783), Stable, Available,
-Compliant and Fresh / future coverage (issue #1784) are implemented; Fresh / continuous
-coverage is tracked by #1782. Adding one means a new subclass,
-an entry here, and whatever fields it needs on `FeedSealContext`. Its windows are not declared
-on the subclass: they come from the policy maps in `shared.common.seal_criteria`, which the
-read API reads too.
-
-`seal_criterion_name` in the database already declares all six values, so a criterion can
-be added without a schema change.
+`EVALUATORS` is the registry the job iterates, and it now covers `seal_criterion_name` exactly:
+Official (#1783), Stable, Available, Compliant, Fresh / future coverage (#1784) and Fresh /
+continuous coverage (#1782). Adding one means a new subclass, an entry here, and whatever fields
+it needs on `FeedSealContext`. Its windows are not declared on the subclass: they come from the
+policy maps in `shared.common.seal_criteria`, which the read API reads too.
 """
 
 from typing import Final, List
@@ -34,6 +30,9 @@ from tasks.seal_of_reliability.evaluators.base import (
 )
 from tasks.seal_of_reliability.evaluators.available import AvailableEvaluator
 from tasks.seal_of_reliability.evaluators.compliant import CompliantEvaluator
+from tasks.seal_of_reliability.evaluators.fresh_continuous import (
+    FreshContinuousEvaluator,
+)
 from tasks.seal_of_reliability.evaluators.fresh_coverage import FreshCoverageEvaluator
 from tasks.seal_of_reliability.evaluators.official import OfficialEvaluator
 from tasks.seal_of_reliability.evaluators.stable import StableEvaluator
@@ -44,6 +43,7 @@ EVALUATORS: Final[List[CriterionEvaluator]] = [
     AvailableEvaluator(),
     CompliantEvaluator(),
     FreshCoverageEvaluator(),
+    FreshContinuousEvaluator(),
 ]
 
 __all__ = [
@@ -52,6 +52,7 @@ __all__ = [
     "CompliantEvaluator",
     "CriterionEvaluator",
     "CriterionObservation",
+    "FreshContinuousEvaluator",
     "FreshCoverageEvaluator",
     "OfficialEvaluator",
     "StableEvaluator",

--- a/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/fresh_continuous.py
+++ b/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/fresh_continuous.py
@@ -1,0 +1,156 @@
+#
+#   MobilityData 2026
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Fresh (continuous coverage) criterion: successive datasets cover service with no gap."""
+
+from datetime import date
+from typing import Optional, Sequence, Tuple
+
+from shared.common.continuous_coverage import (
+    CALENDAR_FILES,
+    FEED_INFO_FILE,
+    MAX_COVERAGE_WINDOW,
+    as_date,
+    overlap_and_gap,
+    window_days,
+    within_max_coverage_window,
+)
+from shared.common.seal_criteria import CriterionStatus, SealCriterionName
+from tasks.seal_of_reliability.context import DatasetCoverage, FeedSealContext
+from tasks.seal_of_reliability.evaluators.base import CriterionEvaluator
+
+Window = Tuple[date, date]
+
+CALENDAR_FILE_LIST = " or ".join(CALENDAR_FILES)
+
+
+def _window(start, end) -> Optional[Window]:
+    """Two plain dates, or None when the window is incomplete or inverted."""
+    start, end = as_date(start), as_date(end)
+    return (start, end) if window_days(start, end) is not None else None
+
+
+def _declared_window(dataset: DatasetCoverage) -> Optional[Window]:
+    return _window(dataset.feed_info_start, dataset.feed_info_end)
+
+
+def _service_window(dataset: DatasetCoverage) -> Optional[Window]:
+    return _window(dataset.service_date_range_start, dataset.service_date_range_end)
+
+
+def _span(window: Window) -> str:
+    return f"{window[0].isoformat()} to {window[1].isoformat()}"
+
+
+def _calendar_verdict(
+    pair: Sequence[DatasetCoverage], declared_note: str
+) -> Tuple[CriterionStatus, str]:
+    """What the validated service windows say, prefixed with `declared_note`."""
+    service = [_service_window(dataset) for dataset in pair]
+    missing = [dataset for dataset, window in zip(pair, service) if window is None]
+    if missing:
+        # no calendar file is the producer's omission; a window we never derived is ours
+        unpublished = [
+            dataset.dataset_id for dataset in missing if not dataset.has_calendar_data
+        ]
+        if unpublished:
+            return (
+                CriterionStatus.FAIL,
+                f"{declared_note}, and dataset {', '.join(unpublished)} carries no "
+                f"{CALENDAR_FILE_LIST}",
+            )
+        return (
+            CriterionStatus.UNKNOWN,
+            f"{declared_note}, and dataset "
+            f"{', '.join(dataset.dataset_id for dataset in missing)} has no validated "
+            "service window yet",
+        )
+
+    _, gap_days = overlap_and_gap(service[0][1], service[1][0])
+    if gap_days is None:
+        return (
+            CriterionStatus.PASS,
+            f"{declared_note}, and the validated service windows leave no gap",
+        )
+    return (
+        CriterionStatus.FAIL,
+        f"{declared_note}, and the validated service windows leave a {gap_days}-day gap",
+    )
+
+
+class FreshContinuousEvaluator(CriterionEvaluator):
+    """Successive datasets cover service with no uncovered day between them (#1782).
+
+    Three steps, in order:
+
+    1. The closest dataset's window - its `feed_info.txt` range, or its validated service
+       window when it declares none - must be no longer than `MAX_COVERAGE_WINDOW`.
+    2. A feed with only that one dataset passes: there is no boundary to break yet.
+    3. Otherwise, the boundary against the previous dataset decides. The declared ranges rule
+       where both datasets declare one, and the validated service windows are what excuses a
+       declared gap and the whole answer with no declared range. A gap has to show in both to
+       fail.
+
+    A boundary that needs the calendar where a dataset shipped no calendar file is a FAIL. It
+    is UNKNOWN only when the file is there, and we have not derived a window from it yet.
+    """
+
+    name = SealCriterionName.FRESH_CONTINUOUS
+
+    def _evaluate(self, ctx: FeedSealContext) -> Tuple[CriterionStatus, str]:
+        newer = ctx.closest_dataset
+        if newer is None:
+            return CriterionStatus.UNKNOWN, "the feed has no dataset"
+
+        # 1. the maximum coverage window, on the closest dataset alone
+        declared = _declared_window(newer)
+        window = declared or _service_window(newer)
+        if window is not None and within_max_coverage_window(*window) is False:
+            return (
+                CriterionStatus.FAIL,
+                f"dataset {newer.dataset_id} covers {_span(window)}, longer than the "
+                f"{MAX_COVERAGE_WINDOW.days}-day maximum coverage window",
+            )
+        elif window is None:
+            return (
+                CriterionStatus.UNKNOWN,
+                f"Unknown coverage window for dataset {newer.dataset_id}",
+            )
+
+        # 2. nothing published before it, so no boundary to judge
+        older = ctx.previous_dataset
+        if older is None:
+            return (
+                CriterionStatus.PASS,
+                f"dataset {newer.dataset_id} is the feed's only dataset as of this run",
+            )
+
+        # 3. the declared ranges, where both datasets declare one
+        pair = (older, newer)
+        older_declared = _declared_window(older)
+        if declared is None or older_declared is None:
+            return _calendar_verdict(
+                pair, f"the datasets do not both declare a {FEED_INFO_FILE} range"
+            )
+
+        _, gap_days = overlap_and_gap(older_declared[1], declared[0])
+        if gap_days is None:
+            return (
+                CriterionStatus.PASS,
+                f"the declared {FEED_INFO_FILE} ranges leave no gap",
+            )
+        return _calendar_verdict(
+            pair, f"the declared {FEED_INFO_FILE} ranges leave a {gap_days}-day gap"
+        )

--- a/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/fresh_continuous.py
+++ b/functions-python/tasks_executor/src/tasks/seal_of_reliability/evaluators/fresh_continuous.py
@@ -95,8 +95,9 @@ class FreshContinuousEvaluator(CriterionEvaluator):
 
     Three steps, in order:
 
-    1. The closest dataset's window - its `feed_info.txt` range, or its validated service
-       window when it declares none - must be no longer than `MAX_COVERAGE_WINDOW`.
+    1. The closest dataset needs a window of its own - its `feed_info.txt` range, or its
+       validated service window when it declares none - no longer than
+       `MAX_COVERAGE_WINDOW`.
     2. A feed with only that one dataset passes: there is no boundary to break yet.
     3. Otherwise, the boundary against the previous dataset decides. The declared ranges rule
        where both datasets declare one, and the validated service windows are what excuses a
@@ -114,21 +115,26 @@ class FreshContinuousEvaluator(CriterionEvaluator):
         if newer is None:
             return CriterionStatus.UNKNOWN, "the feed has no dataset"
 
-        # 1. the maximum coverage window, on the closest dataset alone
+        # 1. the closest dataset's own window: its declared range, else its validated one
         declared = _declared_window(newer)
         window = declared or _service_window(newer)
-        if window is not None and within_max_coverage_window(*window) is False:
+        if window is None:
+            if newer.has_calendar_data:
+                return (
+                    CriterionStatus.UNKNOWN,
+                    f"dataset {newer.dataset_id} has no validated service window yet",
+                )
+            return (
+                CriterionStatus.FAIL,
+                f"dataset {newer.dataset_id} carries neither a {FEED_INFO_FILE} range "
+                f"nor {CALENDAR_FILE_LIST}",
+            )
+        if within_max_coverage_window(*window) is False:
             return (
                 CriterionStatus.FAIL,
                 f"dataset {newer.dataset_id} covers {_span(window)}, longer than the "
                 f"{MAX_COVERAGE_WINDOW.days}-day maximum coverage window",
             )
-        elif window is None:
-            return (
-                CriterionStatus.UNKNOWN,
-                f"Unknown coverage window for dataset {newer.dataset_id}",
-            )
-
         # 2. nothing published before it, so no boundary to judge
         older = ctx.previous_dataset
         if older is None:

--- a/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_evaluators.py
+++ b/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_evaluators.py
@@ -582,9 +582,24 @@ class TestFreshContinuous(unittest.TestCase):
         self.assertIs(result.observed_status, CriterionStatus.PASS)
         self.assertIn("only dataset", result.reason)
 
-    def test_a_feed_with_one_dataset_and_no_window_at_all_passes(self):
+    def test_no_window_and_no_calendar_files_fails(self):
         result = self._verdict(None, self._dataset("ds-newer", has_calendar_data=False))
-        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("carries neither", result.reason)
+
+    def test_no_window_with_calendar_files_is_unknown(self):
+        """The file is there and the window is not, so the missing input is ours."""
+        result = self._verdict(None, self._dataset("ds-newer", has_calendar_data=True))
+        self.assertIs(result.observed_status, CriterionStatus.UNKNOWN)
+        self.assertIn("no validated service window yet", result.reason)
+
+    def test_a_windowless_closest_dataset_is_settled_before_the_boundary(self):
+        older, _ = self._continuous_pair()
+        result = self._verdict(
+            older, self._dataset("ds-newer", has_calendar_data=False)
+        )
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("ds-newer carries neither", result.reason)
 
     def test_a_feed_with_no_dataset_is_unknown(self):
         result = FreshContinuousEvaluator().evaluate(_ctx())
@@ -720,13 +735,6 @@ class TestFreshContinuous(unittest.TestCase):
         result = self._verdict(older, newer)
         self.assertIs(result.observed_status, CriterionStatus.FAIL)
         self.assertIn("do not both declare", result.reason)
-
-    def test_neither_window_nor_calendar_data_fails(self):
-        older = self._dataset("ds-older", has_calendar_data=False)
-        newer = self._dataset("ds-newer", has_calendar_data=False)
-        result = self._verdict(older, newer)
-        self.assertIs(result.observed_status, CriterionStatus.FAIL)
-        self.assertIn("ds-older, ds-newer", result.reason)
 
     def test_an_inverted_window_is_no_window(self):
         older = self._dataset(

--- a/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_evaluators.py
+++ b/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_evaluators.py
@@ -18,6 +18,7 @@
 import unittest
 from datetime import datetime, timedelta, timezone
 
+from shared.common.continuous_coverage import MAX_COVERAGE_WINDOW
 from shared.common.seal_criteria import (
     FUTURE_COVERAGE_HORIZON,
     PROBATION_PERIOD,
@@ -28,7 +29,7 @@ from shared.common.seal_criteria import (
 from tasks.seal_of_reliability.context import (
     AvailabilityCheck,
     FeedSealContext,
-    ClosestDataset,
+    DatasetCoverage,
     ValidationReport,
 )
 from tasks.seal_of_reliability.evaluators import (
@@ -36,6 +37,7 @@ from tasks.seal_of_reliability.evaluators import (
     AvailableEvaluator,
     CompliantEvaluator,
     CriterionEvaluator,
+    FreshContinuousEvaluator,
     FreshCoverageEvaluator,
     OfficialEvaluator,
     StableEvaluator,
@@ -255,7 +257,7 @@ class TestFreshCoverage(unittest.TestCase):
 
     @staticmethod
     def _dataset(coverage_end):
-        return ClosestDataset(
+        return DatasetCoverage(
             dataset_id="mdb-1-202606010000",
             downloaded_at=NOW - timedelta(days=1),
             service_date_range_end=coverage_end,
@@ -412,7 +414,7 @@ class TestCompliant(unittest.TestCase):
             else None
         )
         dataset = (
-            ClosestDataset(
+            DatasetCoverage(
                 dataset_id=self.DATASET_ID,
                 downloaded_at=NOW - timedelta(hours=2),
             )
@@ -475,6 +477,278 @@ class TestCompliant(unittest.TestCase):
     def test_has_a_grace_period_and_serves_probation(self):
         self.assertEqual(CompliantEvaluator().grace_period, timedelta(days=30))
         self.assertEqual(CompliantEvaluator().probation_period, PROBATION_PERIOD)
+
+
+class TestFreshContinuous(unittest.TestCase):
+    """The maximum coverage window, then the single-dataset pass, then the boundary."""
+
+    TODAY = NOW.date()
+
+    def _days(self, offset):
+        return self.TODAY + timedelta(days=offset)
+
+    @staticmethod
+    def _dataset(dataset_id, service=None, declared=None, has_calendar_data=True):
+        """One dataset, its two windows given as `(start, end)` date pairs or None."""
+        return DatasetCoverage(
+            dataset_id=dataset_id,
+            downloaded_at=NOW,
+            service_date_range_start=service[0] if service else None,
+            service_date_range_end=service[1] if service else None,
+            feed_info_start=declared[0] if declared else None,
+            feed_info_end=declared[1] if declared else None,
+            has_calendar_data=has_calendar_data,
+        )
+
+    def _verdict(self, older, newer, **overrides):
+        return FreshContinuousEvaluator().evaluate(
+            _ctx(previous_dataset=older, closest_dataset=newer, **overrides)
+        )
+
+    def _continuous_pair(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-10)),
+            declared=(self._days(-60), self._days(-10)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-20), self._days(60)),
+            declared=(self._days(-20), self._days(60)),
+        )
+        return older, newer
+
+    # 1. the maximum coverage window, on the closest dataset alone
+
+    def test_an_overlong_declared_range_fails(self):
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-20), self._days(60)),
+            declared=(self._days(-20), self._days(MAX_COVERAGE_WINDOW.days + 1)),
+        )
+        older, _ = self._continuous_pair()
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("maximum coverage window", result.reason)
+
+    def test_the_maximum_window_itself_passes(self):
+        older, _ = self._continuous_pair()
+        newer = self._dataset(
+            "ds-newer",
+            declared=(self._days(-20), self._days(-20 + MAX_COVERAGE_WINDOW.days)),
+        )
+        self.assertIs(self._verdict(older, newer).observed_status, CriterionStatus.PASS)
+
+    def test_the_threshold_falls_back_to_the_service_window(self):
+        """No declared range, so the validated one is what the threshold measures."""
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-20), self._days(MAX_COVERAGE_WINDOW.days + 1)),
+        )
+        result = self._verdict(None, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("maximum coverage window", result.reason)
+
+    def test_the_declared_range_is_measured_ahead_of_the_service_window(self):
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-20), self._days(MAX_COVERAGE_WINDOW.days + 1)),
+            declared=(self._days(-20), self._days(60)),
+        )
+        self.assertIs(self._verdict(None, newer).observed_status, CriterionStatus.PASS)
+
+    def test_the_threshold_is_reached_before_the_single_dataset_pass(self):
+        """A feed can fail on its only dataset, which is why this step comes first."""
+        newer = self._dataset(
+            "ds-newer",
+            declared=(self._days(-20), self._days(MAX_COVERAGE_WINDOW.days + 1)),
+        )
+        self.assertIs(self._verdict(None, newer).observed_status, CriterionStatus.FAIL)
+
+    def test_the_previous_datasets_window_is_not_measured(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-MAX_COVERAGE_WINDOW.days - 100), self._days(-10)),
+            declared=(self._days(-MAX_COVERAGE_WINDOW.days - 100), self._days(-10)),
+        )
+        _, newer = self._continuous_pair()
+        self.assertIs(self._verdict(older, newer).observed_status, CriterionStatus.PASS)
+
+    # 2. no previous dataset
+
+    def test_a_feed_with_one_dataset_passes(self):
+        newer = self._dataset("ds-newer", service=(self._days(-20), self._days(60)))
+        result = self._verdict(None, newer)
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIn("only dataset", result.reason)
+
+    def test_a_feed_with_one_dataset_and_no_window_at_all_passes(self):
+        result = self._verdict(None, self._dataset("ds-newer", has_calendar_data=False))
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+
+    def test_a_feed_with_no_dataset_is_unknown(self):
+        result = FreshContinuousEvaluator().evaluate(_ctx())
+        self.assertIs(result.observed_status, CriterionStatus.UNKNOWN)
+        self.assertIn("no dataset", result.reason)
+
+    # 3. the boundary
+
+    def test_overlapping_declared_ranges_pass(self):
+        result = self._verdict(*self._continuous_pair())
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIn("no gap", result.reason)
+
+    def test_declared_ranges_that_meet_exactly_pass(self):
+        older = self._dataset("ds-older", declared=(self._days(-60), self._days(-10)))
+        newer = self._dataset("ds-newer", declared=(self._days(-9), self._days(60)))
+        self.assertIs(self._verdict(older, newer).observed_status, CriterionStatus.PASS)
+
+    def test_a_declared_gap_is_excused_by_continuous_calendars(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-5)),
+            declared=(self._days(-60), self._days(-30)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-10), self._days(60)),
+            declared=(self._days(-20), self._days(60)),
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIn("9-day gap", result.reason)
+        self.assertIn("validated service windows leave no gap", result.reason)
+
+    def test_a_gap_in_both_windows_fails(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-30)),
+            declared=(self._days(-60), self._days(-30)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-20), self._days(60)),
+            declared=(self._days(-20), self._days(60)),
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("validated service windows leave a 9-day gap", result.reason)
+
+    def test_one_uncovered_day_is_enough_to_fail(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-10)),
+            declared=(self._days(-60), self._days(-10)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            service=(self._days(-8), self._days(60)),
+            declared=(self._days(-8), self._days(60)),
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("1-day gap", result.reason)
+
+    def test_a_declared_gap_with_no_calendar_published_fails(self):
+        """The thread's decision: no calendar file is the producer's answer, not a missing one."""
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-30)),
+            declared=(self._days(-60), self._days(-30)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            declared=(self._days(-20), self._days(60)),
+            has_calendar_data=False,
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("ds-newer carries no calendar.txt", result.reason)
+
+    def test_a_declared_gap_with_an_unprocessed_calendar_is_unknown(self):
+        """The file is there and the window is not, so the missing input is ours."""
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-30)),
+            declared=(self._days(-60), self._days(-30)),
+        )
+        newer = self._dataset(
+            "ds-newer",
+            declared=(self._days(-20), self._days(60)),
+            has_calendar_data=True,
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.UNKNOWN)
+        self.assertIn("no validated service window yet", result.reason)
+
+    def test_a_producer_omission_outweighs_our_own_lag(self):
+        """One dataset short of each: the producer's omission decides."""
+        older = self._dataset(
+            "ds-older",
+            declared=(self._days(-60), self._days(-30)),
+            has_calendar_data=False,
+        )
+        newer = self._dataset(
+            "ds-newer",
+            declared=(self._days(-20), self._days(60)),
+            has_calendar_data=True,
+        )
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("ds-older carries no", result.reason)
+
+    def test_with_no_declared_range_the_calendars_decide(self):
+        older = self._dataset("ds-older", service=(self._days(-60), self._days(-10)))
+        newer = self._dataset("ds-newer", service=(self._days(-20), self._days(60)))
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIn("do not both declare", result.reason)
+
+    def test_with_no_declared_range_a_calendar_gap_fails(self):
+        older = self._dataset("ds-older", service=(self._days(-60), self._days(-30)))
+        newer = self._dataset("ds-newer", service=(self._days(-20), self._days(60)))
+        self.assertIs(self._verdict(older, newer).observed_status, CriterionStatus.FAIL)
+
+    def test_a_declared_range_on_only_one_dataset_falls_back_to_the_calendars(self):
+        """Half a declared boundary is not a boundary; the two ends must be comparable."""
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-30)),
+            declared=(self._days(-60), self._days(-10)),
+        )
+        newer = self._dataset("ds-newer", service=(self._days(-20), self._days(60)))
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("do not both declare", result.reason)
+
+    def test_neither_window_nor_calendar_data_fails(self):
+        older = self._dataset("ds-older", has_calendar_data=False)
+        newer = self._dataset("ds-newer", has_calendar_data=False)
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.FAIL)
+        self.assertIn("ds-older, ds-newer", result.reason)
+
+    def test_an_inverted_window_is_no_window(self):
+        older = self._dataset(
+            "ds-older",
+            service=(self._days(-60), self._days(-10)),
+            declared=(self._days(-10), self._days(-60)),
+        )
+        _, newer = self._continuous_pair()
+        result = self._verdict(older, newer)
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+        self.assertIn("do not both declare", result.reason)
+
+    # policy
+
+    def test_a_seasonal_feed_is_still_evaluated(self):
+        """Unlike Fresh / future coverage, this criterion has no seasonal exemption."""
+        result = self._verdict(*self._continuous_pair(), seasonal=True)
+        self.assertIs(result.observed_status, CriterionStatus.PASS)
+
+    def test_has_no_grace_period_but_serves_probation(self):
+        self.assertIsNone(FreshContinuousEvaluator().grace_period)
+        self.assertEqual(FreshContinuousEvaluator().probation_period, PROBATION_PERIOD)
 
 
 if __name__ == "__main__":

--- a/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_updater_db.py
+++ b/functions-python/tasks_executor/tests/tasks/seal_of_reliability/test_seal_updater_db.py
@@ -141,16 +141,17 @@ EXCLUDED_FROM = NOW + timedelta(days=2)
 
 
 class _StopsApplyingEvaluator(CriterionEvaluator):
-    """A criterion that stops applying to the feed partway through, standing in for #1782.
+    """A criterion that stops applying to the feed partway through.
 
-    Fresh / continuous coverage does not apply to a seasonal feed, and a feed can be marked
-    seasonal at any time. Keyed on the clock rather than on `official` so a test can drive it
-    and Official in opposite directions at the same moment. No grace period, so its verdicts
-    land immediately and the tests are about what happens once it withdraws.
+    These tests are about what the roll-up does once a criterion withdraws, not about any real
+    criterion: the only one that ever answers NOT_APPLICABLE is Fresh / future coverage, on a
+    seasonal feed, and `TestFullRegistry` already covers that against real data. Keyed on the
+    clock rather than on `official` so a test can drive it and Official in opposite directions
+    at the same moment. No grace period, so its verdicts land immediately.
 
-    It borrows `fresh_continuous`, which has no evaluator of its own yet, rather than
-    `fresh_coverage`, whose real evaluator now covers the same seasonal case against real
-    data in `TestFullRegistry`.
+    It borrows the `fresh_continuous` name, whose real evaluator is patched out of the registry
+    here, rather than `fresh_coverage`, so the stand-in cannot be confused with the criterion
+    that genuinely withdraws.
     """
 
     name = SealCriterionName.FRESH_CONTINUOUS
@@ -238,6 +239,29 @@ def _seed_dataset(
         Gtfsfeed.__table__.update()
         .where(Gtfsfeed.__table__.c.id == feed_id)
         .values(latest_dataset_id=dataset_id)
+    )
+    db_session.commit()
+
+
+def _seed_previous_dataset(
+    db_session, feed_id: str, coverage_start=None, coverage_end=None
+):
+    """Give the feed an earlier dataset whose service window runs into the newer one's.
+
+    Downloaded a month before the dataset `_seed_dataset` creates and overlapping it, so
+    `fresh_continuous` has a boundary with no uncovered day across it. `latest_dataset_id` is
+    left alone: this is deliberately not the feed's newest dataset.
+    """
+    dataset_id = f"{feed_id}_dataset_previous"
+    db_session.add(
+        Gtfsdataset(
+            id=dataset_id,
+            feed_id=feed_id,
+            stable_id=dataset_id,
+            downloaded_at=NOW - timedelta(days=31),
+            service_date_range_start=coverage_start or NOW - timedelta(days=90),
+            service_date_range_end=coverage_end or NOW - timedelta(days=20),
+        )
     )
     db_session.commit()
 
@@ -405,6 +429,13 @@ class SealDbTestCase(unittest.TestCase):
         feed_id, coverage_end, downloaded_at=None, suffix="", db_session=None
     ):
         _seed_dataset(db_session, feed_id, coverage_end, downloaded_at, suffix)
+
+    @staticmethod
+    @with_db_session(db_url=default_db_url)
+    def seed_previous_dataset(
+        feed_id, coverage_start=None, coverage_end=None, db_session=None
+    ):
+        _seed_previous_dataset(db_session, feed_id, coverage_start, coverage_end)
 
     @staticmethod
     @with_db_session(db_url=default_db_url)
@@ -1268,11 +1299,11 @@ class TestCriterionSnapshot(SealDbTestCase):
 
 
 class TestFullRegistry(SealDbTestCase):
-    """Official, Stable and Fresh together, against real rows and the real registry.
+    """All six criteria together, against real rows and the real registry.
 
     The classes above patch the registry down to Official because they are about the
     report, the roll-up and the snapshot table rather than about any one criterion. These
-    tests are the other half: the three implemented criteria, driven by the columns they
+    tests are the other half: the implemented criteria, driven by the columns they
     actually read.
     """
 
@@ -1294,6 +1325,8 @@ class TestFullRegistry(SealDbTestCase):
     def satisfy_everything(self):
         """Seed the inputs every implemented criterion needs, all passing."""
         self.seed_dataset(TRACKED, self.FAR_FUTURE)
+        # A real boundary for Fresh / continuous coverage, rather than the single-dataset pass.
+        self.seed_previous_dataset(TRACKED)
         self.seed_availability_check(TRACKED, success=True)
         self.seed_validation_report(f"{TRACKED}_dataset", total_error=0)
 
@@ -1314,7 +1347,7 @@ class TestFullRegistry(SealDbTestCase):
     def test_criteria_with_no_data_leave_the_seal_unknown(self):
         """Available and Compliant have never had a verdict, so the seal cannot be decided.
 
-        They do not *deny* the seal - the feed may well qualify - but with two of five
+        They do not *deny* the seal - the feed may well qualify - but with two of six
         criteria unjudged, saying it does not qualify would be as wrong as saying it does.
         """
         self.seed_dataset(TRACKED, self.FAR_FUTURE)
@@ -1722,14 +1755,21 @@ class TestCriteriaSelection(SealDbTestCase):
                 stable_feed_ids=[OFFICIAL], criteria=["not_a_criterion"], now=NOW
             )
 
-    def test_criterion_without_an_evaluator_raises(self):
-        """`fresh_continuous` is a valid DB enum value but has no evaluator yet (#1782)."""
-        with self.assertRaises(ValueError):
-            update_seals(
-                stable_feed_ids=[OFFICIAL],
-                criteria=[SealCriterionName.FRESH_CONTINUOUS.value],
-                now=NOW,
-            )
+    def test_every_db_criterion_has_an_evaluator(self):
+        """Every `seal_criterion_name` value is now runnable, so none of them raises.
+
+        This is the assertion the "criterion without an evaluator" case turned into once
+        #1782 completed the registry: naming any single stored criterion is a valid run.
+        """
+        for criterion in SealCriterionName:
+            with self.subTest(criterion=criterion.value):
+                report = update_seals(
+                    dry_run=True,
+                    stable_feed_ids=[OFFICIAL],
+                    criteria=[criterion.value],
+                    now=NOW,
+                )
+                self.assertEqual(report["criteria"], [criterion.value])
 
     def test_naming_every_implemented_criterion_is_not_a_partial_run(self):
         report = update_seals(


### PR DESCRIPTION
**Summary:**
Closes #1782

Implements the sixth and last Seal of Reliability criterion, `fresh_continuous`: successive datasets cover service with no uncovered day between them. With this the evaluator registry covers `seal_criterion_name` exactly, so a partial run is now only ever one an operator asked for.

- **`evaluators/fresh_continuous.py`** (new) — the criterion, as three ordered steps (chart below).
- **`context.py`** — `ClosestDataset` becomes `DatasetCoverage`, now carrying both coverage windows plus `has_calendar_data`, and the context gains `previous_dataset`. `_load_closest_datasets` becomes `_load_recent_datasets`: one `ROW_NUMBER()` query per batch returning each feed's two most recent datasets, still bounded by the run's `now` so replays and backfills stay honest.
- **`shared/common/continuous_coverage.py`** — added `FEED_INFO_FILE` and `CALENDAR_FILES`; `COVERAGE_FILES` is now composed from them, so the tuple the continuous-coverage endpoint (#1816) serves is byte-for-byte unchanged. `MAX_COVERAGE_WINDOW`, `overlap_and_gap` and `within_max_coverage_window` are reused as-is, so the criterion and the read endpoint cannot disagree about what "successive datasets overlap" means.

No schema change: `seal_criterion_name` already declared `fresh_continuous`, and its grace period (none) and probation period (180 days) were already in the policy maps.

**Expected behavior:**

Three steps, in order. The first two are settled on the closest dataset alone, which is why a feed can fail on a single dataset.

```mermaid
flowchart TD
    A["closest dataset<br/>as of now"] -->|none| U1(["UNKNOWN<br/>no dataset"])
    A --> B{"window?<br/>feed_info range,<br/>else service window"}

    B -->|"none, has calendar file"| U2(["UNKNOWN<br/>not derived yet"])
    B -->|"none, no calendar file"| F1(["FAIL<br/>nothing published"])
    B -->|"longer than 730 days"| F2(["FAIL<br/>placeholder calendar"])
    B -->|ok| C{"previous<br/>dataset?"}

    C -->|none| P1(["PASS<br/>no boundary yet"])
    C --> D{"both datasets declare<br/>a feed_info range?"}

    D -->|"yes, no gap"| P2(["PASS"])
    D -->|"yes, gap"| E{"validated service<br/>windows"}
    D -->|no| E

    E -->|no gap| P3(["PASS<br/>calendar excuses it"])
    E -->|gap| F3(["FAIL"])
    E -->|"missing, no calendar file"| F4(["FAIL<br/>producer's omission"])
    E -->|"missing, has calendar file"| U3(["UNKNOWN<br/>ours to derive"])
```

Two things in there are decisions rather than mechanics:

**The declared range outranks the calendar, and a gap has to show in both to fail.** `feed_info.txt` is the service period the producer intends, so where both datasets declare one it decides; the validated service window is what excuses a declared gap, and is the whole answer when they don't both declare one.

**A missing window is the producer's answer, not a missing one** (per the Slack thread of 2026-08-27, since neither #1782 nor the "how it's calculated" page covers it). If a dataset shipped no `calendar.txt`/`calendar_dates.txt` at all, that is a FAIL — asking two consecutive datasets to carry calendar data is not a high bar. It stays UNKNOWN only when the file *is* there and we have not derived a window from it, which is our lag rather than theirs. That is the `has_calendar_data` flag, and it is why the context loads file presence alongside the windows rather than inferring one from the other.

Also worth flagging for review, since neither is in the issue:

- **Seasonal feeds get no exemption**, unlike `fresh_coverage`. A between-season gap is a real gap; the way to show it is intentional is to keep one of the two windows continuous across it.
- **The 730-day threshold applies to the closest dataset only**, not to the previous one, and it is not re-applied inside the calendar branch.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
