### PR TITLE
feat: added latest failure and reformated latest state

### DIFF
--- a/api/src/feeds/impl/feeds_api_impl.py
+++ b/api/src/feeds/impl/feeds_api_impl.py
@@ -21,11 +21,9 @@ from feeds_gen.models.gtfs_dataset import GtfsDataset
 from feeds_gen.models.gtfs_feed import GtfsFeed
 from feeds_gen.models.gtfs_feed_availability_response import GtfsFeedAvailabilityResponse
 from feeds_gen.models.gtfs_feed_continuous_coverage import GtfsFeedContinuousCoverage
-from feeds_gen.models.gtfs_feed_continuous_coverage_file import GtfsFeedContinuousCoverageFile
 from feeds_gen.models.gtfs_feed_continuous_coverage_response import GtfsFeedContinuousCoverageResponse
 from feeds_gen.models.gtfs_rt_feed import GtfsRTFeed
 from middleware.request_context import is_user_email_restricted
-from shared.common.continuous_coverage import COVERAGE_FILES
 from shared.common.db_utils import (
     get_gtfs_feeds_query,
     get_gtfs_rt_feeds_query,
@@ -33,6 +31,7 @@ from shared.common.db_utils import (
     add_official_filter,
     get_gbfs_feeds_query,
 )
+from shared.common.seal_criteria import SealCriterionName
 from shared.common.error_handling import (
     availability_from_after_to,
     continuous_coverage_downloaded_after_before,
@@ -50,6 +49,7 @@ from shared.database_gen.sqlacodegen_models import (
     Gtfsfeed,
     GtfsFeedAvailabilityCheck,
     Gtfsrealtimefeed,
+    SealCriterion,
 )
 from shared.feed_filters.feed_filter import FeedFilter
 from shared.feed_filters.gtfs_dataset_filter import GtfsDatasetFilter
@@ -431,26 +431,13 @@ class FeedsApiImpl(BaseFeedsApi):
             for dataset, next_dataset in zip(page, page[1:] + [None])
         ]
 
-        latest_coverage = self._latest_continuous_coverage(feed, feed_datasets)
-
         return GtfsFeedContinuousCoverageResponse(
             feed_id=id,
             total=total,
             offset=offset,
             limit=limit,
-            latest_files=(
-                latest_coverage.files
-                if latest_coverage
-                else [GtfsFeedContinuousCoverageFile(name=name, present=False) for name in COVERAGE_FILES]
-            ),
-            latest_coverage_window=latest_coverage.coverage_window if latest_coverage else None,
-            latest_coverage_window_source=latest_coverage.coverage_window_source if latest_coverage else None,
-            latest_within_max_coverage_window=(latest_coverage.within_max_coverage_window if latest_coverage else None),
-            latest_service_window=latest_coverage.service_window if latest_coverage else None,
-            latest_feed_info_window=latest_coverage.feed_info_window if latest_coverage else None,
-            latest_feed_info_matches=latest_coverage.feed_info_matches if latest_coverage else None,
-            latest_overlap_days=latest_coverage.overlap_days if latest_coverage else None,
-            latest_gap_days=latest_coverage.gap_days if latest_coverage else None,
+            latest_state=self._latest_continuous_coverage(feed, feed_datasets),
+            latest_failure=self._latest_failure_continuous_coverage(feed, feed_datasets),
             items=[
                 GtfsFeedContinuousCoverageImpl.from_orm(
                     dataset,
@@ -463,10 +450,7 @@ class FeedsApiImpl(BaseFeedsApi):
 
     @staticmethod
     def _latest_continuous_coverage(feed: Gtfsfeed, feed_datasets: Query) -> Optional[GtfsFeedContinuousCoverage]:
-        """The coverage snapshot for the feed's latest dataset, independent of the requested page or
-        date filters - the root `latest_*` response fields always describe this dataset, even when it
-        falls outside the current page or date range.
-        """
+        """`latest_state`: the feed's latest dataset, whatever page or date range was requested."""
         if feed.latest_dataset_id is None:
             return None
         latest_dataset = (
@@ -474,10 +458,45 @@ class FeedsApiImpl(BaseFeedsApi):
             .options(selectinload(Gtfsdataset.feed_info), selectinload(Gtfsdataset.gtfsfiles))
             .first()
         )
-        if latest_dataset is None:
+        return FeedsApiImpl._continuous_coverage_for(feed, feed_datasets, latest_dataset)
+
+    @staticmethod
+    @with_db_session()
+    def _latest_failure_continuous_coverage(
+        feed: Gtfsfeed, feed_datasets: Query, db_session: Session
+    ) -> Optional[GtfsFeedContinuousCoverage]:
+        """`latest_failure`: the state as of the criterion's `last_observed_failure_at`."""
+        failed_at = (
+            db_session.query(SealCriterion.last_observed_failure_at)
+            .filter(
+                SealCriterion.feed_id == feed.id,
+                SealCriterion.criterion == SealCriterionName.FRESH_CONTINUOUS.value,
+            )
+            .scalar()
+        )
+        if failed_at is None:
             return None
-        previous = FeedsApiImpl._previous_dataset(feed_datasets, latest_dataset)
-        return GtfsFeedContinuousCoverageImpl.from_orm(latest_dataset, previous_dataset=previous, is_latest=True)
+        failing_dataset = (
+            feed_datasets.filter(Gtfsdataset.downloaded_at <= failed_at)
+            .order_by(*FeedsApiImpl._continuous_coverage_order())
+            .options(selectinload(Gtfsdataset.feed_info), selectinload(Gtfsdataset.gtfsfiles))
+            .first()
+        )
+        return FeedsApiImpl._continuous_coverage_for(feed, feed_datasets, failing_dataset)
+
+    @staticmethod
+    def _continuous_coverage_for(
+        feed: Gtfsfeed, feed_datasets: Query, dataset: Optional[Gtfsdataset]
+    ) -> Optional[GtfsFeedContinuousCoverage]:
+        """One state object: `dataset` measured against the dataset downloaded before it."""
+        if dataset is None:
+            return None
+        previous = FeedsApiImpl._previous_dataset(feed_datasets, dataset)
+        return GtfsFeedContinuousCoverageImpl.from_orm(
+            dataset,
+            previous_dataset=previous,
+            is_latest=dataset.id == feed.latest_dataset_id,
+        )
 
     @staticmethod
     def _continuous_coverage_order() -> tuple:

--- a/api/tests/unittest/test_feeds.py
+++ b/api/tests/unittest/test_feeds.py
@@ -785,7 +785,7 @@ def test_latest_failure_continuous_coverage_never_failed():
     db_session = MagicMock()
     db_session.query.return_value.filter.return_value.scalar.return_value = None
 
-    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, MagicMock(), db_session) is None
+    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, MagicMock(), db_session=db_session) is None
 
 
 def test_latest_failure_continuous_coverage_resolves_the_dataset_of_the_moment(mocker):
@@ -802,7 +802,7 @@ def test_latest_failure_continuous_coverage_resolves_the_dataset_of_the_moment(m
     mocker.patch.object(FeedsApiImpl, "_previous_dataset", return_value=previous_dataset)
     from_orm = mocker.patch.object(GtfsFeedContinuousCoverageImpl, "from_orm")
 
-    result = FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session)
+    result = FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session=db_session)
 
     from_orm.assert_called_once_with(failing_dataset, previous_dataset=previous_dataset, is_latest=False)
     assert result is from_orm.return_value
@@ -820,7 +820,7 @@ def test_latest_failure_continuous_coverage_marks_a_current_failure_as_latest(mo
     mocker.patch.object(FeedsApiImpl, "_previous_dataset", return_value=None)
     from_orm = mocker.patch.object(GtfsFeedContinuousCoverageImpl, "from_orm")
 
-    FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session)
+    FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session=db_session)
 
     from_orm.assert_called_once_with(failing_dataset, previous_dataset=None, is_latest=True)
 
