### PR TITLE
feat: increase availability limit reponse to 200

### DIFF
--- a/docs/DatabaseCatalogAPI.yaml
+++ b/docs/DatabaseCatalogAPI.yaml
@@ -2629,12 +2629,12 @@ components:
     limit_query_param_availability_endpoint:
       name: limit
       in: query
-      description: The number of items to be returned. Maximum is 100.
+      description: The number of items to be returned. Maximum is 200.
       required: False
       schema:
         type: integer
         minimum: 0
-        maximum: 100
+        maximum: 200
         default: 100
         example: 10
 


### PR DESCRIPTION
**Summary:**

Increase the/v1/gtfs_feeds/{id}/availability limit to a maximum of 200; 100 is still the default.

**Expected behavior:** 

The  /v1/gtfs_feeds/{id}/availability limit now has a maximum of 200 items per response.

**Testing tips:**

Provide tips, procedures and sample files on how to test the feature.
Testers are invited to follow the tips AND to try anything they deem relevant outside the bounds of the testing tips. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `./scripts/api-tests.sh` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
