### PR TITLE
feat: filter GTFS feeds by status

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -197,6 +197,7 @@ class FeedsApiImpl(BaseFeedsApi):
         self,
         limit: int,
         offset: int,
+        status: str,
         provider: str,
         producer_url: str,
         country_code: str,
@@ -213,6 +214,7 @@ class FeedsApiImpl(BaseFeedsApi):
             feed_query = get_gtfs_feeds_query(
                 limit=limit,
                 offset=offset,
+                status=status,
                 provider=provider,
                 producer_url=producer_url,
                 country_code=country_code,

--- a/api/src/shared/common/db_utils.py
+++ b/api/src/shared/common/db_utils.py
@@ -39,6 +39,7 @@ def get_gtfs_feeds_query(
     stable_id: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
+    status: str | None = None,
     provider: str | None = None,
     producer_url: str | None = None,
     country_code: str | None = None,
@@ -54,6 +55,7 @@ def get_gtfs_feeds_query(
     """Get the DB query to use to retrieve the GTFS feeds.."""
     gtfs_feed_filter = GtfsFeedFilter(
         stable_id=stable_id,
+        status=status,
         provider__ilike=provider,
         producer_url__ilike=producer_url,
         location=None,

--- a/api/src/shared/feed_filters/gtfs_feed_filter.py
+++ b/api/src/shared/feed_filters/gtfs_feed_filter.py
@@ -23,6 +23,7 @@ class LocationFilter(Filter):
 
 class GtfsFeedFilter(Filter):
     stable_id: Optional[str]
+    status: Optional[str]
     provider__ilike: Optional[str]  # case insensitive
     producer_url__ilike: Optional[str]  # case insensitive
     location: Optional[LocationFilter]

--- a/api/tests/integration/test_database.py
+++ b/api/tests/integration/test_database.py
@@ -100,7 +100,19 @@ def test_merge_gtfs_feed(test_database):
         results = {
             feed.id: feed
             for feed in FeedsApiImpl().get_gtfs_feeds(
-                None, None, None, None, None, None, None, None, None, None, None, db_session=session
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                db_session=session,
             )
             if feed.id in TEST_GTFS_FEED_STABLE_IDS
         }

--- a/api/tests/integration/test_feeds_api.py
+++ b/api/tests/integration/test_feeds_api.py
@@ -92,6 +92,20 @@ def test_feeds_gtfs_get(client: TestClient):
     assert response.status_code == 200
 
 
+def test_feeds_gtfs_get_with_status_filter(client: TestClient):
+    """GTFS feeds can be filtered by feed status."""
+    response = client.request(
+        "GET",
+        "/v1/gtfs_feeds",
+        headers=authHeaders,
+        params=[("status", "active")],
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+    assert all(feed["status"] == "active" for feed in response.json())
+
+
 def test_feeds_gtfs_id_get(client: TestClient):
     """Test case for feeds_gtfs_id_get"""
     response = client.request(

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -96,6 +96,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/limit_query_param_gtfs_feeds_endpoint"
         - $ref: "#/components/parameters/offset"
+        - $ref: "#/components/parameters/status"
         - $ref: "#/components/parameters/provider"
         - $ref: "#/components/parameters/producer_url"
         - $ref: "#/components/parameters/country_code"


### PR DESCRIPTION
## Summary

Adds support for filtering `/v1/gtfs_feeds` by the existing `status` query parameter.

This reuses the shared status contract already used by `/v1/feeds`, including:

- `active`
- `deprecated`
- `inactive`
- `development`
- `future`

The `future` status was already present in the API schema/documentation, so no new status value was required.

## Implementation

- expose the existing `status` parameter on `/v1/gtfs_feeds`;
- pass the value through `FeedsApiImpl.get_gtfs_feeds`;
- add `status` filtering to `GtfsFeedFilter`;
- pass the filter through `get_gtfs_feeds_query`;
- add integration coverage for filtering GTFS feeds by active status.

## Verification

Local verification on Python 3.11, matching CI:

- focused status-filter regression: 1 passed;
- baseline + regression: 2 passed;
- `api/tests/integration/test_feeds_api.py`: 96 passed;
- flake8: passed;
- Black check: passed.

Closes #1675