### PR TITLE
fix: require stops.txt before GTFS batch publish

### DIFF
--- a/functions-python/batch_datasets/src/main.py
+++ b/functions-python/batch_datasets/src/main.py
@@ -27,7 +27,7 @@ from google.cloud.pubsub_v1 import PublisherClient
 from google.cloud.pubsub_v1.futures import Future
 from sqlalchemy.orm import Session
 
-from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsdataset
+from shared.database_gen.sqlacodegen_models import Gtfsfeed, Gtfsdataset, Gtfsfile
 from shared.dataset_service.dataset_service_commons import BatchExecution
 from shared.dataset_service.main import BatchExecutionService
 from shared.database.database import with_db_session
@@ -88,6 +88,10 @@ def get_non_deprecated_feeds(
         .select_from(Gtfsfeed)
         .outerjoin(Gtfsdataset, (Gtfsfeed.latest_dataset_id == Gtfsdataset.id))
         .filter(Gtfsfeed.status != "deprecated")
+        .filter(
+            (Gtfsfeed.latest_dataset_id.is_(None))
+            | Gtfsdataset.gtfsfiles.any(Gtfsfile.file_name == "stops.txt")
+        )
     )
     if feed_stable_ids:
         # If feed_stable_ids are provided, filter the query by stable IDs

--- a/functions-python/batch_datasets/tests/conftest.py
+++ b/functions-python/batch_datasets/tests/conftest.py
@@ -25,6 +25,7 @@ from shared.database_gen.sqlacodegen_models import (
     Gtfsfeed,
     Gtfsrealtimefeed,
     Gtfsdataset,
+    Gtfsfile,
 )
 from test_shared.test_utils.database_utils import clean_testing_db, default_db_url
 
@@ -97,6 +98,14 @@ def populate_database(db_session: Session | None = None):
         )
         db_session.add(gtfs_dataset)
         db_session.flush()
+        gtfs_dataset.gtfsfiles = [
+            Gtfsfile(
+                id=fake.uuid4(),
+                gtfs_dataset_id=id,
+                file_name="stops.txt",
+                file_size_bytes=1,
+            )
+        ]
         active_gtfs_feeds[i].latest_dataset_id = id
 
     db_session.flush()

--- a/functions-python/batch_datasets/tests/test_batch_datasets_main.py
+++ b/functions-python/batch_datasets/tests/test_batch_datasets_main.py
@@ -105,6 +105,45 @@ def test_batch_datasets_w_feed_ids(mock_client, mock_publish, db_session):
                 assert message["feed_stable_id"] in [feed.stable_id for feed in feeds]
 
 
+@with_db_session(db_url=default_db_url)
+def test_get_non_deprecated_feeds_requires_stops_for_existing_dataset(db_session):
+    from shared.database_gen.sqlacodegen_models import Gtfsdataset, Gtfsfile
+
+    feeds_before = get_non_deprecated_feeds(db_session)
+
+    feed_without_dataset = next(
+        feed for feed in feeds_before if feed.dataset_stable_id is None
+    )
+
+    feed_with_dataset = next(
+        feed for feed in feeds_before if feed.dataset_stable_id is not None
+    )
+
+    dataset = (
+        db_session.query(Gtfsdataset)
+        .filter(Gtfsdataset.stable_id == feed_with_dataset.dataset_stable_id)
+        .one()
+    )
+
+    assert any(file.file_name == "stops.txt" for file in dataset.gtfsfiles)
+
+    dataset.gtfsfiles = [
+        Gtfsfile(
+            id="missing-stops-routes",
+            gtfs_dataset_id=dataset.id,
+            file_name="routes.txt",
+            file_size_bytes=1,
+        )
+    ]
+    db_session.commit()
+
+    feeds_after = get_non_deprecated_feeds(db_session)
+    returned_ids = {feed.stable_id for feed in feeds_after}
+
+    assert feed_without_dataset.stable_id in returned_ids
+    assert feed_with_dataset.stable_id not in returned_ids
+
+
 def test_batch_datasets_exception():
     exception_message = "Failure occurred"
     mock_session = MagicMock()


### PR DESCRIPTION
## Summary

Ensure the GTFS batch scheduler only publishes feeds whose latest dataset contains `stops.txt`, while preserving first-time ingestion for feeds that do not yet have a latest dataset.

The resulting behavior is:
- feeds with no latest dataset remain eligible for publication;
- feeds whose latest dataset contains `stops.txt` remain eligible;
- feeds whose latest dataset exists but does not contain `stops.txt` are skipped.

This uses the persisted GTFS file inventory introduced by #1259 and keeps the check at the scheduler boundary before publishing the Pub/Sub message.

## Tests

- focused regression covering the three cases above;
- full `functions-python/batch_datasets/tests` suite: 5 passed;
- Black: pass;
- Flake8 with `functions-python/.flake8`: pass.

Fixes #1271