@@ -833,7 +833,7 @@ def test_latest_failure_continuous_coverage_no_dataset_at_the_moment(mocker):
     feed_datasets = MagicMock()
     feed_datasets.filter.return_value.order_by.return_value.options.return_value.first.return_value = None
 
-    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session) is None
+    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session=db_session) is None
 
 
 # ---- Regression tests: `datetime.fromisoformat` parses `Z`-suffixed dates directly on Python

--- a/api/tests/unittest/test_feeds.py
+++ b/api/tests/unittest/test_feeds.py
@@ -624,7 +624,7 @@ def test_gtfs_feed_get_without_seal_reports_null(client: TestClient):
     assert response.json()["reliability_seal"] is None
 
 
-# ---- Unit tests for the continuous coverage endpoint's `latest_*` root fields ----
+# ---- Unit tests for the continuous coverage endpoint's two states ----
 
 
 def test_latest_continuous_coverage_no_latest_dataset():
@@ -661,31 +661,47 @@ def test_latest_continuous_coverage_delegates_to_the_model_impl(mocker):
     assert result is from_orm.return_value
 
 
-def test_get_gtfs_feed_continuous_coverage_maps_latest_fields(mocker):
-    """The response's root `latest_*` fields are the `_latest_continuous_coverage` snapshot, not the
-    first item of whatever page was requested."""
-    feed = Gtfsfeed(latest_dataset_id="dataset-latest")
-    mocker.patch.object(FeedsApiImpl, "_get_gtfs_feed", return_value=feed)
-
-    latest_coverage = GtfsFeedContinuousCoverage(
-        dataset_id="dataset-latest",
-        is_latest=True,
+def _coverage(dataset_id: str, previous_dataset_id: str, is_latest: bool, gap_days=None):
+    """A coverage state object."""
+    return GtfsFeedContinuousCoverage(
+        dataset_id=dataset_id,
+        is_latest=is_latest,
         coverage_window=ServiceDateWindow(start=date(2026, 9, 16), end=date(2027, 7, 28), days=316),
         coverage_window_source="service_dates",
         within_max_coverage_window=True,
         service_window=ServiceDateWindow(start=date(2026, 9, 16), end=date(2027, 7, 28), days=316),
         feed_info_window=None,
         feed_info_matches=None,
-        overlap_days=15,
-        gap_days=None,
+        previous_dataset_id=previous_dataset_id,
+        overlap_days=None if gap_days else 15,
+        gap_days=gap_days,
         files=[GtfsFeedContinuousCoverageFile(name=name, present=True) for name in COVERAGE_FILES],
     )
-    mocker.patch.object(FeedsApiImpl, "_latest_continuous_coverage", return_value=latest_coverage)
 
+
+def _empty_page_session():
+    """A session whose dataset query returns no rows, leaving only the two states under test."""
     db_session = MagicMock()
     db_session.query.return_value.filter.return_value.count.return_value = 0
     empty_page = db_session.query.return_value.filter.return_value.order_by.return_value
     empty_page.offset.return_value.limit.return_value.options.return_value.all.return_value = []
+    return db_session
+
+
+def test_get_gtfs_feed_continuous_coverage_maps_both_states(mocker):
+    """Both states come from their own lookup, not from the first item of the requested page."""
+    feed = Gtfsfeed(latest_dataset_id="dataset-latest")
+    mocker.patch.object(FeedsApiImpl, "_get_gtfs_feed", return_value=feed)
+    mocker.patch.object(
+        FeedsApiImpl,
+        "_latest_continuous_coverage",
+        return_value=_coverage("dataset-latest", "dataset-previous", is_latest=True),
+    )
+    mocker.patch.object(
+        FeedsApiImpl,
+        "_latest_failure_continuous_coverage",
+        return_value=_coverage("dataset-broke", "dataset-before-broke", is_latest=False, gap_days=3),
+    )
 
     response = FeedsApiImpl().get_gtfs_feed_continuous_coverage(
         id="mdb-1",
@@ -693,30 +709,59 @@ def test_get_gtfs_feed_continuous_coverage_maps_latest_fields(mocker):
         downloaded_before=None,
         limit=20,
         offset=0,
-        db_session=db_session,
+        db_session=_empty_page_session(),
     )
 
-    assert response.latest_coverage_window.start == date(2026, 9, 16)
-    assert response.latest_coverage_window_source == "service_dates"
-    assert response.latest_within_max_coverage_window is True
-    assert response.latest_service_window.end == date(2027, 7, 28)
-    assert response.latest_feed_info_window is None
-    assert response.latest_feed_info_matches is None
-    assert response.latest_overlap_days == 15
-    assert response.latest_gap_days is None
-    assert [f.present for f in response.latest_files] == [True] * len(COVERAGE_FILES)
+    assert response.latest_state.dataset_id == "dataset-latest"
+    assert response.latest_state.is_latest is True
+    assert response.latest_state.coverage_window.start == date(2026, 9, 16)
+    assert response.latest_state.coverage_window_source == "service_dates"
+    assert response.latest_state.within_max_coverage_window is True
+    assert response.latest_state.service_window.end == date(2027, 7, 28)
+    assert response.latest_state.feed_info_window is None
+    assert response.latest_state.feed_info_matches is None
+    assert response.latest_state.overlap_days == 15
+    assert response.latest_state.gap_days is None
+    assert [f.present for f in response.latest_state.files] == [True] * len(COVERAGE_FILES)
+
+    assert response.latest_failure.dataset_id == "dataset-broke"
+    assert response.latest_failure.is_latest is False
+    assert response.latest_failure.gap_days == 3
+    # At most four datasets across both states.
+    assert {
+        response.latest_state.dataset_id,
+        response.latest_state.previous_dataset_id,
+        response.latest_failure.dataset_id,
+        response.latest_failure.previous_dataset_id,
+    } == {"dataset-latest", "dataset-previous", "dataset-broke", "dataset-before-broke"}
+
+
+def test_get_gtfs_feed_continuous_coverage_states_can_share_datasets(mocker):
+    """A feed failing right now reports the same dataset in both states."""
+    feed = Gtfsfeed(latest_dataset_id="dataset-latest")
+    mocker.patch.object(FeedsApiImpl, "_get_gtfs_feed", return_value=feed)
+    current = _coverage("dataset-latest", "dataset-previous", is_latest=True, gap_days=3)
+    mocker.patch.object(FeedsApiImpl, "_latest_continuous_coverage", return_value=current)
+    mocker.patch.object(FeedsApiImpl, "_latest_failure_continuous_coverage", return_value=current)
+
+    response = FeedsApiImpl().get_gtfs_feed_continuous_coverage(
+        id="mdb-1",
+        downloaded_after=None,
+        downloaded_before=None,
+        limit=20,
+        offset=0,
+        db_session=_empty_page_session(),
+    )
+
+    assert response.latest_state.dataset_id == response.latest_failure.dataset_id == "dataset-latest"
+    assert response.latest_failure.is_latest is True, "the failure is the feed's current dataset"
 
 
 def test_get_gtfs_feed_continuous_coverage_no_latest_dataset(mocker):
-    """A feed with no datasets still returns the required `latest_files` list, with every file
-    reported absent rather than the field being omitted."""
+    """A feed with no datasets reports both states as null, not as empty objects."""
     feed = Gtfsfeed(latest_dataset_id=None)
     mocker.patch.object(FeedsApiImpl, "_get_gtfs_feed", return_value=feed)
-
-    db_session = MagicMock()
-    db_session.query.return_value.filter.return_value.count.return_value = 0
-    empty_page = db_session.query.return_value.filter.return_value.order_by.return_value
-    empty_page.offset.return_value.limit.return_value.options.return_value.all.return_value = []
+    mocker.patch.object(FeedsApiImpl, "_latest_failure_continuous_coverage", return_value=None)
 
     response = FeedsApiImpl().get_gtfs_feed_continuous_coverage(
         id="mdb-1",
@@ -724,12 +769,71 @@ def test_get_gtfs_feed_continuous_coverage_no_latest_dataset(mocker):
         downloaded_before=None,
         limit=20,
         offset=0,
-        db_session=db_session,
+        db_session=_empty_page_session(),
     )
 
-    assert response.latest_coverage_window is None
-    assert [f.name for f in response.latest_files] == list(COVERAGE_FILES)
-    assert [f.present for f in response.latest_files] == [False] * len(COVERAGE_FILES)
+    assert response.latest_state is None
+    assert response.latest_failure is None
+
+
+# ---- Unit tests for `latest_failure` ----
+
+
+def test_latest_failure_continuous_coverage_never_failed():
+    """No recorded failure means no failure state."""
+    feed = Gtfsfeed(id="feed-1", latest_dataset_id="dataset-latest")
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.scalar.return_value = None
+
+    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, MagicMock(), db_session) is None
+
+
+def test_latest_failure_continuous_coverage_resolves_the_dataset_of_the_moment(mocker):
+    """The failing dataset is the last one downloaded at or before the recorded failure."""
+    failed_at = datetime(2026, 6, 28, tzinfo=timezone.utc)
+    feed = Gtfsfeed(id="feed-1", latest_dataset_id="dataset-latest")
+    failing_dataset = Gtfsdataset(id="dataset-broke", stable_id="dataset-broke")
+    previous_dataset = Gtfsdataset(id="dataset-before-broke", stable_id="dataset-before-broke")
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.scalar.return_value = failed_at
+    feed_datasets = MagicMock()
+    feed_datasets.filter.return_value.order_by.return_value.options.return_value.first.return_value = failing_dataset
+    mocker.patch.object(FeedsApiImpl, "_previous_dataset", return_value=previous_dataset)
+    from_orm = mocker.patch.object(GtfsFeedContinuousCoverageImpl, "from_orm")
+
+    result = FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session)
+
+    from_orm.assert_called_once_with(failing_dataset, previous_dataset=previous_dataset, is_latest=False)
+    assert result is from_orm.return_value
+
+
+def test_latest_failure_continuous_coverage_marks_a_current_failure_as_latest(mocker):
+    """A failure resolving to the feed's current dataset is flagged `is_latest`."""
+    feed = Gtfsfeed(id="feed-1", latest_dataset_id="dataset-latest")
+    failing_dataset = Gtfsdataset(id="dataset-latest", stable_id="dataset-latest")
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.scalar.return_value = datetime(2026, 6, 28, tzinfo=timezone.utc)
+    feed_datasets = MagicMock()
+    feed_datasets.filter.return_value.order_by.return_value.options.return_value.first.return_value = failing_dataset
+    mocker.patch.object(FeedsApiImpl, "_previous_dataset", return_value=None)
+    from_orm = mocker.patch.object(GtfsFeedContinuousCoverageImpl, "from_orm")
+
+    FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session)
+
+    from_orm.assert_called_once_with(failing_dataset, previous_dataset=None, is_latest=True)
+
+
+def test_latest_failure_continuous_coverage_no_dataset_at_the_moment(mocker):
+    """A failure older than every dataset the feed still has leaves nothing to report."""
+    feed = Gtfsfeed(id="feed-1", latest_dataset_id="dataset-latest")
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.scalar.return_value = datetime(2026, 6, 28, tzinfo=timezone.utc)
+    feed_datasets = MagicMock()
+    feed_datasets.filter.return_value.order_by.return_value.options.return_value.first.return_value = None
+
+    assert FeedsApiImpl._latest_failure_continuous_coverage(feed, feed_datasets, db_session) is None
 
 
 # ---- Regression tests: `datetime.fromisoformat` parses `Z`-suffixed dates directly on Python
