### PR TITLE
fix: mark feeds without service dates inactive

### DIFF
--- a/functions-python/helpers/feed_status.py
+++ b/functions-python/helpers/feed_status.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timezone
-from sqlalchemy import text
+from sqlalchemy import or_, text
 from shared.database_gen.sqlacodegen_models import Gtfsdataset, Feed, Gtfsfeed
 from typing import TYPE_CHECKING
 
@@ -20,16 +20,16 @@ def update_feed_statuses_query(session: "Session", stable_feed_ids: list[str]):
             Gtfsdataset.service_date_range_end,
         )
         .join(Gtfsfeed, Gtfsfeed.latest_dataset_id == Gtfsdataset.id)
-        .filter(
-            Gtfsdataset.service_date_range_start.isnot(None),
-            Gtfsdataset.service_date_range_end.isnot(None),
-        )
         .subquery()
     )
 
     status_conditions = [
         (
-            latest_dataset_subq.c.service_date_range_end < today_utc,
+            or_(
+                latest_dataset_subq.c.service_date_range_start.is_(None),
+                latest_dataset_subq.c.service_date_range_end.is_(None),
+                latest_dataset_subq.c.service_date_range_end < today_utc,
+            ),
             "inactive",
         ),
         (

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -105,17 +105,13 @@ def test_null_service_date_range_sets_feed_inactive(db_session: Session) -> None
         feed.latest_dataset_id = dataset.id
         db_session.flush()
 
-        with patch(
-            "shared.helpers.feed_status.create_refresh_materialized_view_task"
-        ):
+        with patch("shared.helpers.feed_status.create_refresh_materialized_view_task"):
             result = dict(update_feed_statuses_query(db_session, [stable_id]))
 
         db_session.expire_all()
 
         updated_feed = (
-            db_session.query(Gtfsfeed)
-            .filter(Gtfsfeed.stable_id == stable_id)
-            .one()
+            db_session.query(Gtfsfeed).filter(Gtfsfeed.stable_id == stable_id).one()
         )
 
         assert result == {

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -128,7 +128,6 @@ def test_null_service_date_range_sets_feed_inactive(db_session: Session) -> None
         db_session.rollback()
 
 
-
 @with_db_session(db_url=default_db_url)
 def test_update_feed_status_with_ids(db_session: Session) -> None:
     # clean_testing_db()

--- a/functions-python/update_feed_status/tests/test_update_feed_status_main.py
+++ b/functions-python/update_feed_status/tests/test_update_feed_status_main.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch, MagicMock
 
-from sqlalchemy import func
+from sqlalchemy import column, func
 
 from shared.database.database import with_db_session
 from test_shared.test_utils.database_utils import default_db_url
@@ -9,8 +9,9 @@ from main import (
     update_feed_statuses_query,
 )
 from shared.database_gen.sqlacodegen_models import Feed, Gtfsdataset, Gtfsfeed
-from datetime import date, timedelta
+from datetime import datetime, timezone
 from typing import Iterator, NamedTuple
+from uuid import uuid4
 
 import os
 
@@ -76,6 +77,59 @@ def test_update_feed_status(db_session: Session) -> None:
 
 
 @with_db_session(db_url=default_db_url)
+def test_null_service_date_range_sets_feed_inactive(db_session: Session) -> None:
+    feed_id = str(uuid4())
+    dataset_id = str(uuid4())
+    stable_id = f"issue-1209-{uuid4()}"
+
+    feed = Gtfsfeed(
+        id=feed_id,
+        stable_id=stable_id,
+        status="active",
+    )
+    try:
+        db_session.add(feed)
+        db_session.flush()
+
+        dataset = Gtfsdataset(
+            id=dataset_id,
+            stable_id=f"{stable_id}-dataset",
+            feed=feed,
+            downloaded_at=datetime.now(timezone.utc),
+            service_date_range_start=None,
+            service_date_range_end=None,
+        )
+        db_session.add(dataset)
+        db_session.flush()
+
+        feed.latest_dataset_id = dataset.id
+        db_session.flush()
+
+        with patch(
+            "shared.helpers.feed_status.create_refresh_materialized_view_task"
+        ):
+            result = dict(update_feed_statuses_query(db_session, [stable_id]))
+
+        db_session.expire_all()
+
+        updated_feed = (
+            db_session.query(Gtfsfeed)
+            .filter(Gtfsfeed.stable_id == stable_id)
+            .one()
+        )
+
+        assert result == {
+            "inactive": 1,
+            "active": 0,
+            "future": 0,
+        }
+        assert updated_feed.status == "inactive"
+    finally:
+        db_session.rollback()
+
+
+
+@with_db_session(db_url=default_db_url)
 def test_update_feed_status_with_ids(db_session: Session) -> None:
     # clean_testing_db()
     # populate_database()
@@ -101,23 +155,16 @@ def test_update_feed_status_with_ids(db_session: Session) -> None:
 def test_update_feed_status_failed_query():
     mock_session = MagicMock()
 
-    today = date(2025, 3, 1)
-
     class Columns:
-        feed_id = 1
-        service_date_range_start = today - timedelta(days=10)
-        service_date_range_end = today + timedelta(days=10)
+        feed_id = column("feed_id")
+        service_date_range_start = column("service_date_range_start")
+        service_date_range_end = column("service_date_range_end")
 
     mock_subquery = MagicMock()
     mock_subquery.c = Columns()
-    # mock_subquery.c.feed_id = 1
-    # mock_subquery.c.service_date_range_start = today - timedelta(days=10)
-    # mock_subquery.c.service_date_range_end = today + timedelta(days=10)
 
     mock_query = mock_session.query.return_value
-    mock_query.join.return_value.filter.return_value.subquery.return_value = (
-        mock_subquery
-    )
+    mock_query.join.return_value.subquery.return_value = mock_subquery
 
     mock_update_query = mock_session.query.return_value.filter.return_value
     mock_update_query.update.side_effect = Exception("Mocked exception")


### PR DESCRIPTION
## Summary

Fixes #1209.

Feeds whose latest GTFS dataset has no derived service-date range are now classified as `inactive`, matching the maintainer-confirmed behaviour in #1209.

The update removes the query filter that previously excluded datasets with null service-date bounds, then treats a null start or end date as `inactive` before evaluating the existing future/active/expired conditions.

## Tests

Added a database-backed regression covering a feed whose latest dataset has null service-date bounds.

Verification performed locally against the repository test database:

- new null-service-date regression: passed twice
- full `update_feed_status_main.py` test file: 6 passed, run twice
- existing failure-path mock updated to use SQLAlchemy column expressions after the query shape changed
- final diff limited to `functions-python/helpers/feed_status.py` and `functions-python/update_feed_status/tests/test_update_feed_status_main.py`

Commit: `5d26c41fd01e44f61775c77ad2b7919eeccc96f7`