@@ -745,6 +849,7 @@ def test_get_gtfs_feed_continuous_coverage_accepts_z_suffixed_dates(mocker):
 
     feed_datasets = MagicMock()
     feed_datasets.filter.return_value = feed_datasets  # chained `.filter()` calls stay on one mock
+    feed_datasets.scalar.return_value = None  # no recorded failure, so `latest_failure` is skipped
     feed_datasets.count.return_value = 0
     feed_datasets.order_by.return_value.offset.return_value.limit.return_value.options.return_value.all.return_value = (
         []
@@ -830,6 +935,7 @@ def test_get_gtfs_feed_continuous_coverage_mixed_naive_and_aware_dates(mocker):
 
     feed_datasets = MagicMock()
     feed_datasets.filter.return_value = feed_datasets
+    feed_datasets.scalar.return_value = None  # no recorded failure, so `latest_failure` is skipped
     feed_datasets.count.return_value = 0
     feed_datasets.order_by.return_value.offset.return_value.limit.return_value.options.return_value.all.return_value = (
         []

--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -332,10 +332,11 @@ paths:
       - $ref: "#/components/parameters/feed_id_path_param"
     get:
       description: >
-        Returns the continuous coverage history for a GTFS feed: one entry per dataset, ordered by
-        `downloaded_at` from newest to oldest. Each entry carries the service window the dataset
-        covers, the window declared in its `feed_info.txt`, whether the two agree, and how much that
-        dataset overlaps the previous (older) one.
+        Returns the continuous coverage of a GTFS feed: `latest_state` and `latest_failure`,
+        plus the history, one entry per dataset ordered by `downloaded_at` from newest to oldest.
+        Each entry carries the service window the dataset covers, the window declared in its
+        `feed_info.txt`, whether the two agree, and how much that dataset overlaps the previous
+        (older) one.
       tags:
         - "feeds"
       operationId: getGtfsFeedContinuousCoverage
@@ -1391,10 +1392,14 @@ components:
 
     GtfsFeedContinuousCoverageResponse:
       type: object
+      description: >
+        `latest_state` is the feed's latest dataset measured against the one before it;
+        `latest_failure` is the same measurement at the criterion's last observed failure. Both
+        have the structure of an `items[]` entry, and either can be null. Together they name at
+        most four datasets, shared when the latest state is itself the failure.
       required:
         - feed_id
         - items
-        - latest_files
         - total
         - offset
         - limit
@@ -1403,67 +1408,10 @@ components:
           type: string
           description: Unique identifier of the GTFS feed.
           example: mdb-123
-        latest_files:
-          type: array
-          description: >
-            The files the calculation reads for the feed's latest dataset (the `items[]` entry
-            with `is_latest: true`), and whether each was present. Always returned in the same
-            order with one entry per file, so a client can render a fixed row.
-          items:
-            $ref: "#/components/schemas/GtfsFeedContinuousCoverageFile"
-        latest_coverage_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_coverage_window_source:
-          type: string
-          nullable: true
-          description: >
-            Which input the latest dataset's `latest_coverage_window` was taken from.
-
-            * `service_dates` - the service dates derived by the validator from `calendar.txt` and
-              `calendar_dates.txt`.
-            * `feed_info` - the dates declared in `feed_info.txt`, used only when the service dates
-              are missing.
-          enum:
-            - service_dates
-            - feed_info
-          example: service_dates
-        latest_within_max_coverage_window:
-          type: boolean
-          nullable: true
-          description: >
-            Whether the latest dataset's `latest_coverage_window` stays inside the maximum
-            coverage window the seal allows (two years). Null when there is no coverage window to
-            measure.
-          example: true
-        latest_service_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_feed_info_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_feed_info_matches:
-          type: boolean
-          nullable: true
-          description: >
-            Whether the latest dataset's `latest_feed_info_window` agrees with
-            `latest_service_window` on both bounds. Null when either window is missing, which is
-            not the same as a mismatch.
-          example: true
-        latest_overlap_days:
-          type: integer
-          nullable: true
-          description: >
-            Days of overlap between the latest dataset's coverage window and that of the dataset
-            immediately older than it. Zero means the windows meet exactly; a gap is reported as
-            `latest_gap_days` instead. Null when either window is missing or there is no older
-            dataset.
-          example: 15
-        latest_gap_days:
-          type: integer
-          nullable: true
-          description: >
-            Days of uncovered service between the end of the older dataset's window and the start
-            of the latest dataset's window. Null when the windows overlap or meet, which is the
-            passing case.
-          example: 3
+        latest_state:
+          $ref: "#/components/schemas/GtfsFeedContinuousCoverage"
+        latest_failure:
+          $ref: "#/components/schemas/GtfsFeedContinuousCoverage"
         total:
           type: integer
           description: Total number of matching datasets regardless of limit and offset.

--- a/docs/OperationsAPI.yaml
+++ b/docs/OperationsAPI.yaml
@@ -1431,10 +1431,12 @@ components:
           example: timeout
     GtfsFeedContinuousCoverageResponse:
       type: object
+      description: >
+        `latest_state` is the feed's latest dataset measured against the one before it; `latest_failure` is the same measurement at the criterion's last observed failure. Both have the structure of an `items[]` entry, and either can be null. Together they name at most four datasets, shared when the latest state is itself the failure.
+
       required:
         - feed_id
         - items
-        - latest_files
         - total
         - offset
         - limit
@@ -1443,63 +1445,10 @@ components:
           type: string
           description: Unique identifier of the GTFS feed.
           example: mdb-123
-        latest_files:
-          type: array
-          description: >
-            The files the calculation reads for the feed's latest dataset (the `items[]` entry with `is_latest: true`), and whether each was present. Always returned in the same order with one entry per file, so a client can render a fixed row.
-
-          items:
-            $ref: "#/components/schemas/GtfsFeedContinuousCoverageFile"
-        latest_coverage_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_coverage_window_source:
-          type: string
-          nullable: true
-          description: >
-            Which input the latest dataset's `latest_coverage_window` was taken from.
-
-            * `service_dates` - the service dates derived by the validator from `calendar.txt` and
-
-              `calendar_dates.txt`.
-            * `feed_info` - the dates declared in `feed_info.txt`, used only when the service dates
-
-              are missing.
-          enum:
-            - service_dates
-            - feed_info
-          example: service_dates
-        latest_within_max_coverage_window:
-          type: boolean
-          nullable: true
-          description: >
-            Whether the latest dataset's `latest_coverage_window` stays inside the maximum coverage window the seal allows (two years). Null when there is no coverage window to measure.
-
-          example: true
-        latest_service_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_feed_info_window:
-          $ref: "#/components/schemas/ServiceDateWindow"
-        latest_feed_info_matches:
-          type: boolean
-          nullable: true
-          description: >
-            Whether the latest dataset's `latest_feed_info_window` agrees with `latest_service_window` on both bounds. Null when either window is missing, which is not the same as a mismatch.
-
-          example: true
-        latest_overlap_days:
-          type: integer
-          nullable: true
-          description: >
-            Days of overlap between the latest dataset's coverage window and that of the dataset immediately older than it. Zero means the windows meet exactly; a gap is reported as `latest_gap_days` instead. Null when either window is missing or there is no older dataset.
-
-          example: 15
-        latest_gap_days:
-          type: integer
-          nullable: true
-          description: >
-            Days of uncovered service between the end of the older dataset's window and the start of the latest dataset's window. Null when the windows overlap or meet, which is the passing case.
-
-          example: 3
+        latest_state:
+          $ref: "#/components/schemas/GtfsFeedContinuousCoverage"
+        latest_failure:
+          $ref: "#/components/schemas/GtfsFeedContinuousCoverage"
         total:
           type: integer
           description: Total number of matching datasets regardless of limit and offset.


### PR DESCRIPTION
**Summary:**
Closes https://github.com/MobilityData/product-tasks/issues/219

`GET /v1/gtfs_feeds/{id}/continuous_coverage` reported the current state as nine flattened `latest_*` fields. Those are replaced by two objects, `latest_state` and `latest_failure`, both `$ref`-ing the existing `GtfsFeedContinuousCoverage` schema so each has the structure of an `items[]` entry.

- `latest_state` — the feed's latest dataset measured against the one before it.
- `latest_failure` — the same measurement at the `fresh_continuous` criterion's `last_observed_failure_at`, so the endpoint cannot disagree with the seal's verdict. `null` when the criterion has never been observed failing.

Each state names its own dataset plus its `previous_dataset_id`: at most four datasets across both, shared when the current state is itself the failure. `items`, `total`, `offset`, `limit` and the query params are unchanged.

**Breaking change** — removed: `latest_files`, `latest_coverage_window`, `latest_coverage_window_source`, `latest_within_max_coverage_window`, `latest_service_window`, `latest_feed_info_window`, `latest_feed_info_matches`, `latest_overlap_days`, `latest_gap_days`. Same data, now under `latest_state`.

Stubs regenerated with `scripts/api-gen.sh`, `scripts/api-operations-update-schema.sh` and `scripts/api-operations-gen.sh`.

**Expected behavior:**

Currently passing feed: `latest_state` is the latest dataset, `latest_failure` is `null` or an older boundary. Currently failing feed: both describe the same dataset, with `latest_failure.is_latest` true. Feed with no datasets: both `null`.
